### PR TITLE
Add Codex repo-local workflow skills

### DIFF
--- a/.agents/skills/architect/SKILL.md
+++ b/.agents/skills/architect/SKILL.md
@@ -17,10 +17,10 @@ Use this skill before implementation when requirements, boundaries, or tradeoffs
 ## Output
 
 - Lead with the recommended approach.
+- Produce an ADR-style decision record when the change involves a real architecture or workflow decision that should be tracked over time.
 - List alternatives considered and the reason they were not selected.
 - Make the implementation boundary explicit enough that `engineer` and `tester` can proceed without reinterpreting the design.
 
 ## Constraints
 
 - Do not start implementation while key design questions remain unresolved.
-- Respect active repo constraints, including temporary bans on touching `docs/`.

--- a/.agents/skills/architect/SKILL.md
+++ b/.agents/skills/architect/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: architect
+description: Use when designing a feature or change, comparing implementation options, documenting tradeoffs, or deciding what should be built before code is written.
+---
+
+# Architect
+
+Use this skill before implementation when requirements, boundaries, or tradeoffs matter.
+
+## Responsibilities
+
+- Clarify the problem, constraints, and success criteria.
+- Propose 2 to 4 concrete options when there is a real design choice.
+- Recommend one option directly and explain why.
+- Call out operational, extensibility, and interface risks.
+
+## Output
+
+- Lead with the recommended approach.
+- List alternatives considered and the reason they were not selected.
+- Make the implementation boundary explicit enough that `engineer` and `tester` can proceed without reinterpreting the design.
+
+## Constraints
+
+- Do not start implementation while key design questions remain unresolved.
+- Respect active repo constraints, including temporary bans on touching `docs/`.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: commit
+description: Use when a task is complete and the branch must be finalized with a clean commit and push using a conventional commit message.
+---
+
+# Commit
+
+Use this skill to finalize completed work.
+
+## Steps
+
+1. Inspect `git status`.
+2. Review `git diff` and `git diff --staged`.
+3. Stage only the intended files.
+4. Write a Conventional Commit message.
+5. Commit.
+6. Push the current branch.
+7. Verify the worktree is clean afterward.
+
+## Required report
+
+- Full commit SHA.
+- Branch name.
+- Push result.
+- Any remaining follow-up risk that was intentionally left out of the commit.
+
+## Constraints
+
+- Do not end the task before pushing unless the user explicitly says not to push.

--- a/.agents/skills/doc-writer/SKILL.md
+++ b/.agents/skills/doc-writer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: doc-writer
+description: Use when syncing allowed non-code documentation such as README or contributor guidance with the current repository behavior, while respecting task-specific documentation constraints.
+---
+
+# Doc Writer
+
+Use this skill to update repository documentation that is in scope for the current task.
+
+## Responsibilities
+
+- Read the current code and relevant repo instructions before editing prose.
+- Prefer updating existing files over creating new ones.
+- Keep structure, claims, and examples aligned with the actual repository state.
+
+## Current repo constraint
+
+- Do not modify anything under `docs/` unless the user explicitly allows it.
+
+## Output
+
+- Report each modified documentation file and the reason it changed.

--- a/.agents/skills/doc-writer/SKILL.md
+++ b/.agents/skills/doc-writer/SKILL.md
@@ -1,21 +1,17 @@
 ---
 name: doc-writer
-description: Use when syncing allowed non-code documentation such as README or contributor guidance with the current repository behavior, while respecting task-specific documentation constraints.
+description: Use when syncing repository documentation such as README, guides, references, or manuals with the current project behavior and workflow.
 ---
 
 # Doc Writer
 
-Use this skill to update repository documentation that is in scope for the current task.
+Use this skill to update repository documentation.
 
 ## Responsibilities
 
 - Read the current code and relevant repo instructions before editing prose.
 - Prefer updating existing files over creating new ones.
 - Keep structure, claims, and examples aligned with the actual repository state.
-
-## Current repo constraint
-
-- Do not modify anything under `docs/` unless the user explicitly allows it.
 
 ## Output
 

