### PR TITLE
docs: add compose example for master runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Required env:
 - Optional: `MASTER_COMMAND_RATE_LIMIT_COUNT` (default `20`)
 - Optional: `MASTER_COMMAND_RATE_LIMIT_WINDOW_SECONDS` (default `60`)
 - For a Compose-based master runtime, use `docker-compose.master-agent.example.yml` (Podman Compose-oriented example for the v1 master container)
+  Set `MASTER_RUNTIME_IMAGE` to override the master container image tag used by that compose example.
 
 ## Agent Worker Mode (Phase 2 WIP)
 The container can run as a worker (no Slack connection) by setting:

--- a/docker-compose.master-agent.example.yml
+++ b/docker-compose.master-agent.example.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: codex-slack-v1-uat
+    image: ${MASTER_RUNTIME_IMAGE:-codex-slack-v1-uat}
     working_dir: /opt/codex-slack
     command: ["python", "-m", "src.master.main"]
     userns_mode: "keep-id"

--- a/docs/MASTER_AGENT_RUNBOOK.md
+++ b/docs/MASTER_AGENT_RUNBOOK.md
@@ -57,6 +57,7 @@ export UID="$(id -u)"
 export GID="$(id -g)"
 export PODMAN_SOCKET_PATH="/run/user/$(id -u)/podman/podman.sock"
 export MASTER_DATA_DIR="$(pwd)/data/master"
+export MASTER_RUNTIME_IMAGE="codex-slack-v1-uat"
 export MASTER_CODEX_AUTH_JSON_PATH="${HOME}/.codex/auth.json"
 export MASTER_SSH_AUTH_SOCK_PATH="${SSH_AUTH_SOCK}"
 export MASTER_ADMIN_CHANNELS="<admin_channel_id>"
@@ -69,6 +70,7 @@ podman compose -f docker-compose.master-agent.example.yml up --build -d
 podman compose -f docker-compose.master-agent.example.yml logs -f
 ```
 The compose example is intended for Podman Compose and already includes `userns_mode: keep-id`, `security_opt: [label=disable]`, and `x-podman.in_pod: false`.
+It also reads the master container image from `MASTER_RUNTIME_IMAGE` (default `codex-slack-v1-uat`) so you can swap tags without editing the compose file.
 For non-container local debugging, you can also run:
 ```bash
 python -m src.master.main


### PR DESCRIPTION
## Summary
- add a dedicated `docker-compose.master-agent.example.yml` for the v1 master runtime
- document a Compose-based master startup path in the master runbook
- point the README to the new Compose example

## Testing
- not run (docs/config artifact only; no application code changes)