### PR TITLE
fix: show adapter in master agent list

### DIFF
--- a/src/master/command_format.py
+++ b/src/master/command_format.py
@@ -29,6 +29,7 @@ def _format_agent_list_table(result: CommandResult) -> str | None:
             (
                 f"• *{_clip(item.get('name', '-'), 24)}*"
                 f" | state=`{_clip(item.get('status', '-'), 12)}`"
+                f" | adapter=`{_clip(item.get('agent_adapter', '-'), 14)}`"
                 f" | channel=`{_clip(item.get('channel_id', '-'), 14)}`"
                 f" | ref=`{_clip(item.get('repo_ref', '-'), 12)}`"
                 f" | runtime=`{_clip(item.get('runtime', '-'), 10)}`"

--- a/tests/master/test_slack_app.py
+++ b/tests/master/test_slack_app.py
@@ -280,6 +280,7 @@ def test_format_command_result_renders_agent_list_as_bullets() -> None:
                     {
                         "name": "aidotfile-agent",
                         "status": "running",
+                        "agent_adapter": "claude-code",
                         "channel_id": "C0123456789",
                         "repo_ref": "master",
                         "runtime": "podman",
@@ -292,6 +293,7 @@ def test_format_command_result_renders_agent_list_as_bullets() -> None:
     assert "*Total agents:* 1" in payload
     assert "• *aidotfile-agent*" in payload
     assert "state=`running`" in payload
+    assert "adapter=`claude-code`" in payload
     assert "aidotfile-agent" in payload
     assert "container=`agent-aidotfile-agent`" in payload
 


### PR DESCRIPTION
## Summary
- include the agent adapter in `/master-agent-list` output
- add Slack coverage for the adapter field in the formatted list response

## Why
Operators need to see whether an agent is running `codex` or `claude-code` directly from the list view.

## Test Evidence
- `. .venv/bin/activate && pytest -q tests/master/test_slack_app.py`
- Result: `28 passed`