--- a/.agents/skills/engineer/SKILL.md
+++ b/.agents/skills/engineer/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: engineer
+description: Use when implementing code changes on the current branch after the design is clear, with a focus on clean code, small units of change, and preserving interface extensibility.
+---
+
+# Engineer
+
+Use this skill for implementation work on the current branch.
+
+## Responsibilities
+
+- Read the relevant code paths before editing.
+- Implement the agreed behavior with small, coherent changes.
+- Preserve extension points so new channels, adapters, or runtimes do not require core rewrites.
+- Report any design drift immediately instead of silently inventing behavior.
+
+## Constraints
+
+- Do not treat unclear requirements as permission to improvise scope.
+- Do not skip testing handoff; call out what changed and where tester attention should focus.
+- Do not leave the task uncommitted or unpushed at completion unless the user explicitly says not to.

--- a/.agents/skills/feature-workflow/SKILL.md
+++ b/.agents/skills/feature-workflow/SKILL.md
@@ -20,7 +20,7 @@ Use this skill for non-trivial work that should mirror the repository's structur
 6. Review the result.
    Use the `reviewer` skill for a read-only findings pass before finalizing.
 7. Sync allowed documentation.
-   Use the `doc-writer` skill only for files permitted by the current task constraints.
+   Use the `doc-writer` skill to align repository documentation with the completed change.
 8. Finish with `commit` and `push`.
    Every non-trivial task in this repo must end with a commit and push unless the user explicitly waives that rule.
 
@@ -28,4 +28,3 @@ Use this skill for non-trivial work that should mirror the repository's structur
 
 - Do not skip design for significant work just because implementation seems obvious.
 - Do not leave the branch with uncommitted changes at task completion.
-- Do not modify `docs/` when the active task forbids it.

--- a/.agents/skills/feature-workflow/SKILL.md
+++ b/.agents/skills/feature-workflow/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: feature-workflow
+description: Use when a task is a significant feature or change that should follow the repository lifecycle: design, implementation, testing, review, documentation sync, commit, and push.
+---
+
+# Feature Workflow
+
+Use this skill for non-trivial work that should mirror the repository's structured agent workflow.
+
+## Sequence
+
+1. Confirm the current branch is not `master` or `main`.
+2. Clarify scope, constraints, and acceptance criteria before implementation.
+3. Run design first.
+   Use the `architect` skill for options, tradeoffs, and the recommended approach.
+4. Implement the agreed change.
+   Use the `engineer` skill for code changes.
+5. Add or update tests.
+   Use the `tester` skill for test coverage, full-suite execution, and UAT guidance where relevant.
+6. Review the result.
+   Use the `reviewer` skill for a read-only findings pass before finalizing.
+7. Sync allowed documentation.
+   Use the `doc-writer` skill only for files permitted by the current task constraints.
+8. Finish with `commit` and `push`.
+   Every non-trivial task in this repo must end with a commit and push unless the user explicitly waives that rule.
+
+## Constraints
+
+- Do not skip design for significant work just because implementation seems obvious.
+- Do not leave the branch with uncommitted changes at task completion.
+- Do not modify `docs/` when the active task forbids it.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pr
+description: Use when preparing or opening a pull request from the current branch, including summary, test evidence, and verification notes.
+---
+
+# PR
+
+Use this skill after the branch has been committed and pushed.
+
+## Steps
+
+1. Confirm the worktree is clean.
+2. Review commits on the branch against `master`.
+3. Summarize what changed and why.
+4. Include test evidence and any manual verification notes.
+5. Open or draft the pull request against `master`.
+
+## Constraints
+
+- Do not open a PR from a dirty branch.
+- Do not omit test evidence from the PR body.

--- a/.agents/skills/reviewer/SKILL.md
+++ b/.agents/skills/reviewer/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: reviewer
+description: Use when performing a read-only review of branch changes, focusing on correctness, regression risk, interface breakage, and missing tests.
+---
+
+# Reviewer
+
+Use this skill for a code review pass after implementation and testing.
+
+## Process
+
+1. Review `git diff` for the branch.
+2. Read changed files in full, not only the diff hunks.
+3. Evaluate correctness, regression risk, extensibility, and test coverage.
+
+## Report format
+
+- Findings first, ordered by severity.
+- Each finding should include file, line, issue, and concrete fix direction.
+- End with a short verdict: approve, approve with minor fixes, or request changes.
+
+## Constraints
+
+- Read-only review only.
+- Do not mix review findings with implementation.

--- a/.agents/skills/tag/SKILL.md
+++ b/.agents/skills/tag/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: tag
+description: Use when creating and pushing a git tag for the current commit, including proposing the next version when the tag name is not provided.
+---
+
+# Tag
+
+Use this skill for release or release-candidate tagging.
+
+## Steps
+
+1. Inspect recent tags if no tag name was supplied.
+2. Propose the next logical version.
+3. Create the tag on the current commit.
+4. Push the tag.
+5. Report the tag name and commit SHA.
+
+## Constraints
+
+- Do not guess a version if the repository tag pattern is unclear; ask instead.

--- a/.agents/skills/tag/SKILL.md
+++ b/.agents/skills/tag/SKILL.md
@@ -9,12 +9,15 @@ Use this skill for release or release-candidate tagging.
 
 ## Steps
 
-1. Inspect recent tags if no tag name was supplied.
-2. Propose the next logical version.
-3. Create the tag on the current commit.
-4. Push the tag.
-5. Report the tag name and commit SHA.
+1. If the user supplied a tag name, use it directly.
+2. Otherwise inspect tags matching `v*` and start from the largest existing version.
+3. Follow the repository release-candidate pattern `v1.2-rc3`.
+4. If no RC exists for a version yet, start at `-rc1`.
+5. If RC tags already exist for the chosen version, increment the RC number by one.
+6. Create the tag on the current commit.
+7. Push the tag.
+8. Report the tag name and commit SHA.
 
 ## Constraints
 
-- Do not guess a version if the repository tag pattern is unclear; ask instead.
+- Unless the user explicitly asks for a different target version, always derive the next tag from the largest existing `v*` tag.

--- a/.agents/skills/tester/SKILL.md
+++ b/.agents/skills/tester/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: tester
+description: Use when adding or updating tests, running the full test suite, checking interface stability, or preparing a user acceptance checklist.
+---
+
+# Tester
+
+Use this skill for automated and manual validation work.
+
+## Responsibilities
+
+- Add or update tests under `tests/` for every user-visible or contract-changing behavior.
+- Prioritize interface boundaries: Podman, Slack, Discord, agent adapters, and command surfaces.
+- Run the full relevant test suite before finalizing.
+- Produce a concise UAT checklist when manual verification is useful.
+
+## Report format
+
+- Total passed and failed.
+- Exact failing tests and the handoff needed to fix them.
+- Residual risks if coverage is incomplete.
+
+## Constraints
+
+- Do not modify implementation files when the task is purely a testing pass.
+- Do not mark the task complete while tests are knowingly red unless the user accepts that state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,49 @@
 # Repository Guidelines
 
+## Codex Workflow
+
+This repository supports two agent frameworks:
+- `.claude/` for Claude Code
+- `.agents/skills/` for Codex
+
+When working in Codex, treat this file as the primary repo-level contract and use the repo-local skills under `.agents/skills/` when they match the task.
+
+### Git workflow
+
+- Never commit directly to `master` or `main`.
+- Start work from a feature branch named for the task, such as `feat/...`, `fix/...`, `refactor/...`, or `docs/...`.
+- Every non-trivial task must end with a commit and push unless the user explicitly says not to commit or not to push.
+- Keep the worktree clean at task completion. If that is not possible, stop and explain exactly why.
+
+### Execution model
+
+- Significant features should follow this order: design, implementation, testing, review, documentation sync, commit, push.
+- Use the `feature-workflow` skill to run the full lifecycle.
+- Use the role-specific skills to keep ownership boundaries clear:
+  - `architect`: design, options, tradeoffs, ADR-style outputs
+  - `engineer`: implementation on the current branch
+  - `tester`: test authoring, execution, and UAT guidance
+  - `reviewer`: read-only review and findings
+  - `doc-writer`: README and non-`docs/` documentation sync allowed by the current task
+  - `commit`, `pr`, `tag`: git workflow helpers
+
+### Current migration constraint
+
+- Do not modify anything under `docs/` unless the user explicitly changes that instruction.
+- For this Codex migration, keep the durable workflow artifacts in repo instructions and skills only.
+
 ## Project Structure & Module Organization
+
 - `src/` application source code, organized by subdomain: `bot/`, `master/`, `agent/`, `cd/`.
 - `tests/` automated tests mirroring `src/` paths.
 - `docs/` all documentation — operational runbooks, setup guides, and knowledge-base entries.
 - `.claude/` Claude Code agent framework: project CLAUDE.md, subagent definitions, and slash-command skills.
+- `.agents/skills/` Codex repo-local skills for workflow orchestration and reusable task guidance.
 
 Example: `src/master/dispatcher.py` should map to `tests/master/test_dispatcher.py`.
 
 ## Build, Test, and Development Commands
+
 The project uses Python with pip for dependency management and pytest for testing.
 
 ```bash
@@ -20,6 +55,7 @@ pytest -q                  # run full test suite
 For containerised development, see `BUILD.md` and `docs/CONTAINER.md`.
 
 ## Coding Style & Naming Conventions
+
 Until language-specific configs are added:
 - Use 4 spaces for Python, 2 spaces for JS/TS/JSON/YAML.
 - Prefer descriptive names: `feature_action_target` for files where idiomatic.
@@ -29,14 +65,16 @@ Until language-specific configs are added:
 Add and enforce formatter/linter configs early (for example, `prettier` + `eslint`, or `ruff` + `black`).
 
 ## Testing Guidelines
+
 - Place tests in `tests/` with mirrored paths.
 - Name tests by behavior, e.g., `session_expires_after_timeout`.
 - Add tests for every bug fix and user-visible behavior change.
 - Target meaningful coverage on core logic before raising thresholds.
 
-Run all tests locally before opening a PR.
+Run all tests locally before committing.
 
 ## Commit & Pull Request Guidelines
+
 Use Conventional Commits:
 - `feat: add session token validation`
 - `fix: handle missing config file`
@@ -44,8 +82,9 @@ Use Conventional Commits:
 
 PRs should include:
 - Clear summary of what changed and why.
-- Linked issue/ticket when available.
-- Test evidence (command + result).
-- Screenshots/logs for UI or behavior changes.
+- Linked issue or ticket when available.
+- Test evidence with command and result.
+- Screenshots or logs for UI or behavior changes.
 
-Use the `.claude/commands/commit.md` skill and `.claude/commands/pr.md` skill when working inside the Claude Code agent framework.
+When working in Codex, use the repo-local `commit`, `pr`, and `tag` skills.
+When working in Claude Code, use `.claude/commands/commit.md` and `.claude/commands/pr.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,8 @@ When working in Codex, treat this file as the primary repo-level contract and us
   - `engineer`: implementation on the current branch
   - `tester`: test authoring, execution, and UAT guidance
   - `reviewer`: read-only review and findings
-  - `doc-writer`: README and non-`docs/` documentation sync allowed by the current task
+  - `doc-writer`: repository documentation sync
   - `commit`, `pr`, `tag`: git workflow helpers
-
-### Current migration constraint
-
-- Do not modify anything under `docs/` unless the user explicitly changes that instruction.
-- For this Codex migration, keep the durable workflow artifacts in repo instructions and skills only.
 
 ## Project Structure & Module Organization
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ podman compose -f docker-compose.yml -f docker-compose.podman.yml up --build -d
 ```
 
 Full setup (Slack app creation, OAuth scopes, slash commands): `BUILD.md`.
+For Codex contributors, repository workflow instructions live in `AGENTS.md` and repo-local skills live under `.agents/skills/`.
 
 ## Project structure
 
@@ -58,6 +59,8 @@ Full setup (Slack app creation, OAuth scopes, slash commands): `BUILD.md`.
 ├── scripts/                      # Build, bootstrap, and utility scripts
 ├── config/                       # Environment and service configuration
 ├── docs/                         # All documentation
+├── .agents/                      # Codex repo-local workflow skills
+│   └── skills/                   #   Workflow, role, and git helper skills
 ├── .claude/                      # Claude Code agent framework
 │   ├── CLAUDE.md                 #   Project-scope agent instructions
 │   ├── agents/                   #   Subagent definitions (architect, engineer, tester, reviewer, doc-writer)


### PR DESCRIPTION
## Summary
- add repo-local Codex skills under `.agents/skills/` for workflow orchestration, role-specific work, and git helpers
- update `AGENTS.md` to make Codex workflow rules explicit, including the required commit-and-push completion rule
- update `README.md` to show the new Codex skill layer alongside the existing `.claude` framework

## Test plan
- [x] Verified `git status --short` is clean before PR creation
- [x] Reviewed `git diff master...HEAD --stat` to confirm the change scope is limited to workflow instructions and skill files
- [x] Confirmed no files under `docs/` were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)