### PR TITLE
feat: add agent provisioning workflow

### DIFF
--- a/.github/workflows/publish-agent-minimal.yml
+++ b/.github/workflows/publish-agent-minimal.yml
@@ -42,8 +42,24 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha
+            type=sha,prefix=sha-
             type=ref,event=tag
+
+      - name: Build smoke image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.agent-minimal
+          load: true
+          tags: codex-slack-agent-minimal:smoke
+
+      - name: Smoke test runtime contract
+        run: |
+          docker run --rm codex-slack-agent-minimal:smoke sh -lc '
+            codex --version &&
+            claude --version &&
+            python -m src.agent.main --help >/dev/null
+          '
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,10 +33,12 @@ This directory is the canonical home for repository documentation.
 ## Design
 
 - `docs/design/agent-container-runtime-design.md` — canonical runtime contract for agent containers
+- `docs/design/agent-provisioning-detailed-design.md` — detailed design for agent/channel/repo provisioning
 - `docs/design/master-agent-interface-design.md` — canonical interface between master and agent containers
 - `docs/design/frontend-master-interface-design.md` — canonical interface between Slack/Discord and master
 - `docs/design/master-agent-architecture.md` — architecture background and constraints
 - `docs/design/master-agent-implementation-plan.md` — phased implementation plan
+- `docs/design/separate-base-agent-image-detailed-design.md` — detailed design for publishing and consuming the base agent image
 - `docs/design/v3-0-multi-adapter-frontend-plan.md` — v3.0 adapter/frontend design plan
 
 ## Decisions

--- a/docs/decisions/0001-agent-provisioning-orchestration.md
+++ b/docs/decisions/0001-agent-provisioning-orchestration.md
@@ -1,0 +1,159 @@
+# 0001 Agent Provisioning Orchestration
+
+- Status: proposed
+- Date: 2026-04-03
+- Issue: [#37](https://github.com/pandazxx/codex-slack/issues/37)
+
+## Context
+
+The current master-agent workflow assumes provisioning dependencies already exist:
+
+- `/master-agent-load` requires an existing `channel_id`
+- repository input must already resolve to a local checkout, explicit Git URL, or GitHub shorthand
+
+Issue `#37` expands provisioning so an operator can optionally:
+
+- create the destination channel automatically
+- create the backing GitHub repository automatically
+
+The current implementation boundaries matter:
+
+- `MasterService.load_agent()` in `src/master/service.py` is a bind-and-checkout flow
+- Slack and Discord API clients live in the frontend layers, not in `MasterService`
+- repository checkout and registry persistence live in master core
+
+If channel creation, repository creation, and load/bind behavior are all pushed into `load_agent()`, the existing low-level operation becomes a cross-system orchestration step with frontend SDK coupling and more complex failure handling.
+
+## Decision
+
+Introduce a new high-level provisioning workflow and keep `/master-agent-load` unchanged.
+
+### Command model
+
+Add a new command surface:
+
+- `/master-agent-provision`
+
+Keep `/master-agent-load` as the low-level primitive for binding an already-existing repository and channel.
+
+### Architecture boundary
+
+Add a provisioning orchestration layer that composes three responsibilities:
+
+1. repository creation
+2. channel creation
+3. existing `load_agent()` binding
+
+Recommended module split:
+
+- `ProvisioningCoordinator`
+- `RepoProvisioner` protocol
+- `ChannelProvisioner` protocol
+
+### Ownership
+
+Repository creation belongs in master backend orchestration.
+
+- GitHub repository creation is not frontend-specific
+- it should use `GH_TOKEN` / `GITHUB_TOKEN`
+- it should return clone URL plus creation metadata
+
+Channel creation belongs in platform-specific provisioners.
+
+- Slack creation should live near Slack frontend integration
+- Discord creation should live near Discord frontend integration
+- `MasterService` should not depend directly on Slack or Discord SDK clients
+
+### Resource creation model
+
+For v1:
+
+- create channels, not threads
+- default generated channel name: `agent-<name>`
+- default generated repository name: `<name>`
+- default repo visibility: `private`
+- allow channel creation and repo creation to be independently optional
+
+Provisioning flow:
+
+1. validate request
+2. create repo if requested
+3. create channel if requested
+4. call `load_agent()` with resolved `repo_path` / `repo_source` and `channel_id`
+5. return combined provisioning result
+
+### Persistence and results
+
+At minimum, the provisioning result should include:
+
+- created repo URL
+- repo owner
+- repo name
+- repo visibility
+- created channel id
+- created channel name
+- platform
+
+If operator workflows need this metadata later, extend the registry schema to persist:
+
+- `channel_name`
+- `provisioned_channel`
+- `repo_owner`
+- `repo_name`
+- `provisioned_repo`
+
+## Alternatives Considered
+
+### 1. Extend `/master-agent-load`
+
+Rejected.
+
+This would overload a deterministic bind command with external side effects and make validation, UX, and rollback behavior harder to reason about.
+
+### 2. Put channel creation inside `MasterService`
+
+Rejected.
+
+`MasterService` does not currently own Slack or Discord API client context. Moving frontend resource creation into the service layer would couple core orchestration to platform SDK details.
+
+### 3. Implement only auto channel creation
+
+Rejected.
+
+Issue `#37` now also includes optional GitHub repository auto-creation. The architecture should solve both under one provisioning workflow instead of creating a second orchestration path later.
+
+## Consequences
+
+Positive:
+
+- preserves the current `load_agent()` contract
+- keeps frontend-specific channel APIs out of `MasterService`
+- makes Slack and Discord differences explicit
+- supports staged rollout and easier testing through provider mocks
+
+Tradeoffs:
+
+- adds a new command instead of extending the existing one
+- requires provider abstractions and additional tests
+- creates partial-failure scenarios across GitHub and frontend channel APIs
+
+## Operational Notes
+
+Recommended initial constraints:
+
+- Discord channel creation should target a configured guild/category, not an inferred thread destination
+- Slack public/private behavior should be explicit or policy-driven, not implicit
+- GitHub repo creation should define owner, visibility, and auth requirements up front
+- v1 should prefer explicit failure reporting over best-effort rollback automation
+
+## Implementation Guidance
+
+Engineer and tester should treat this ADR as defining the v1 implementation boundary:
+
+- add `/master-agent-provision`
+- keep `/master-agent-load` behavior unchanged
+- add provisioner protocols and coordinator
+- add GitHub repo provisioner
+- add Slack channel provisioner
+- add Discord channel provisioner
+- add tests for success, idempotent reuse, conflict, and partial-failure paths

--- a/docs/decisions/0001-agent-provisioning-orchestration.md
+++ b/docs/decisions/0001-agent-provisioning-orchestration.md
@@ -82,6 +82,33 @@ Provisioning flow:
 4. call `load_agent()` with resolved `repo_path` / `repo_source` and `channel_id`
 5. return combined provisioning result
 
+### Provisioning boundary diagram
+
+```mermaid
+flowchart LR
+    OP[Operator]
+    FE[Slack / Discord Frontend]
+    PC[ProvisioningCoordinator]
+    CP[ChannelProvisioner]
+    RP[RepoProvisioner]
+    MS[MasterService]
+    REG[(Agent Registry)]
+    GIT[(GitHub)]
+    CHAT[(Slack / Discord APIs)]
+
+    OP --> FE
+    FE --> PC
+    PC --> RP
+    PC --> CP
+    RP --> GIT
+    CP --> CHAT
+    PC --> MS
+    MS --> REG
+
+    FE -. platform client context .-> CP
+    MS -. existing bind / checkout flow .-> REG
+```
+
 ### Persistence and results
 
 At minimum, the provisioning result should include:

--- a/docs/decisions/0002-separate-base-agent-image.md
+++ b/docs/decisions/0002-separate-base-agent-image.md
@@ -26,7 +26,11 @@ However, issue `#38` calls out that the contract is still incomplete:
 2. add CI/CD to publish it to GHCR
 3. provide clear project-facing instructions for building on it
 
-There is also an ambiguity around "project specific manifest". The current implemented customization contract is Dockerfile-based, not manifest-based:
+In this ADR, "project specific manifest" means the repo-local image customization contract:
+
+- `.prj_assistant/image/Dockerfile`
+
+That is already the implemented project-specific image input:
 
 - `MasterService._resolve_image_plan()` in `src/master/service.py` detects `.prj_assistant/image/Dockerfile`
 - there is no implemented project image manifest loader in the current runtime path
@@ -97,13 +101,13 @@ The project image contract is:
 - do not replace the entrypoint unless there is a documented reason
 - preserve the agent runtime assumptions around `/workspace`, `/workspace/home`, and `CODEX_CONTAINER_MODE=agent-worker`
 
-### Project manifest decision
+### Project-specific manifest decision
 
-Do not introduce a second project image manifest format in this change.
-
-For this issue, "project specific manifest" should be documented as the current repo-local image customization contract:
+Standardize the term "project specific manifest" in docs for this issue to mean:
 
 - `.prj_assistant/image/Dockerfile`
+
+Do not introduce a second project image metadata format in this change.
 
 A richer metadata manifest can be considered later, but it should not block:
 

--- a/docs/decisions/0002-separate-base-agent-image.md
+++ b/docs/decisions/0002-separate-base-agent-image.md
@@ -1,0 +1,189 @@
+# 0002 Separate Base Agent Image
+
+- Status: proposed
+- Date: 2026-04-03
+- Issue: [#38](https://github.com/pandazxx/codex-slack/issues/38)
+
+## Context
+
+The repository currently has two image definitions:
+
+- `Dockerfile`
+  - used for the broader runtime and master-oriented workflows
+  - includes tools such as `gh`, `jq`, `make`, and `podman`
+  - copies repository docs/config content into the image
+- `Dockerfile.agent-minimal`
+  - intended as a leaner worker image for agent runtime
+
+The existing docs already hint at a published agent base image:
+
+- `ghcr.io/<owner>/codex-slack-agent-minimal:latest`
+- repo-specific customization through `.prj_assistant/image/Dockerfile`
+
+However, issue `#38` calls out that the contract is still incomplete:
+
+1. establish a bare minimum base agent image
+2. add CI/CD to publish it to GHCR
+3. provide clear project-facing instructions for building on it
+
+There is also an ambiguity around "project specific manifest". The current implemented customization contract is Dockerfile-based, not manifest-based:
+
+- `MasterService._resolve_image_plan()` in `src/master/service.py` detects `.prj_assistant/image/Dockerfile`
+- there is no implemented project image manifest loader in the current runtime path
+
+## Decision
+
+Adopt a dedicated published base agent image and keep repo-level customization Dockerfile-based for v1.
+
+### Base image split
+
+Treat `Dockerfile.agent-minimal` as the canonical base image for agent containers.
+
+Treat `Dockerfile` as the broader master/runtime image, not the project extension point.
+
+### Published image contract
+
+Publish a dedicated base image to GHCR:
+
+- image name: `ghcr.io/<owner>/codex-slack-agent-minimal`
+
+Tagging policy:
+
+- immutable `sha-<commit>` tags for every publishable build
+- exact git tag mirrors for RC and release tags
+- `latest` for the current default branch publish target
+
+### Base image contents
+
+The base agent image should include only the runtime dependencies required for `src.agent.main` and the supported adapters:
+
+- Python runtime
+- `codex` CLI
+- `claude` CLI
+- `git`
+- `openssh-client`
+- `bash`
+- `curl`
+- `ca-certificates`
+- `tini`
+- agent entrypoint and Python dependencies needed by `src.agent.main`
+
+The base image should not carry master-only operational tooling by default:
+
+- `podman`
+- `podman-compose`
+- `gh`
+- `jq`
+- `make`
+- repository docs/config payload not required for agent runtime
+
+If a project needs additional tools, it should layer them in its own repo-local image.
+
+### Project customization contract
+
+For v1, the project-specific extension point remains:
+
+- `.prj_assistant/image/Dockerfile`
+
+Project image builds should extend the published base image with:
+
+```dockerfile
+FROM ghcr.io/<owner>/codex-slack-agent-minimal:<tag>
+```
+
+The project image contract is:
+
+- add project-specific OS packages, CLIs, or runtimes
+- do not replace the entrypoint unless there is a documented reason
+- preserve the agent runtime assumptions around `/workspace`, `/workspace/home`, and `CODEX_CONTAINER_MODE=agent-worker`
+
+### Project manifest decision
+
+Do not introduce a second project image manifest format in this change.
+
+For this issue, "project specific manifest" should be documented as the current repo-local image customization contract:
+
+- `.prj_assistant/image/Dockerfile`
+
+A richer metadata manifest can be considered later, but it should not block:
+
+- base image publication
+- GHCR CI/CD
+- project onboarding guidance
+
+## Boundary diagram
+
+```mermaid
+flowchart LR
+    R[Repository]
+    B[Dockerfile.agent-minimal]
+    CI[CI/CD Workflow]
+    GHCR[GHCR Base Image]
+    PROJ[Project Repo]
+    PD[.prj_assistant/image/Dockerfile]
+    MASTER[MasterService image plan]
+    AGENT[Built Agent Image]
+
+    R --> B
+    B --> CI
+    CI --> GHCR
+    GHCR --> PD
+    PROJ --> PD
+    PD --> MASTER
+    MASTER --> AGENT
+```
+
+## Alternatives Considered
+
+### 1. Keep using the monolithic `Dockerfile` as the extension base
+
+Rejected.
+
+This couples agent customization to master-only tooling and a broader image payload than worker runtime actually needs.
+
+### 2. Introduce a new project image manifest now
+
+Rejected for v1.
+
+The implemented runtime already uses `.prj_assistant/image/Dockerfile`. Adding a second manifest format before the published base contract is stabilized would create documentation and implementation drift.
+
+### 3. Publish only local/manual images and skip GHCR automation
+
+Rejected.
+
+Issue `#38` explicitly asks for CI/CD publication and clear project usage instructions. Manual-only publication would keep onboarding inconsistent and fragile.
+
+## Consequences
+
+Positive:
+
+- gives projects a clear and stable extension point
+- removes master-only tooling from the default agent base
+- makes CI/CD image publication explicit and repeatable
+- aligns docs with the already-implemented `.prj_assistant/image/Dockerfile` flow
+
+Tradeoffs:
+
+- requires maintaining two image definitions with distinct purposes
+- requires release/tag discipline for GHCR publishing
+- pushes some tool installation burden to project-specific images
+
+## Documentation deliverables
+
+The implementation should update or add project-facing guidance that explains:
+
+- which image is the base image
+- which tag types are safe to consume
+- how to write `.prj_assistant/image/Dockerfile`
+- which base-image invariants must not be broken
+- how `MASTER_AGENT_BASE_IMAGE` relates to the published base image
+
+## Implementation Guidance
+
+Engineer and tester should treat this ADR as the v1 boundary:
+
+- keep `Dockerfile.agent-minimal` as the agent base source
+- add GHCR publication for the base image
+- keep `.prj_assistant/image/Dockerfile` as the project customization contract
+- do not introduce a new project image manifest format in this issue
+- add tests or validation for image-plan resolution and documentation updates where practical

--- a/docs/design/agent-provisioning-detailed-design.md
+++ b/docs/design/agent-provisioning-detailed-design.md
@@ -1,0 +1,401 @@
+# Agent Provisioning Detailed Design
+
+**Status:** proposed  
+**Issue:** [#37](https://github.com/pandazxx/codex-slack/issues/37)  
+**ADR:** `docs/decisions/0001-agent-provisioning-orchestration.md`
+
+## Goal
+
+Define the implementation-oriented design for provisioning a new agent when some or all dependencies do not already exist.
+
+This design covers:
+
+- automatic channel creation
+- optional GitHub repository auto-creation
+- orchestration boundaries between frontends and master core
+- command UX, result contract, error handling, and tests
+
+## Scope
+
+### In Scope
+
+- add a new high-level provisioning workflow
+- create Slack or Discord channels for new agents
+- optionally create a GitHub repository as part of provisioning
+- bind created resources through the existing agent registry/load flow
+- return provisioning metadata to operators
+
+### Out of Scope
+
+- project template scaffolding inside the new repo
+- automatic branch protection or repository policy setup
+- provisioning voice channels, forum channels, or Discord threads
+- automatic rollback of already-created resources beyond best-effort cleanup notes
+
+## Product Decision
+
+The provisioning workflow should be a new command, not a change to `/master-agent-load`.
+
+Recommended command:
+
+- `/master-agent-provision`
+
+Rationale:
+
+- `/master-agent-load` is already a stable low-level bind operation
+- provisioning introduces external side effects in GitHub and frontend APIs
+- separating the workflows keeps the existing operational command deterministic
+
+## High-Level Architecture
+
+Provisioning introduces a coordinator layer between frontend command handling and `MasterService.load_agent()`.
+
+```mermaid
+sequenceDiagram
+    participant OP as Operator
+    participant FE as Frontend Adapter
+    participant PC as ProvisioningCoordinator
+    participant RP as RepoProvisioner
+    participant CP as ChannelProvisioner
+    participant SVC as MasterService
+    participant REG as AgentRegistry
+
+    OP->>FE: /master-agent-provision ...
+    FE->>PC: ProvisionRequest
+    alt create repo
+        PC->>RP: create_repo(...)
+        RP-->>PC: repo metadata + clone URL
+    end
+    alt create channel
+        PC->>CP: create_channel(...)
+        CP-->>PC: channel metadata
+    end
+    PC->>SVC: load_agent(...)
+    SVC->>REG: upsert(record)
+    SVC-->>PC: CommandResult
+    PC-->>FE: ProvisionResult
+    FE-->>OP: success / failure response
+```
+
+## Component Boundaries
+
+### Frontend Adapter
+
+Frontend adapters own:
+
+- command intake and argument parsing
+- platform API client context
+- channel creation for their platform
+- final operator response rendering
+
+Slack and Discord should each own their own `ChannelProvisioner` implementation because the API contracts and permission models differ.
+
+### ProvisioningCoordinator
+
+Coordinator responsibilities:
+
+- validate the provisioning request shape
+- invoke repo creation when requested
+- invoke channel creation when requested
+- derive final `repo_path` / `repo_source` and `channel_id`
+- call existing `MasterService.load_agent()`
+- return a normalized result with created-resource metadata
+
+This layer is the orchestration boundary. It should not directly own frontend SDK code or registry persistence logic.
+
+### MasterService
+
+`MasterService` remains responsible for:
+
+- repo source normalization
+- checkout / branch fallback
+- image-plan resolution
+- registry upsert
+
+`MasterService.load_agent()` should not create channels or repositories directly.
+
+### RepoProvisioner
+
+GitHub-specific repository creation should be implemented behind a provider interface.
+
+Recommended v1 provider:
+
+- GitHub REST API provider using `GH_TOKEN` or `GITHUB_TOKEN`
+
+Why REST API instead of `gh repo create`:
+
+- easier to unit test
+- avoids CLI-specific formatting and subprocess coupling
+- aligns with service-style provider boundaries
+
+## Command Surface
+
+### Slack
+
+Recommended text form:
+
+```text
+/master-agent-provision <name> [repo_spec] [--create-repo] [--repo-owner <owner>] [--repo-name <name>] [--repo-visibility private|public] [--create-channel] [--channel-name <name>] [--adapter codex|claude-code] [--branch <branch>]
+```
+
+### Discord
+
+Recommended application command arguments:
+
+- `name`
+- `repo_spec`
+- `create_repo`
+- `repo_owner`
+- `repo_name`
+- `repo_visibility`
+- `create_channel`
+- `channel_name`
+- `branch`
+- `adapter`
+
+### Required v1 rules
+
+- at least one of `repo_spec` or `--create-repo` must be present
+- at least one of `channel_id` or `--create-channel` equivalent must be available
+- the final resolved request passed into `load_agent()` must include a concrete `repo_path`/`repo_source` and a concrete `channel_id`
+
+## Request Model
+
+Recommended internal request shape:
+
+```json
+{
+  "name": "payments-api",
+  "platform": "slack",
+  "repo": {
+    "mode": "existing|create",
+    "source": "pandazxx/payments-api",
+    "owner": "pandazxx",
+    "name": "payments-api",
+    "visibility": "private"
+  },
+  "channel": {
+    "mode": "existing|create",
+    "channel_id": "C123",
+    "name": "agent-payments-api"
+  },
+  "repo_ref": "main",
+  "agent_adapter": "codex"
+}
+```
+
+## Resource Naming Rules
+
+### Agent name
+
+Continue using the existing agent-name rule from `MasterService`:
+
+- `^[a-z0-9][a-z0-9-]{1,30}$`
+
+### Repository name
+
+Default:
+
+- `<agent-name>`
+
+Rules:
+
+- slug normalization should mirror GitHub repository naming rules where practical
+- operator-supplied override wins
+
+### Channel name
+
+Default:
+
+- `agent-<agent-name>`
+
+Rules:
+
+- Slack name normalization must follow Slack channel naming constraints
+- Discord name normalization must follow Discord text-channel naming constraints
+
+## Channel Provisioning Design
+
+### Slack
+
+Recommended v1 behavior:
+
+- create a text channel named `agent-<name>`
+- default to a policy-driven channel type:
+  - either explicit flag required
+  - or configured default via master config
+- ensure the bot is present in the created channel
+
+Provider output:
+
+```json
+{
+  "platform": "slack",
+  "channel_id": "C123456",
+  "channel_name": "agent-payments-api",
+  "visibility": "private"
+}
+```
+
+### Discord
+
+Recommended v1 behavior:
+
+- create a text channel, not a thread
+- create it in a configured guild/category
+- use the created channel id as the registry-mapped destination
+
+Provider output:
+
+```json
+{
+  "platform": "discord",
+  "channel_id": "1483608068142010560",
+  "channel_name": "agent-payments-api",
+  "guild_id": "123456789012345678",
+  "category_id": "234567890123456789"
+}
+```
+
+### Why channels, not threads
+
+- the current mapping model uses stable `channel_id` values
+- Discord thread creation depends on a parent channel and different lifecycle semantics
+- Slack thread routing is already a data-plane behavior after the mapped channel exists
+
+## Repository Provisioning Design
+
+### GitHub v1 behavior
+
+Required inputs:
+
+- owner or org
+- repo name
+- visibility
+
+Optional later:
+
+- template repository
+- default branch selection
+- branch protection bootstrap
+
+Provider output:
+
+```json
+{
+  "provider": "github",
+  "owner": "pandazxx",
+  "repo_name": "payments-api",
+  "visibility": "private",
+  "html_url": "https://github.com/pandazxx/payments-api",
+  "clone_url": "https://github.com/pandazxx/payments-api.git"
+}
+```
+
+### Existing repo reuse
+
+Recommended behavior:
+
+- if repo creation was requested but the repo already exists and is accessible, return a structured conflict or explicit reuse path
+- do not silently adopt an existing repo without confirming the ownership/name match expected by the request
+
+## Persistence Design
+
+### Immediate result payload
+
+The provisioning response should return:
+
+- final `channel_id`
+- final `repo_source`
+- created channel metadata
+- created repo metadata
+- `repo_ref`
+- `agent_adapter`
+
+### Registry extension
+
+Recommended optional registry fields:
+
+- `channel_name`
+- `provisioned_channel`
+- `repo_owner`
+- `repo_name`
+- `provisioned_repo`
+
+These fields are useful for later operator visibility and diagnostics but are not required to make v1 function if the response already includes them.
+
+## Error Handling
+
+Recommended stable provisioning error codes:
+
+- `ERR_PROVISION_INVALID_ARGS`
+- `ERR_CHANNEL_CREATE_FAILED`
+- `ERR_REPO_CREATE_FAILED`
+- `ERR_PROVISION_CONFLICT`
+- `ERR_PROVISION_PARTIAL`
+
+Error payloads should report:
+
+- which step failed
+- what had already been created
+- whether manual cleanup is required
+
+Example:
+
+```json
+{
+  "ok": false,
+  "code": "ERR_PROVISION_PARTIAL",
+  "message": "channel created but repo creation failed",
+  "data": {
+    "created_channel_id": "C123456",
+    "cleanup_required": true,
+    "failed_step": "repo_create"
+  }
+}
+```
+
+## Rollout Strategy
+
+Recommended delivery order:
+
+1. request/result types and coordinator
+2. GitHub repo provisioner
+3. Slack channel provisioner
+4. Discord channel provisioner
+5. command wiring
+6. docs and UAT
+
+## Test Design
+
+### Unit tests
+
+- request parsing and validation
+- repo provisioner success/failure
+- channel provisioner success/failure
+- coordinator success path
+- coordinator partial-failure path
+- result rendering
+
+### Integration-style tests
+
+- Slack provisioning -> `load_agent()` bind call
+- Discord provisioning -> `load_agent()` bind call
+- created resource metadata visible in output
+
+### UAT
+
+- create repo + channel + load agent from Slack
+- create repo + channel + load agent from Discord
+- repo creation disabled, channel creation enabled
+- channel creation disabled, repo creation enabled
+- conflict and partial-failure operator messaging
+
+## Open Questions
+
+These do not block the design, but they must be decided before implementation:
+
+- Slack default channel type: private or public?
+- Discord target guild/category source: config-driven or inferred from invoking admin channel?
+- should repo/channel creation support an explicit "reuse existing if present" mode?
+- should provisioning immediately call `/master-agent-start`, or remain load-only in v1?

--- a/docs/design/agent-provisioning-detailed-design.md
+++ b/docs/design/agent-provisioning-detailed-design.md
@@ -269,8 +269,11 @@ Provider output:
 
 Required inputs:
 
-- owner or org
 - repo name
+
+Optional inputs:
+
+- owner or org
 - visibility
 
 Optional later:
@@ -291,6 +294,13 @@ Provider output:
   "clone_url": "https://github.com/pandazxx/payments-api.git"
 }
 ```
+
+Default resolution rules:
+
+- if `owner` is omitted, resolve it from the current authenticated GitHub token identity
+- if the token belongs to a user account, create the repository under that user by default
+- if the token is scoped for org automation and repo creation should target an org, require an explicit owner override in v1
+- if `visibility` is omitted, default to `private`
 
 ### Existing repo reuse
 

--- a/docs/design/separate-base-agent-image-detailed-design.md
+++ b/docs/design/separate-base-agent-image-detailed-design.md
@@ -1,0 +1,251 @@
+# Separate Base Agent Image Detailed Design
+
+**Status:** proposed  
+**Issue:** [#38](https://github.com/pandazxx/codex-slack/issues/38)  
+**ADR:** `docs/decisions/0002-separate-base-agent-image.md`
+
+## Goal
+
+Define the detailed implementation design for separating and publishing a reusable base agent image that projects can extend safely.
+
+This design covers:
+
+- base image ownership and scope
+- GHCR publication workflow
+- project customization contract
+- docs that project teams need in order to consume the image
+
+## Product Decision
+
+The canonical published agent base image should come from `Dockerfile.agent-minimal`.
+
+Projects should customize agent runtime through:
+
+- `.prj_assistant/image/Dockerfile`
+
+In this design, "project specific manifest" means that repo-local Dockerfile contract, not a separate metadata file.
+
+## Current State
+
+The repository currently has:
+
+- `Dockerfile`
+  - broader runtime image
+  - includes master-oriented tooling such as `podman`, `gh`, `jq`, and `make`
+- `Dockerfile.agent-minimal`
+  - leaner image closer to agent-worker needs
+
+The docs already reference a published base image, but the workflow is not yet defined as a complete contract.
+
+## Desired State
+
+### Base image role
+
+The base image should provide only the stable runtime needed by agent containers:
+
+- Python runtime
+- `codex` CLI
+- `claude` CLI
+- `git`
+- `openssh-client`
+- agent entrypoint
+- Python dependencies required by `src.agent.main`
+
+### Non-goals for the base image
+
+Do not include master-only tooling by default:
+
+- `podman`
+- `podman-compose`
+- `gh`
+- `jq`
+- `make`
+
+Projects that need additional tools should extend the base image in their own `.prj_assistant/image/Dockerfile`.
+
+## Architecture Boundary
+
+```mermaid
+flowchart LR
+    SRC[Repository source]
+    DF[Dockerfile.agent-minimal]
+    WF[Image publish workflow]
+    REG[GHCR]
+    PROJ[Project repo]
+    PDF[.prj_assistant/image/Dockerfile]
+    PLAN[MasterService image-plan detection]
+    IMG[Project-specific agent image]
+
+    SRC --> DF
+    DF --> WF
+    WF --> REG
+    REG --> PDF
+    PROJ --> PDF
+    PDF --> PLAN
+    PLAN --> IMG
+```
+
+## Publishing Design
+
+### Registry target
+
+Publish to:
+
+- `ghcr.io/<owner>/codex-slack-agent-minimal`
+
+### Tagging policy
+
+Required tags:
+
+- `sha-<commit>` for immutable traceability
+- exact git tag mirrors, including release candidates
+- `latest` for default branch publication
+
+### Trigger policy
+
+Recommended workflow triggers:
+
+- pushes to default branch affecting agent runtime/image inputs
+- git tags for release and RC builds
+- manual dispatch for rebuilds
+
+### Build inputs
+
+Workflow should build from:
+
+- `Dockerfile.agent-minimal`
+
+Not from:
+
+- `Dockerfile`
+
+### Metadata
+
+Publish image metadata including:
+
+- source repository
+- commit SHA
+- git tag when present
+- build timestamp
+
+## Project Customization Contract
+
+### Required path
+
+Project repos should customize through:
+
+- `.prj_assistant/image/Dockerfile`
+
+### Required `FROM`
+
+Example:
+
+```dockerfile
+FROM ghcr.io/<owner>/codex-slack-agent-minimal:<tag>
+```
+
+### Allowed customization
+
+- install OS packages
+- install project CLIs or language runtimes
+- add project-specific support libraries
+
+### Discouraged customization
+
+- replacing the entrypoint
+- changing the worker startup command
+- changing workspace or home-directory assumptions
+
+## Runtime Invariants
+
+Project images built from the base must preserve:
+
+- `/workspace` workspace mount contract
+- `/workspace/repo` checkout location
+- `/workspace/home` effective home directory
+- `CODEX_CONTAINER_MODE=agent-worker`
+- entrypoint behavior from `docker/entrypoint.sh`
+
+If a project must break one of these invariants, it should be treated as a non-standard image and documented separately.
+
+## Master Integration
+
+The existing image-plan logic already detects:
+
+- `.prj_assistant/image/Dockerfile`
+
+That means the base-image separation does not require a new project image manifest format.
+
+The master-side contract remains:
+
+- default-image agents use `MASTER_AGENT_BASE_IMAGE`
+- project-customized agents use repo-local Dockerfiles
+
+## Documentation Deliverables
+
+Implementation should produce or update:
+
+1. project-facing guide for using the base image
+2. clear example `.prj_assistant/image/Dockerfile`
+3. guidance on choosing between `latest`, RC tags, and `sha-*` tags
+4. explanation of which runtime invariants must be preserved
+5. clarification that "project specific manifest" means `.prj_assistant/image/Dockerfile`
+
+Recommended doc touch points:
+
+- `docs/guides/tutorials.md`
+- `docs/guides/container-runtime.md`
+- `docs/guides/runbooks/master-agent.md`
+- FAQ entry if needed
+
+## CI/CD Design
+
+### Workflow responsibilities
+
+- build the base image
+- log in to GHCR
+- publish required tags
+- optionally emit a summary with pushed image references
+
+### Inputs and secrets
+
+- GitHub Actions token or package publish credentials
+- repository owner/org context
+
+### Validation
+
+The workflow should verify:
+
+- image builds successfully from `Dockerfile.agent-minimal`
+- `python -m src.agent.main` remains runnable
+- expected CLIs exist in the image
+
+## Test and Verification Plan
+
+### Automated
+
+- build test for `Dockerfile.agent-minimal`
+- smoke check that `codex` and `claude` binaries exist
+- smoke check that entrypoint can launch `src.agent.main`
+- image tag calculation tests if implemented in scripts
+
+### Manual / UAT
+
+- project extends the base image via `.prj_assistant/image/Dockerfile`
+- master loads and starts an agent using the project image path
+- agent still honors auth/config injection and workspace layout
+
+## Rollout Plan
+
+Recommended delivery order:
+
+1. finalize base image package contents
+2. add GHCR publication workflow
+3. update docs with project consumption guidance
+4. verify one sample project image build from the published base
+
+## Open Questions
+
+- should `latest` track only default branch, or only accepted releases?
+- should GHCR publication include both public and internal/private package guidance?
+- do we want a sample project repo or only in-repo docs/examples?

--- a/docs/guides/container-runtime.md
+++ b/docs/guides/container-runtime.md
@@ -6,12 +6,26 @@ This guide is operational. The canonical runtime contract for master-managed
 agent containers lives in
 `docs/design/agent-container-runtime-design.md`.
 
+## Runtime Images
+This repository currently has two container-image roles:
+
+- `Dockerfile`
+  - broader master/runtime image
+  - includes master-oriented tools such as `podman`, `gh`, `jq`, and `make`
+- `Dockerfile.agent-minimal`
+  - published base image for agent containers
+  - intended to be extended by project repos through `.prj_assistant/image/Dockerfile`
+
 ## Included Tools
-The image ships with:
+The published minimal agent base image from `Dockerfile.agent-minimal` ships with:
 - Python 3.11 runtime
 - `codex` CLI (installed via npm package `@openai/codex`)
 - `claude` CLI
-- `git`, `gh`, `curl`, `jq`, `make`, `openssh-client`
+- `git`
+- `openssh-client`
+- agent entrypoint and Python dependencies required by `src.agent.main`
+
+It intentionally does not include master-only tooling like `podman`, `gh`, `jq`, or `make`.
 
 For detailed master-agent operational steps, see
 `docs/guides/runbooks/master-agent.md`.
@@ -221,6 +235,33 @@ podman exec -it agent-<name> sh -lc 'ls -la /workspace/repo/.codex /workspace/re
 For auth/config injection details, user-scope vs project-scope paths, and
 request-manifest behavior, refer to
 `docs/design/agent-container-runtime-design.md`.
+
+## Published Base Image Contract
+Use the published minimal base image when a project needs extra packages or CLIs but should keep the standard agent runtime contract.
+
+- Published image:
+  - `ghcr.io/<owner>/codex-slack-agent-minimal:<tag>`
+- Recommended tag choices:
+  - `latest` for default-branch testing
+  - `vX.Y-rcN` or release tags for controlled rollout
+  - `sha-<commit>` for immutable pinning
+- Project customization path:
+  - `.prj_assistant/image/Dockerfile`
+
+Example project Dockerfile:
+
+```dockerfile
+FROM ghcr.io/<owner>/codex-slack-agent-minimal:latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    jq ripgrep && \
+    rm -rf /var/lib/apt/lists/*
+```
+
+Keep these invariants when extending the base:
+- preserve `/workspace`, `/workspace/repo`, and `/workspace/home`
+- preserve `CODEX_CONTAINER_MODE=agent-worker`
+- do not replace `docker/entrypoint.sh` behavior unless you are intentionally leaving the standard runtime contract
 
 ## Codex Sandbox Bypass
 Container mode is configured to run Codex with:

--- a/docs/guides/discord-setup.md
+++ b/docs/guides/discord-setup.md
@@ -95,6 +95,38 @@ Usage model:
   - mapped to one agent
   - used for prompt routing and follow-up replies
 
+## 4A. Enable Bot-Driven Channel Creation
+If you want to use `/master-agent-provision` with Discord `create_channel=true`, the bot must be allowed to create channels in the target location.
+
+Current behavior:
+- Discord provisioning creates the new text channel in the same guild/category as the admin channel where you run `/master-agent-provision`.
+- The bot therefore needs channel-creation permission in that category, not just in the server generally.
+
+Required permission:
+- `Manage Channels`
+
+Recommended setup:
+1. Pick the category where provisioned agent channels should be created.
+2. Put your Discord admin channel inside that same category if you want provisioning to land there automatically.
+3. Open the category in Discord and choose **Edit Category**.
+4. Open **Permissions**.
+5. Add the bot role or the bot user explicitly.
+6. Grant at least:
+   - **View Channel**
+   - **Send Messages**
+   - **Read Message History**
+   - **Manage Channels**
+7. Save the category permission changes.
+8. Verify the bot role is not blocked by another category override.
+
+Recommended validation:
+1. Run `/master-agent-provision` from that admin channel.
+2. If it fails with Discord error code `50013` (`Missing Permissions`), re-check the category overrides first.
+
+Important:
+- Server-level bot permissions alone may not be enough if the category overrides deny `Manage Channels`.
+- If you run provisioning from a different admin channel in another category, the new channel will be created there instead.
+
 ## 5. Enable Developer Mode and Copy Channel IDs
 To obtain channel IDs for `DISCORD_ADMIN_CHANNELS` and `/master-agent-load`:
 1. In Discord, open **User Settings**.
@@ -201,6 +233,8 @@ Notes:
 ## 11. Common Discord Errors
 - `Missing Access` / command not visible:
   - Bot lacks required permissions or app command sync not complete.
+- `403 Forbidden (50013): Missing Permissions` during `/master-agent-provision`:
+  - Bot lacks `Manage Channels` in the category containing the admin channel used for provisioning.
 - Mention messages ignored:
   - Bot not present in channel, or Message Content Intent not enabled.
 - Command rejected as non-admin channel:

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -202,6 +202,8 @@ Omit the model argument to clear the override:
 - Fast recovery options:
   - rerun the command from an admin channel in a category where the bot can create channels
   - or grant the bot `Manage Channels` on the intended category before retrying
+- Setup reference:
+  - `docs/guides/discord-setup.md`, section `Enable Bot-Driven Channel Creation`
 - Useful provisioning logs:
   - `master.provision_command_parsed`
   - `provision.start`

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -100,7 +100,10 @@ python -m src.master.main
 ```
 
 Important env notes:
-- Set `MASTER_AGENT_BASE_IMAGE` to the image tag you actually rebuilt for agent containers. If unset, default-image agents still start from `codex-slack-bot:latest`.
+- Set `MASTER_AGENT_BASE_IMAGE` to the default-image tag you want master to use for agents without `.prj_assistant/image/Dockerfile`.
+- Recommended published base image:
+  - `ghcr.io/<owner>/codex-slack-agent-minimal:<tag>`
+- If unset, default-image agents still start from `codex-slack-bot:latest`.
 - `MASTER_CODEX_AUTH_JSON_PATH` must be a host filesystem path visible to host Podman. It is mounted into each agent as `/run/secrets/codex_auth.json:ro`.
 - `MASTER_SSH_AUTH_SOCK_PATH` must be a host filesystem path visible to host Podman. It is mounted into each agent as `/run/secrets/ssh-auth.sock`.
 - The master container itself also needs the same SSH socket mounted separately, for example `-v /absolute/host/path/ssh-agent.sock:/ssh-agent`, with `SSH_AUTH_SOCK=/ssh-agent` so `/master-agent-load` can clone private repos over SSH.
@@ -110,6 +113,7 @@ Important env notes:
 - Default command template is `MASTER_AGENT_COMMAND_TEMPLATE='codex exec --dangerously-bypass-approvals-and-sandbox resume --last -'`.
 - Default adapter is `MASTER_DEFAULT_AGENT_ADAPTER=codex`.
 - If you use the `claude-code` adapter, rebuild the base image from this branch so the agent container includes the `claude` CLI binary.
+- If a project repo contains `.prj_assistant/image/Dockerfile`, master builds that repo-local image on `/master-agent-start` and does not use `MASTER_AGENT_BASE_IMAGE` for that agent.
 
 Claude subscription auth in headless containers:
 - Generate `CLAUDE_CODE_OAUTH_TOKEN` on the host with:

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -190,6 +190,25 @@ Omit the model argument to clear the override:
 ```
 - Re-run `/master-agent-load` for the new mapping.
 
+### Discord provisioning channel-create failure
+- If `/master-agent-provision` returns `ERR_PROVISION_FAILED` and master logs show `discord.errors.Forbidden: 403 Forbidden (error code: 50013): Missing Permissions`, the GitHub repo step may already have succeeded and only the Discord channel-create step failed.
+- Current behavior creates the new Discord text channel in the same guild/category as the admin channel where the provisioning command was invoked.
+- Required permission in that target location:
+  - `Manage Channels`
+- Check:
+  - the bot role has `Manage Channels` in the guild
+  - the category inherited from the admin channel does not override-deny `Manage Channels`
+  - the bot can view the target category
+- Fast recovery options:
+  - rerun the command from an admin channel in a category where the bot can create channels
+  - or grant the bot `Manage Channels` on the intended category before retrying
+- Useful provisioning logs:
+  - `master.provision_command_parsed`
+  - `provision.start`
+  - `provision.github_create_done`
+  - `provision.discord_channel_create_start`
+  - `provision.failed`
+
 ### Worker init failure
 - Inspect status file in agent container path:
 `/tmp/master-agent/status.json`

--- a/docs/guides/tutorials.md
+++ b/docs/guides/tutorials.md
@@ -124,6 +124,10 @@ Use this when your project needs extra OS packages, CLI tools, or language runti
 1. Use the published minimal base image from registry (default path).
    - Base image:
      - `ghcr.io/<owner>/codex-slack-agent-minimal:latest`
+   - Tag guidance:
+     - `latest` for testing against current default branch
+     - `vX.Y-rcN` for release-candidate validation
+     - `sha-<commit>` for immutable pinning
    - Reason: no local base-image bootstrap is required for normal customization flow.
 
 2. Optional fallback for local-only development:
@@ -131,8 +135,8 @@ Use this when your project needs extra OS packages, CLI tools, or language runti
 
 ```bash
 cd /workspace/repo
-podman build -t codex-slack-bot:latest -f Dockerfile .
-podman tag codex-slack-bot:latest localhost/codex-slack-bot:latest
+podman build -t codex-slack-agent-minimal:latest -f Dockerfile.agent-minimal .
+podman tag codex-slack-agent-minimal:latest localhost/codex-slack-agent-minimal:latest
 ```
 
 3. Add project image files in your repo:
@@ -141,7 +145,7 @@ podman tag codex-slack-bot:latest localhost/codex-slack-bot:latest
    - Start with:
      - `FROM ghcr.io/<owner>/codex-slack-agent-minimal:latest`
    - Local fallback:
-     - `FROM localhost/codex-slack-bot:latest`
+     - `FROM localhost/codex-slack-agent-minimal:latest`
    - Install only project dependencies on top.
    - Do not override `ENTRYPOINT`, container mode env flow, or workspace mount assumptions unless required.
 5. Example Dockerfile:
@@ -162,6 +166,7 @@ podman build -t local-<project>-agent -f .prj_assistant/image/Dockerfile .prj_as
 
 7. Run a smoke test for base behavior compatibility:
    - Container starts successfully.
+   - `codex --version` and `claude --version` both work in the image.
    - `python -m src.agent.main` is still runnable in image context.
    - Required project tools are present (`jq`, `rg`, language runtime, etc.).
 

--- a/docs/knowledge-base/faq.md
+++ b/docs/knowledge-base/faq.md
@@ -37,3 +37,9 @@ The container image does not include the `claude` CLI. Rebuild the base image fr
 **Q: Where do I find the agent registry?**
 
 Default path: `data/master/agents.json`. Override with `MASTER_REGISTRY_PATH`.
+
+---
+
+**Q: `/master-agent-provision` created the GitHub repo but failed with Discord `50013 Missing Permissions`. What does that mean?**
+
+The GitHub part succeeded and the Discord channel-creation step failed. Current Discord provisioning creates the new text channel in the same guild/category as the admin channel where you ran the command. The bot needs `Manage Channels` in that target category. If the category overrides deny it, move to a different admin channel/category or grant the bot `Manage Channels` there before retrying.

--- a/docs/test-plans/master-agent-uat.md
+++ b/docs/test-plans/master-agent-uat.md
@@ -71,6 +71,10 @@ Expected:
 - Command behavior and response semantics match Slack command flow.
 - Admin-channel enforcement uses `DISCORD_ADMIN_CHANNELS`.
 
+Discord provisioning note:
+- When validating `/master-agent-provision` with `create_channel=true`, run it from an admin channel in the guild/category where the new channel should be created.
+- The bot must have `Manage Channels` in that target category. If provisioning fails with Discord error code `50013` (`Missing Permissions`), the repo-creation step may still have succeeded while channel creation failed.
+
 ### UAT-v3-005: Adapter Routing Selection
 Preconditions:
 - One agent loaded with `--adapter codex`.

--- a/src/master/command_dispatch.py
+++ b/src/master/command_dispatch.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import shlex
 
+from .provisioning import ProvisionContext, ProvisionRequest, ProvisioningCoordinator
 from .service import CommandResult, MasterService
 
 
@@ -43,6 +45,116 @@ def parse_load_text(text: str) -> tuple[str, str, str, str, str | None]:
     return name, repo_path, channel_id, repo_ref, adapter
 
 
+def parse_provision_text(text: str) -> ProvisionRequest:
+    usage = (
+        "usage: /master-agent-provision <name> [repo_path] [channel_id] [branch] "
+        "[--branch <branch>] "
+        "[--create-repo] [--repo-owner <owner>] [--repo-name <name>] [--repo-visibility private|public] "
+        "[--create-channel] [--channel-name <name>] [--channel-visibility private|public] "
+        "[--adapter codex|claude-code]"
+    )
+    parts = shlex.split(text)
+    if not parts:
+        raise ValueError(usage)
+
+    name = parts[0].strip()
+    repo_path: str | None = None
+    channel_id: str | None = None
+    repo_ref = "main"
+    agent_adapter: str | None = None
+    create_repo = False
+    repo_owner: str | None = None
+    repo_name: str | None = None
+    repo_visibility = "private"
+    create_channel = False
+    channel_name: str | None = None
+    channel_visibility = "private"
+
+    positional: list[str] = []
+    idx = 1
+    while idx < len(parts):
+        token = parts[idx]
+        if token == "--create-repo":
+            create_repo = True
+            idx += 1
+            continue
+        if token == "--branch":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            repo_ref = parts[idx + 1].strip()
+            idx += 2
+            continue
+        if token == "--repo-owner":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            repo_owner = parts[idx + 1].strip()
+            idx += 2
+            continue
+        if token == "--repo-name":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            repo_name = parts[idx + 1].strip()
+            idx += 2
+            continue
+        if token == "--repo-visibility":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            repo_visibility = parts[idx + 1].strip().lower()
+            idx += 2
+            continue
+        if token == "--create-channel":
+            create_channel = True
+            idx += 1
+            continue
+        if token == "--channel-name":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            channel_name = parts[idx + 1].strip()
+            idx += 2
+            continue
+        if token == "--channel-visibility":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            channel_visibility = parts[idx + 1].strip().lower()
+            idx += 2
+            continue
+        if token == "--adapter":
+            if idx + 1 >= len(parts):
+                raise ValueError(usage)
+            agent_adapter = parts[idx + 1].strip().lower()
+            idx += 2
+            continue
+        if token.startswith("--"):
+            raise ValueError(f"unknown option: {token}")
+        positional.append(token)
+        idx += 1
+
+    if len(positional) > 3:
+        raise ValueError(usage)
+    if positional:
+        repo_path = positional[0]
+    if len(positional) >= 2:
+        channel_id = positional[1]
+    if len(positional) >= 3:
+        repo_ref = positional[2]
+
+    return ProvisionRequest(
+        name=name,
+        platform="slack",
+        repo_path=repo_path,
+        channel_id=channel_id,
+        repo_ref=repo_ref,
+        agent_adapter=agent_adapter,
+        create_repo=create_repo,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        repo_visibility=repo_visibility,
+        create_channel=create_channel,
+        channel_name=channel_name,
+        channel_visibility=channel_visibility,
+    )
+
+
 def parse_single_name_text(text: str, command_name: str) -> str:
     name = text.strip()
     if not name:
@@ -75,7 +187,13 @@ def parse_set_model_text(text: str, command_name: str = "/master-agent-set-model
     return parts[0], parts[1] or None
 
 
-def dispatch_command(service: MasterService, request: MasterCommandRequest) -> CommandResult:
+def dispatch_command(
+    service: MasterService,
+    request: MasterCommandRequest,
+    *,
+    provisioning: ProvisioningCoordinator | None = None,
+    provision_context: ProvisionContext | None = None,
+) -> CommandResult:
     if request.command_name == "/master-agent-list":
         return service.list_agents()
 
@@ -88,6 +206,25 @@ def dispatch_command(service: MasterService, request: MasterCommandRequest) -> C
             repo_ref=repo_ref,
             platform=request.platform,
             agent_adapter=agent_adapter,
+        )
+
+    if request.command_name == "/master-agent-provision":
+        if provisioning is None or provision_context is None:
+            return CommandResult(
+                ok=False,
+                code="ERR_INTERNAL",
+                message="provisioning is not configured",
+                data={},
+            )
+        parsed = parse_provision_text(request.text)
+        return provisioning.provision_agent(
+            ProvisionRequest(
+                **{
+                    **parsed.__dict__,
+                    "platform": request.platform,
+                }
+            ),
+            context=provision_context,
         )
 
     if request.command_name == "/master-agent-start":

--- a/src/master/command_dispatch.py
+++ b/src/master/command_dispatch.py
@@ -141,6 +141,11 @@ def parse_provision_text(text: str) -> ProvisionRequest:
     if len(positional) >= 3:
         repo_ref = positional[2]
 
+    if repo_path is None:
+        create_repo = True
+    if channel_id is None:
+        create_channel = True
+
     return ProvisionRequest(
         name=name,
         platform="slack",

--- a/src/master/command_dispatch.py
+++ b/src/master/command_dispatch.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 import shlex
 
 from .provisioning import ProvisionContext, ProvisionRequest, ProvisioningCoordinator
 from .service import CommandResult, MasterService
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -217,6 +220,18 @@ def dispatch_command(
                 data={},
             )
         parsed = parse_provision_text(request.text)
+        LOGGER.info(
+            "master.provision_command_parsed platform=%s admin_channel=%s agent=%s repo_path=%s channel_id=%s create_repo=%s create_channel=%s repo_ref=%s adapter=%s",
+            request.platform,
+            provision_context.admin_channel_id,
+            parsed.name,
+            parsed.repo_path or "-",
+            parsed.channel_id or "-",
+            parsed.create_repo,
+            parsed.create_channel,
+            parsed.repo_ref,
+            parsed.agent_adapter or "-",
+        )
         return provisioning.provision_agent(
             ProvisionRequest(
                 **{

--- a/src/master/command_runtime.py
+++ b/src/master/command_runtime.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from .command_dispatch import MasterCommandRequest, dispatch_command, parse_optional_name_text
 from .command_format import format_command_result, format_status_full_chunks, wants_full_status
+from .provisioning import ProvisionContext, ProvisioningCoordinator
 from .router import ChannelRouter
 from .service import CommandResult, MasterService
 
@@ -34,6 +35,8 @@ def execute_master_command(
     service: MasterService,
     router: ChannelRouter | None = None,
     rate_limiter: RateLimiter | None = None,
+    provisioning: ProvisioningCoordinator | None = None,
+    provision_context: ProvisionContext | None = None,
 ) -> list[str]:
     request = MasterCommandRequest(
         command_name=command_name,
@@ -102,7 +105,12 @@ def execute_master_command(
                     data={"usage": router.usage_summary(selected_agent)},
                 )
         else:
-            result = dispatch_command(service, request)
+            result = dispatch_command(
+                service,
+                request,
+                provisioning=provisioning,
+                provision_context=provision_context,
+            )
 
         LOGGER.info(
             "master.command_dispatch_done command=%s channel=%s user=%s ok=%s code=%s",

--- a/src/master/discord_app.py
+++ b/src/master/discord_app.py
@@ -10,6 +10,12 @@ from urllib.request import Request, urlopen
 
 from .command_runtime import execute_master_command
 from .dispatch_guard import in_flight_dispatch, is_shutting_down
+from .provisioning import (
+    DiscordChannelProvisioner,
+    ProvisionContext,
+    ProvisioningCoordinator,
+    RepoProvisioner,
+)
 from .router import ChannelRouter, RouteError, RouteSkip
 from .service import MasterService
 from .slack_app import format_forward_ack
@@ -256,6 +262,7 @@ def run_discord_frontend(
     service: MasterService,
     router: ChannelRouter,
     rate_limiter: object | None = None,
+    repo_provisioner: RepoProvisioner | None = None,
 ) -> None:
     try:
         import discord
@@ -268,6 +275,13 @@ def run_discord_frontend(
     intents.message_content = True
     client = discord.Client(intents=intents)
     tree = discord.app_commands.CommandTree(client)
+    provisioning = None
+    if repo_provisioner is not None:
+        provisioning = ProvisioningCoordinator(
+            service=service,
+            repo_provisioner=repo_provisioner,
+            channel_provisioner=DiscordChannelProvisioner(client),
+        )
 
     async def _send_messages(interaction, messages: list[str]) -> None:  # type: ignore[no-untyped-def]
         expanded: list[str] = []
@@ -317,7 +331,14 @@ def run_discord_frontend(
         for idx, buf in enumerate(mermaid_buffers, start=1):
             await thread.send(file=discord.File(buf, filename=f"diagram-{idx}.png"))
 
-    def _run_command(*, command_name: str, text: str, channel_id: str, user_id: str) -> list[str]:
+    def _run_command(
+        *,
+        command_name: str,
+        text: str,
+        channel_id: str,
+        user_id: str,
+        provision_context: ProvisionContext | None = None,
+    ) -> list[str]:
         return execute_master_command(
             platform="discord",
             command_name=command_name,
@@ -328,17 +349,30 @@ def run_discord_frontend(
             service=service,
             router=router,
             rate_limiter=rate_limiter,  # type: ignore[arg-type]
+            provisioning=provisioning,
+            provision_context=provision_context,
         )
 
     async def _execute_and_send(interaction, *, command_name: str, text: str) -> None:  # type: ignore[no-untyped-def]
         if not interaction.response.is_done():
             await interaction.response.defer(thinking=True)
+        channel = interaction.channel
+        guild_id = getattr(getattr(channel, "guild", None), "id", None)
+        category_id = getattr(getattr(channel, "category", None), "id", None)
+        provision_context = ProvisionContext(
+            platform="discord",
+            admin_channel_id=str(interaction.channel_id),
+            discord_guild_id=str(guild_id) if guild_id is not None else None,
+            discord_category_id=str(category_id) if category_id is not None else None,
+            discord_event_loop=asyncio.get_running_loop(),
+        )
         messages = await asyncio.to_thread(
             _run_command,
             command_name=command_name,
             text=text,
             channel_id=str(interaction.channel_id),
             user_id=str(interaction.user.id),
+            provision_context=provision_context,
         )
         await _send_messages(interaction, messages)
 
@@ -406,6 +440,13 @@ def run_discord_frontend(
                     text=args_text,
                     channel_id=admin_channel_id,
                     user_id=user_id,
+                    provision_context=ProvisionContext(
+                        platform="discord",
+                        admin_channel_id=admin_channel_id,
+                        discord_guild_id=str(getattr(getattr(message.channel, "guild", None), "id", "") or "") or None,
+                        discord_category_id=str(getattr(getattr(message.channel, "category", None), "id", "") or "") or None,
+                        discord_event_loop=asyncio.get_running_loop(),
+                    ),
                 )
                 for reply in messages:
                     await _reply_message_chunks(message, reply)
@@ -507,6 +548,47 @@ def run_discord_frontend(
     ) -> None:  # type: ignore[no-untyped-def]
         text = f"{name} {repo_path} {channel_id} {branch} --adapter {adapter}".strip()
         await _execute_and_send(interaction, command_name="/master-agent-load", text=text)
+
+    @tree.command(name="master-agent-provision", description="Provision an agent mapping")
+    async def cmd_provision(
+        interaction,
+        name: str,
+        repo_path: str = "",
+        channel_id: str = "",
+        branch: str = "main",
+        create_repo: bool = False,
+        repo_owner: str = "",
+        repo_name: str = "",
+        repo_visibility: str = "private",
+        create_channel: bool = False,
+        channel_name: str = "",
+        channel_visibility: str = "private",
+        adapter: str = "codex",
+    ) -> None:  # type: ignore[no-untyped-def]
+        parts = [name]
+        if repo_path:
+            parts.append(repo_path)
+        if channel_id:
+            parts.append(channel_id)
+        if branch:
+            parts.extend(["--branch", branch])
+        if create_repo:
+            parts.append("--create-repo")
+        if repo_owner:
+            parts.extend(["--repo-owner", repo_owner])
+        if repo_name:
+            parts.extend(["--repo-name", repo_name])
+        if repo_visibility:
+            parts.extend(["--repo-visibility", repo_visibility])
+        if create_channel:
+            parts.append("--create-channel")
+        if channel_name:
+            parts.extend(["--channel-name", channel_name])
+        if channel_visibility:
+            parts.extend(["--channel-visibility", channel_visibility])
+        if adapter:
+            parts.extend(["--adapter", adapter])
+        await _execute_and_send(interaction, command_name="/master-agent-provision", text=" ".join(parts))
 
     @tree.command(name="master-agent-start", description="Start an agent")
     async def cmd_start(interaction, name: str) -> None:  # type: ignore[no-untyped-def]

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -11,6 +11,7 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from .config import load_master_settings
 from .discord_app import run_discord_frontend
 from .dispatch_guard import install_sigterm_handler
+from .provisioning import GitHubRepoProvisioner
 from .registry import AgentRegistry
 from .router import ChannelRouter, ClaudeCodeDispatcher, MultiAgentDispatcher, PodmanExecDispatcher
 from .runtime_adapter import PodmanRuntimeAdapter
@@ -105,6 +106,7 @@ def main() -> None:
         max_calls=settings.command_rate_limit_count,
         window_seconds=settings.command_rate_limit_window_seconds,
     )
+    repo_provisioner = GitHubRepoProvisioner()
 
     threads: list[Thread] = []
     if "slack" in settings.frontends:
@@ -114,6 +116,7 @@ def main() -> None:
             service=service,
             router=router,
             rate_limiter=rate_limiter,
+            repo_provisioner=repo_provisioner,
         )
         handler = SocketModeHandler(app, settings.slack_app_token)
         slack_thread = Thread(target=handler.start, name="frontend-slack", daemon=True)
@@ -130,6 +133,7 @@ def main() -> None:
                 "service": service,
                 "router": router,
                 "rate_limiter": rate_limiter,
+                "repo_provisioner": repo_provisioner,
             },
             name="frontend-discord",
             daemon=True,

--- a/src/master/provisioning.py
+++ b/src/master/provisioning.py
@@ -46,6 +46,7 @@ class CreatedRepo:
     visibility: str
     html_url: str
     clone_url: str
+    ssh_url: str
 
 
 @dataclass(frozen=True)
@@ -134,6 +135,7 @@ class GitHubRepoProvisioner:
             visibility="private" if bool(response.get("private")) else "public",
             html_url=str(response["html_url"]),
             clone_url=str(response["clone_url"]),
+            ssh_url=str(response["ssh_url"]),
         )
 
     def _fetch_token_identity(self) -> tuple[str, str]:
@@ -278,7 +280,7 @@ class ProvisioningCoordinator:
                     repo_name=request.repo_name,
                     visibility=request.repo_visibility,
                 )
-                resolved_repo_path = created_repo.clone_url
+                resolved_repo_path = created_repo.ssh_url or created_repo.clone_url
 
             if request.create_channel:
                 if self._channel_provisioner is None:

--- a/src/master/provisioning.py
+++ b/src/master/provisioning.py
@@ -47,6 +47,7 @@ class CreatedRepo:
     owner: str
     repo_name: str
     visibility: str
+    default_branch: str | None
     html_url: str
     clone_url: str
     ssh_url: str
@@ -134,6 +135,7 @@ class GitHubRepoProvisioner:
         payload = {
             "name": resolved_repo_name,
             "private": visibility == "private",
+            "auto_init": True,
         }
         if is_org:
             response = self._request("POST", f"/orgs/{resolved_owner}/repos", payload)
@@ -145,16 +147,18 @@ class GitHubRepoProvisioner:
             owner=str(response["owner"]["login"]),
             repo_name=str(response["name"]),
             visibility="private" if bool(response.get("private")) else "public",
+            default_branch=str(response.get("default_branch") or "") or None,
             html_url=str(response["html_url"]),
             clone_url=str(response["clone_url"]),
             ssh_url=str(response["ssh_url"]),
         )
         LOGGER.info(
-            "provision.github_create_done agent=%s owner=%s repo_name=%s visibility=%s ssh_url=%s",
+            "provision.github_create_done agent=%s owner=%s repo_name=%s visibility=%s default_branch=%s ssh_url=%s",
             agent_name,
             created.owner,
             created.repo_name,
             created.visibility,
+            created.default_branch or "-",
             created.ssh_url,
         )
         return created
@@ -340,6 +344,7 @@ class ProvisioningCoordinator:
         created_channel: CreatedChannel | None = None
         resolved_repo_path = request.repo_path
         resolved_channel_id = request.channel_id
+        resolved_repo_ref = request.repo_ref
 
         try:
             if request.create_repo:
@@ -352,11 +357,14 @@ class ProvisioningCoordinator:
                     visibility=request.repo_visibility,
                 )
                 resolved_repo_path = created_repo.ssh_url or created_repo.clone_url
+                if request.repo_ref == "main" and created_repo.default_branch:
+                    resolved_repo_ref = created_repo.default_branch
                 LOGGER.info(
-                    "provision.repo_ready agent=%s repo_path=%s clone_url=%s",
+                    "provision.repo_ready agent=%s repo_path=%s clone_url=%s repo_ref=%s",
                     request.name,
                     resolved_repo_path,
                     created_repo.clone_url,
+                    resolved_repo_ref,
                 )
 
             if request.create_channel:
@@ -399,7 +407,7 @@ class ProvisioningCoordinator:
             request.name,
             resolved_repo_path or "-",
             resolved_channel_id or "-",
-            request.repo_ref,
+            resolved_repo_ref,
             request.platform,
             request.agent_adapter or "-",
         )
@@ -407,7 +415,7 @@ class ProvisioningCoordinator:
             name=request.name,
             repo_path=resolved_repo_path or "",
             channel_id=resolved_channel_id or "",
-            repo_ref=request.repo_ref,
+            repo_ref=resolved_repo_ref,
             platform=request.platform,
             agent_adapter=request.agent_adapter,
         )

--- a/src/master/provisioning.py
+++ b/src/master/provisioning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -10,6 +11,8 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from .service import CommandResult, MasterService
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -119,6 +122,15 @@ class GitHubRepoProvisioner:
         token_owner, token_owner_type = self._fetch_token_identity()
         resolved_owner = owner or token_owner
         is_org = token_owner_type.lower() == "organization" or (owner is not None and owner != token_owner)
+        LOGGER.info(
+            "provision.github_create_start agent=%s owner=%s owner_source=%s repo_name=%s visibility=%s mode=%s",
+            agent_name,
+            resolved_owner,
+            "explicit" if owner else "token",
+            resolved_repo_name,
+            visibility,
+            "org" if is_org else "user",
+        )
         payload = {
             "name": resolved_repo_name,
             "private": visibility == "private",
@@ -128,7 +140,7 @@ class GitHubRepoProvisioner:
         else:
             response = self._request("POST", "/user/repos", payload)
 
-        return CreatedRepo(
+        created = CreatedRepo(
             provider="github",
             owner=str(response["owner"]["login"]),
             repo_name=str(response["name"]),
@@ -137,6 +149,15 @@ class GitHubRepoProvisioner:
             clone_url=str(response["clone_url"]),
             ssh_url=str(response["ssh_url"]),
         )
+        LOGGER.info(
+            "provision.github_create_done agent=%s owner=%s repo_name=%s visibility=%s ssh_url=%s",
+            agent_name,
+            created.owner,
+            created.repo_name,
+            created.visibility,
+            created.ssh_url,
+        )
+        return created
 
     def _fetch_token_identity(self) -> tuple[str, str]:
         payload = self._request("GET", "/user")
@@ -183,17 +204,32 @@ class SlackChannelProvisioner:
         if visibility not in {"private", "public"}:
             raise RuntimeError(f"unsupported slack channel visibility: {visibility}")
         resolved_name = normalize_channel_name(channel_name or f"agent-{agent_name}")
+        LOGGER.info(
+            "provision.slack_channel_create_start agent=%s admin_channel=%s channel_name=%s visibility=%s",
+            agent_name,
+            context.admin_channel_id,
+            resolved_name,
+            visibility,
+        )
         result = self._client.conversations_create(name=resolved_name, is_private=(visibility == "private"))
         channel = result.get("channel", {})
         channel_id = str(channel.get("id") or "")
         if not channel_id:
             raise RuntimeError("slack channel create returned no channel id")
-        return CreatedChannel(
+        created = CreatedChannel(
             platform="slack",
             channel_id=channel_id,
             channel_name=str(channel.get("name") or resolved_name),
             visibility=visibility,
         )
+        LOGGER.info(
+            "provision.slack_channel_create_done agent=%s channel_id=%s channel_name=%s visibility=%s",
+            agent_name,
+            created.channel_id,
+            created.channel_name,
+            created.visibility,
+        )
+        return created
 
 
 class DiscordChannelProvisioner:
@@ -213,6 +249,15 @@ class DiscordChannelProvisioner:
         if not context.discord_guild_id:
             raise RuntimeError("discord provisioning requires a guild id")
         resolved_name = normalize_channel_name(channel_name or f"agent-{agent_name}")
+        LOGGER.info(
+            "provision.discord_channel_create_start agent=%s admin_channel=%s guild_id=%s category_id=%s channel_name=%s visibility=%s",
+            agent_name,
+            context.admin_channel_id,
+            context.discord_guild_id,
+            context.discord_category_id or "-",
+            resolved_name,
+            visibility,
+        )
 
         async def _create() -> CreatedChannel:
             guild = self._client.get_guild(int(context.discord_guild_id))
@@ -234,7 +279,16 @@ class DiscordChannelProvisioner:
             )
 
         future = asyncio.run_coroutine_threadsafe(_create(), context.discord_event_loop)
-        return future.result(timeout=30)
+        created = future.result(timeout=30)
+        LOGGER.info(
+            "provision.discord_channel_create_done agent=%s channel_id=%s channel_name=%s guild_id=%s category_id=%s",
+            agent_name,
+            created.channel_id,
+            created.channel_name,
+            created.guild_id or "-",
+            created.category_id or "-",
+        )
+        return created
 
 
 class ProvisioningCoordinator:
@@ -250,6 +304,23 @@ class ProvisioningCoordinator:
         self._channel_provisioner = channel_provisioner
 
     def provision_agent(self, request: ProvisionRequest, *, context: ProvisionContext) -> CommandResult:
+        LOGGER.info(
+            "provision.start agent=%s platform=%s repo_path=%s channel_id=%s create_repo=%s repo_owner=%s repo_name=%s repo_visibility=%s create_channel=%s channel_name=%s channel_visibility=%s repo_ref=%s adapter=%s admin_channel=%s",
+            request.name,
+            request.platform,
+            request.repo_path or "-",
+            request.channel_id or "-",
+            request.create_repo,
+            request.repo_owner or "-",
+            request.repo_name or "-",
+            request.repo_visibility,
+            request.create_channel,
+            request.channel_name or "-",
+            request.channel_visibility,
+            request.repo_ref,
+            request.agent_adapter or "-",
+            context.admin_channel_id,
+        )
         if not request.repo_path and not request.create_repo:
             return CommandResult(
                 ok=False,
@@ -281,6 +352,12 @@ class ProvisioningCoordinator:
                     visibility=request.repo_visibility,
                 )
                 resolved_repo_path = created_repo.ssh_url or created_repo.clone_url
+                LOGGER.info(
+                    "provision.repo_ready agent=%s repo_path=%s clone_url=%s",
+                    request.name,
+                    resolved_repo_path,
+                    created_repo.clone_url,
+                )
 
             if request.create_channel:
                 if self._channel_provisioner is None:
@@ -292,7 +369,21 @@ class ProvisioningCoordinator:
                     context=context,
                 )
                 resolved_channel_id = created_channel.channel_id
+                LOGGER.info(
+                    "provision.channel_ready agent=%s platform=%s channel_id=%s channel_name=%s",
+                    request.name,
+                    created_channel.platform,
+                    created_channel.channel_id,
+                    created_channel.channel_name,
+                )
         except Exception as exc:  # noqa: BLE001
+            LOGGER.exception(
+                "provision.failed agent=%s platform=%s repo_step=%s channel_step=%s",
+                request.name,
+                request.platform,
+                "done" if created_repo else ("requested" if request.create_repo else "skipped"),
+                "done" if created_channel else ("requested" if request.create_channel else "skipped"),
+            )
             return CommandResult(
                 ok=False,
                 code="ERR_PROVISION_FAILED",
@@ -303,6 +394,15 @@ class ProvisioningCoordinator:
                 },
             )
 
+        LOGGER.info(
+            "provision.load_agent_start agent=%s repo_path=%s channel_id=%s repo_ref=%s platform=%s adapter=%s",
+            request.name,
+            resolved_repo_path or "-",
+            resolved_channel_id or "-",
+            request.repo_ref,
+            request.platform,
+            request.agent_adapter or "-",
+        )
         load_result = self._service.load_agent(
             name=request.name,
             repo_path=resolved_repo_path or "",
@@ -310,6 +410,13 @@ class ProvisioningCoordinator:
             repo_ref=request.repo_ref,
             platform=request.platform,
             agent_adapter=request.agent_adapter,
+        )
+        LOGGER.info(
+            "provision.load_agent_done agent=%s ok=%s code=%s message=%s",
+            request.name,
+            load_result.ok,
+            load_result.code,
+            load_result.message,
         )
         if not load_result.ok:
             data = dict(load_result.data)
@@ -329,6 +436,13 @@ class ProvisioningCoordinator:
             data["created_repo"] = created_repo.__dict__
         if created_channel:
             data["created_channel"] = created_channel.__dict__
+        LOGGER.info(
+            "provision.done agent=%s platform=%s created_repo=%s created_channel=%s",
+            request.name,
+            request.platform,
+            created_repo is not None,
+            created_channel is not None,
+        )
         return CommandResult(
             ok=True,
             code="OK",

--- a/src/master/provisioning.py
+++ b/src/master/provisioning.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .service import CommandResult, MasterService
+
+
+@dataclass(frozen=True)
+class ProvisionRequest:
+    name: str
+    platform: str
+    repo_path: str | None
+    channel_id: str | None
+    repo_ref: str
+    agent_adapter: str | None
+    create_repo: bool
+    repo_owner: str | None
+    repo_name: str | None
+    repo_visibility: str
+    create_channel: bool
+    channel_name: str | None
+    channel_visibility: str
+
+
+@dataclass(frozen=True)
+class ProvisionContext:
+    platform: str
+    admin_channel_id: str
+    discord_guild_id: str | None = None
+    discord_category_id: str | None = None
+    discord_event_loop: asyncio.AbstractEventLoop | None = None
+
+
+@dataclass(frozen=True)
+class CreatedRepo:
+    provider: str
+    owner: str
+    repo_name: str
+    visibility: str
+    html_url: str
+    clone_url: str
+
+
+@dataclass(frozen=True)
+class CreatedChannel:
+    platform: str
+    channel_id: str
+    channel_name: str
+    visibility: str | None = None
+    guild_id: str | None = None
+    category_id: str | None = None
+
+
+class RepoProvisioner(Protocol):
+    def create_repo(
+        self,
+        *,
+        agent_name: str,
+        owner: str | None,
+        repo_name: str | None,
+        visibility: str,
+    ) -> CreatedRepo:
+        ...
+
+
+class ChannelProvisioner(Protocol):
+    def create_channel(
+        self,
+        *,
+        agent_name: str,
+        channel_name: str | None,
+        visibility: str,
+        context: ProvisionContext,
+    ) -> CreatedChannel:
+        ...
+
+
+def normalize_repo_name(name: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "-", name.strip()).strip(".-")
+    return value or "agent-repo"
+
+
+def normalize_channel_name(name: str) -> str:
+    value = re.sub(r"[^a-z0-9-]+", "-", name.strip().lower())
+    value = re.sub(r"-{2,}", "-", value).strip("-")
+    return value or "agent"
+
+
+class GitHubRepoProvisioner:
+    api_base_url = "https://api.github.com"
+
+    def __init__(self, token: str | None = None) -> None:
+        resolved = (token or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN") or "").strip()
+        self._token = resolved
+
+    def create_repo(
+        self,
+        *,
+        agent_name: str,
+        owner: str | None,
+        repo_name: str | None,
+        visibility: str,
+    ) -> CreatedRepo:
+        if not self._token:
+            raise RuntimeError("GitHub repo provisioning requires GH_TOKEN or GITHUB_TOKEN")
+
+        resolved_repo_name = normalize_repo_name(repo_name or agent_name)
+        if visibility not in {"private", "public"}:
+            raise RuntimeError(f"unsupported repo visibility: {visibility}")
+
+        token_owner, token_owner_type = self._fetch_token_identity()
+        resolved_owner = owner or token_owner
+        is_org = token_owner_type.lower() == "organization" or (owner is not None and owner != token_owner)
+        payload = {
+            "name": resolved_repo_name,
+            "private": visibility == "private",
+        }
+        if is_org:
+            response = self._request("POST", f"/orgs/{resolved_owner}/repos", payload)
+        else:
+            response = self._request("POST", "/user/repos", payload)
+
+        return CreatedRepo(
+            provider="github",
+            owner=str(response["owner"]["login"]),
+            repo_name=str(response["name"]),
+            visibility="private" if bool(response.get("private")) else "public",
+            html_url=str(response["html_url"]),
+            clone_url=str(response["clone_url"]),
+        )
+
+    def _fetch_token_identity(self) -> tuple[str, str]:
+        payload = self._request("GET", "/user")
+        return str(payload["login"]), str(payload.get("type") or "User")
+
+    def _request(self, method: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = Request(
+            f"{self.api_base_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "User-Agent": "codex-slack-master",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urlopen(request, timeout=15) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"github api error {exc.code}: {detail}") from exc
+        except URLError as exc:
+            raise RuntimeError(f"github api request failed: {exc}") from exc
+
+        return json.loads(raw) if raw else {}
+
+
+class SlackChannelProvisioner:
+    def __init__(self, client: object) -> None:
+        self._client = client
+
+    def create_channel(
+        self,
+        *,
+        agent_name: str,
+        channel_name: str | None,
+        visibility: str,
+        context: ProvisionContext,
+    ) -> CreatedChannel:
+        if visibility not in {"private", "public"}:
+            raise RuntimeError(f"unsupported slack channel visibility: {visibility}")
+        resolved_name = normalize_channel_name(channel_name or f"agent-{agent_name}")
+        result = self._client.conversations_create(name=resolved_name, is_private=(visibility == "private"))
+        channel = result.get("channel", {})
+        channel_id = str(channel.get("id") or "")
+        if not channel_id:
+            raise RuntimeError("slack channel create returned no channel id")
+        return CreatedChannel(
+            platform="slack",
+            channel_id=channel_id,
+            channel_name=str(channel.get("name") or resolved_name),
+            visibility=visibility,
+        )
+
+
+class DiscordChannelProvisioner:
+    def __init__(self, client: object) -> None:
+        self._client = client
+
+    def create_channel(
+        self,
+        *,
+        agent_name: str,
+        channel_name: str | None,
+        visibility: str,
+        context: ProvisionContext,
+    ) -> CreatedChannel:
+        if context.discord_event_loop is None:
+            raise RuntimeError("discord provisioning requires an event loop")
+        if not context.discord_guild_id:
+            raise RuntimeError("discord provisioning requires a guild id")
+        resolved_name = normalize_channel_name(channel_name or f"agent-{agent_name}")
+
+        async def _create() -> CreatedChannel:
+            guild = self._client.get_guild(int(context.discord_guild_id))
+            if guild is None:
+                guild = await self._client.fetch_guild(int(context.discord_guild_id))
+            category = None
+            if context.discord_category_id:
+                category = self._client.get_channel(int(context.discord_category_id))
+                if category is None:
+                    category = await self._client.fetch_channel(int(context.discord_category_id))
+            created = await guild.create_text_channel(resolved_name, category=category)
+            return CreatedChannel(
+                platform="discord",
+                channel_id=str(created.id),
+                channel_name=str(created.name),
+                visibility=visibility,
+                guild_id=str(guild.id),
+                category_id=str(getattr(category, "id", "") or ""),
+            )
+
+        future = asyncio.run_coroutine_threadsafe(_create(), context.discord_event_loop)
+        return future.result(timeout=30)
+
+
+class ProvisioningCoordinator:
+    def __init__(
+        self,
+        *,
+        service: MasterService,
+        repo_provisioner: RepoProvisioner | None = None,
+        channel_provisioner: ChannelProvisioner | None = None,
+    ) -> None:
+        self._service = service
+        self._repo_provisioner = repo_provisioner
+        self._channel_provisioner = channel_provisioner
+
+    def provision_agent(self, request: ProvisionRequest, *, context: ProvisionContext) -> CommandResult:
+        if not request.repo_path and not request.create_repo:
+            return CommandResult(
+                ok=False,
+                code="ERR_INVALID_ARGS",
+                message="repo_path is required unless --create-repo is set",
+                data={"field": "repo_path"},
+            )
+        if not request.channel_id and not request.create_channel:
+            return CommandResult(
+                ok=False,
+                code="ERR_INVALID_ARGS",
+                message="channel_id is required unless --create-channel is set",
+                data={"field": "channel_id"},
+            )
+
+        created_repo: CreatedRepo | None = None
+        created_channel: CreatedChannel | None = None
+        resolved_repo_path = request.repo_path
+        resolved_channel_id = request.channel_id
+
+        try:
+            if request.create_repo:
+                if self._repo_provisioner is None:
+                    raise RuntimeError("repo provisioner is not configured")
+                created_repo = self._repo_provisioner.create_repo(
+                    agent_name=request.name,
+                    owner=request.repo_owner,
+                    repo_name=request.repo_name,
+                    visibility=request.repo_visibility,
+                )
+                resolved_repo_path = created_repo.clone_url
+
+            if request.create_channel:
+                if self._channel_provisioner is None:
+                    raise RuntimeError("channel provisioner is not configured")
+                created_channel = self._channel_provisioner.create_channel(
+                    agent_name=request.name,
+                    channel_name=request.channel_name,
+                    visibility=request.channel_visibility,
+                    context=context,
+                )
+                resolved_channel_id = created_channel.channel_id
+        except Exception as exc:  # noqa: BLE001
+            return CommandResult(
+                ok=False,
+                code="ERR_PROVISION_FAILED",
+                message=str(exc),
+                data={
+                    "created_repo": created_repo.__dict__ if created_repo else None,
+                    "created_channel": created_channel.__dict__ if created_channel else None,
+                },
+            )
+
+        load_result = self._service.load_agent(
+            name=request.name,
+            repo_path=resolved_repo_path or "",
+            channel_id=resolved_channel_id or "",
+            repo_ref=request.repo_ref,
+            platform=request.platform,
+            agent_adapter=request.agent_adapter,
+        )
+        if not load_result.ok:
+            data = dict(load_result.data)
+            if created_repo:
+                data["created_repo"] = created_repo.__dict__
+            if created_channel:
+                data["created_channel"] = created_channel.__dict__
+            return CommandResult(
+                ok=False,
+                code=load_result.code,
+                message=load_result.message,
+                data=data,
+            )
+
+        data = dict(load_result.data)
+        if created_repo:
+            data["created_repo"] = created_repo.__dict__
+        if created_channel:
+            data["created_channel"] = created_channel.__dict__
+        return CommandResult(
+            ok=True,
+            code="OK",
+            message=f"provisioned {request.name}",
+            data=data,
+        )

--- a/src/master/slack_app.py
+++ b/src/master/slack_app.py
@@ -21,6 +21,7 @@ from .command_format import (
 from .command_runtime import execute_master_command
 from .command_runtime import is_admin_channel
 from .dispatch_guard import in_flight_dispatch, is_shutting_down
+from .provisioning import ProvisionContext, ProvisioningCoordinator, RepoProvisioner, SlackChannelProvisioner
 from .router import ChannelRouter, RouteError, RouteSkip
 from .service import CommandResult, MasterService
 
@@ -63,6 +64,7 @@ def _register_command(
     service: MasterService,
     router: ChannelRouter | None = None,
     rate_limiter: CommandRateLimiter | None = None,
+    provisioning: ProvisioningCoordinator | None = None,
 ) -> None:
     @app.command(command_name)
     def on_command(ack, respond, command: dict) -> None:  # type: ignore[no-untyped-def]
@@ -81,6 +83,8 @@ def _register_command(
             service=service,
             router=router,
             rate_limiter=rate_limiter,
+            provisioning=provisioning,
+            provision_context=ProvisionContext(platform="slack", admin_channel_id=channel_id),
         )
         for message in messages:
             respond(message)
@@ -93,8 +97,16 @@ def create_master_app(
     service: MasterService,
     router: ChannelRouter | None = None,
     rate_limiter: CommandRateLimiter | None = None,
+    repo_provisioner: RepoProvisioner | None = None,
 ) -> App:
     app = App(token=bot_token)
+    provisioning = None
+    if repo_provisioner is not None:
+        provisioning = ProvisioningCoordinator(
+            service=service,
+            repo_provisioner=repo_provisioner,
+            channel_provisioner=SlackChannelProvisioner(app.client),
+        )
     LOGGER.info(
         "master.slack_app_init admin_channels=%s router_enabled=%s rate_limiter_enabled=%s",
         ",".join(sorted(admin_channels)),
@@ -269,6 +281,7 @@ def create_master_app(
     for command_name in (
         "/master-agent-list",
         "/master-agent-load",
+        "/master-agent-provision",
         "/master-agent-start",
         "/master-agent-stop",
         "/master-agent-status",
@@ -285,6 +298,7 @@ def create_master_app(
             service=service,
             router=router,
             rate_limiter=rate_limiter,
+            provisioning=provisioning,
         )
         LOGGER.info("master.command_registered command=%s", command_name)
 

--- a/tests/master/test_command_runtime.py
+++ b/tests/master/test_command_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from src.master.command_runtime import execute_master_command
+from src.master.provisioning import ProvisionContext
 from src.master.service import CommandResult
 from src.master.slack_app import CommandRateLimiter
 
@@ -62,6 +63,23 @@ class FakeRouter:
                 "avg_latency_ms": 123.4,
             }
         ]
+
+
+class FakeProvisioning:
+    def provision_agent(self, request, *, context: ProvisionContext) -> CommandResult:  # type: ignore[no-untyped-def]
+        return CommandResult(
+            ok=True,
+            code="OK",
+            message="provisioned",
+            data={
+                "name": request.name,
+                "platform": request.platform,
+                "repo_path": request.repo_path,
+                "channel_id": request.channel_id,
+                "repo_ref": request.repo_ref,
+                "context_platform": context.platform,
+            },
+        )
 
 
 def test_execute_master_command_rejects_non_admin_channel() -> None:
@@ -145,3 +163,19 @@ def test_execute_master_command_infers_platform_from_frontend_context() -> None:
     )
     assert "platform\": \"discord\"" in messages[0]
     assert "agent_adapter\": \"claude-code\"" in messages[0]
+
+
+def test_execute_master_command_supports_provisioning_flow() -> None:
+    messages = execute_master_command(
+        platform="slack",
+        command_name="/master-agent-provision",
+        text="payments /tmp/repo C123 --branch release/1",
+        channel_id="CADMIN",
+        user_id="U1",
+        admin_channels={"CADMIN"},
+        service=FakeService(),
+        provisioning=FakeProvisioning(),  # type: ignore[arg-type]
+        provision_context=ProvisionContext(platform="slack", admin_channel_id="CADMIN"),
+    )
+    assert "provisioned" in messages[0]
+    assert "release/1" in messages[0]

--- a/tests/master/test_provisioning.py
+++ b/tests/master/test_provisioning.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from src.master.command_dispatch import parse_provision_text
+from src.master.provisioning import (
+    CreatedChannel,
+    CreatedRepo,
+    ProvisionContext,
+    ProvisionRequest,
+    ProvisioningCoordinator,
+    SlackChannelProvisioner,
+)
+from src.master.service import CommandResult
+
+
+class FakeService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def load_agent(
+        self,
+        *,
+        name: str,
+        repo_path: str,
+        channel_id: str,
+        repo_ref: str = "main",
+        platform: str = "slack",
+        agent_adapter: str | None = None,
+    ) -> CommandResult:
+        self.calls.append(
+            {
+                "name": name,
+                "repo_path": repo_path,
+                "channel_id": channel_id,
+                "repo_ref": repo_ref,
+                "platform": platform,
+                "agent_adapter": agent_adapter,
+            }
+        )
+        return CommandResult(
+            ok=True,
+            code="OK",
+            message="loaded",
+            data={"name": name, "repo_path": repo_path, "channel_id": channel_id, "platform": platform},
+        )
+
+
+class FakeRepoProvisioner:
+    def create_repo(
+        self,
+        *,
+        agent_name: str,
+        owner: str | None,
+        repo_name: str | None,
+        visibility: str,
+    ) -> CreatedRepo:
+        return CreatedRepo(
+            provider="github",
+            owner=owner or "token-owner",
+            repo_name=repo_name or agent_name,
+            visibility=visibility,
+            html_url=f"https://github.com/{owner or 'token-owner'}/{repo_name or agent_name}",
+            clone_url=f"https://github.com/{owner or 'token-owner'}/{repo_name or agent_name}.git",
+        )
+
+
+class FakeChannelProvisioner:
+    def create_channel(
+        self,
+        *,
+        agent_name: str,
+        channel_name: str | None,
+        visibility: str,
+        context: ProvisionContext,
+    ) -> CreatedChannel:
+        return CreatedChannel(
+            platform=context.platform,
+            channel_id="C999" if context.platform == "slack" else "123456789012345678",
+            channel_name=channel_name or f"agent-{agent_name}",
+            visibility=visibility,
+            guild_id=context.discord_guild_id,
+            category_id=context.discord_category_id,
+        )
+
+
+def test_parse_provision_text_accepts_existing_resources() -> None:
+    parsed = parse_provision_text("payments /tmp/repo C123")
+    assert parsed == ProvisionRequest(
+        name="payments",
+        platform="slack",
+        repo_path="/tmp/repo",
+        channel_id="C123",
+        repo_ref="main",
+        agent_adapter=None,
+        create_repo=False,
+        repo_owner=None,
+        repo_name=None,
+        repo_visibility="private",
+        create_channel=False,
+        channel_name=None,
+        channel_visibility="private",
+    )
+
+
+def test_parse_provision_text_accepts_create_flags() -> None:
+    parsed = parse_provision_text(
+        'payments --branch main --create-repo --repo-owner pandazxx --repo-name pay-api --repo-visibility public '
+        '--create-channel --channel-name "agent-payments" --channel-visibility public --adapter claude-code'
+    )
+    assert parsed.name == "payments"
+    assert parsed.repo_path is None
+    assert parsed.repo_ref == "main"
+    assert parsed.create_repo is True
+    assert parsed.repo_owner == "pandazxx"
+    assert parsed.repo_name == "pay-api"
+    assert parsed.repo_visibility == "public"
+    assert parsed.create_channel is True
+    assert parsed.channel_name == "agent-payments"
+    assert parsed.channel_visibility == "public"
+    assert parsed.agent_adapter == "claude-code"
+
+
+def test_provisioning_coordinator_creates_repo_and_channel_before_load() -> None:
+    service = FakeService()
+    coordinator = ProvisioningCoordinator(
+        service=service,  # type: ignore[arg-type]
+        repo_provisioner=FakeRepoProvisioner(),
+        channel_provisioner=FakeChannelProvisioner(),
+    )
+
+    result = coordinator.provision_agent(
+        ProvisionRequest(
+            name="payments",
+            platform="slack",
+            repo_path=None,
+            channel_id=None,
+            repo_ref="main",
+            agent_adapter="codex",
+            create_repo=True,
+            repo_owner=None,
+            repo_name=None,
+            repo_visibility="private",
+            create_channel=True,
+            channel_name=None,
+            channel_visibility="private",
+        ),
+        context=ProvisionContext(platform="slack", admin_channel_id="CADMIN"),
+    )
+
+    assert result.ok is True
+    assert service.calls == [
+        {
+            "name": "payments",
+            "repo_path": "https://github.com/token-owner/payments.git",
+            "channel_id": "C999",
+            "repo_ref": "main",
+            "platform": "slack",
+            "agent_adapter": "codex",
+        }
+    ]
+    assert result.data["created_repo"]["owner"] == "token-owner"
+    assert result.data["created_channel"]["channel_id"] == "C999"
+
+
+def test_provisioning_coordinator_requires_repo_or_create_repo() -> None:
+    coordinator = ProvisioningCoordinator(service=FakeService())  # type: ignore[arg-type]
+    result = coordinator.provision_agent(
+        ProvisionRequest(
+            name="payments",
+            platform="slack",
+            repo_path=None,
+            channel_id="C123",
+            repo_ref="main",
+            agent_adapter=None,
+            create_repo=False,
+            repo_owner=None,
+            repo_name=None,
+            repo_visibility="private",
+            create_channel=False,
+            channel_name=None,
+            channel_visibility="private",
+        ),
+        context=ProvisionContext(platform="slack", admin_channel_id="CADMIN"),
+    )
+    assert result.ok is False
+    assert result.code == "ERR_INVALID_ARGS"
+
+
+def test_slack_channel_provisioner_creates_private_channel() -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeClient:
+        def conversations_create(self, *, name: str, is_private: bool) -> dict[str, object]:
+            calls.append({"name": name, "is_private": is_private})
+            return {"channel": {"id": "C777", "name": name}}
+
+    provisioner = SlackChannelProvisioner(FakeClient())
+    created = provisioner.create_channel(
+        agent_name="payments-api",
+        channel_name=None,
+        visibility="private",
+        context=ProvisionContext(platform="slack", admin_channel_id="CADMIN"),
+    )
+
+    assert calls == [{"name": "agent-payments-api", "is_private": True}]
+    assert created.channel_id == "C777"
+    assert created.channel_name == "agent-payments-api"

--- a/tests/master/test_provisioning.py
+++ b/tests/master/test_provisioning.py
@@ -60,6 +60,7 @@ class FakeRepoProvisioner:
             visibility=visibility,
             html_url=f"https://github.com/{owner or 'token-owner'}/{repo_name or agent_name}",
             clone_url=f"https://github.com/{owner or 'token-owner'}/{repo_name or agent_name}.git",
+            ssh_url=f"git@github.com:{owner or 'token-owner'}/{repo_name or agent_name}.git",
         )
 
 
@@ -150,7 +151,7 @@ def test_provisioning_coordinator_creates_repo_and_channel_before_load() -> None
     assert service.calls == [
         {
             "name": "payments",
-            "repo_path": "https://github.com/token-owner/payments.git",
+            "repo_path": "git@github.com:token-owner/payments.git",
             "channel_id": "C999",
             "repo_ref": "main",
             "platform": "slack",
@@ -158,6 +159,7 @@ def test_provisioning_coordinator_creates_repo_and_channel_before_load() -> None
         }
     ]
     assert result.data["created_repo"]["owner"] == "token-owner"
+    assert result.data["created_repo"]["ssh_url"] == "git@github.com:token-owner/payments.git"
     assert result.data["created_channel"]["channel_id"] == "C999"
 
 

--- a/tests/master/test_provisioning.py
+++ b/tests/master/test_provisioning.py
@@ -58,6 +58,7 @@ class FakeRepoProvisioner:
             owner=owner or "token-owner",
             repo_name=repo_name or agent_name,
             visibility=visibility,
+            default_branch="main",
             html_url=f"https://github.com/{owner or 'token-owner'}/{repo_name or agent_name}",
             clone_url=f"https://github.com/{owner or 'token-owner'}/{repo_name or agent_name}.git",
             ssh_url=f"git@github.com:{owner or 'token-owner'}/{repo_name or agent_name}.git",
@@ -161,6 +162,64 @@ def test_provisioning_coordinator_creates_repo_and_channel_before_load() -> None
     assert result.data["created_repo"]["owner"] == "token-owner"
     assert result.data["created_repo"]["ssh_url"] == "git@github.com:token-owner/payments.git"
     assert result.data["created_channel"]["channel_id"] == "C999"
+
+
+def test_provisioning_coordinator_uses_created_repo_default_branch() -> None:
+    service = FakeService()
+
+    class TrunkRepoProvisioner(FakeRepoProvisioner):
+        def create_repo(
+            self,
+            *,
+            agent_name: str,
+            owner: str | None,
+            repo_name: str | None,
+            visibility: str,
+        ) -> CreatedRepo:
+            created = super().create_repo(
+                agent_name=agent_name,
+                owner=owner,
+                repo_name=repo_name,
+                visibility=visibility,
+            )
+            return CreatedRepo(
+                provider=created.provider,
+                owner=created.owner,
+                repo_name=created.repo_name,
+                visibility=created.visibility,
+                default_branch="trunk",
+                html_url=created.html_url,
+                clone_url=created.clone_url,
+                ssh_url=created.ssh_url,
+            )
+
+    coordinator = ProvisioningCoordinator(
+        service=service,  # type: ignore[arg-type]
+        repo_provisioner=TrunkRepoProvisioner(),
+        channel_provisioner=FakeChannelProvisioner(),
+    )
+
+    result = coordinator.provision_agent(
+        ProvisionRequest(
+            name="payments",
+            platform="slack",
+            repo_path=None,
+            channel_id=None,
+            repo_ref="main",
+            agent_adapter="codex",
+            create_repo=True,
+            repo_owner=None,
+            repo_name=None,
+            repo_visibility="private",
+            create_channel=True,
+            channel_name=None,
+            channel_visibility="private",
+        ),
+        context=ProvisionContext(platform="slack", admin_channel_id="CADMIN"),
+    )
+
+    assert result.ok is True
+    assert service.calls[0]["repo_ref"] == "trunk"
 
 
 def test_provisioning_coordinator_requires_repo_or_create_repo() -> None:

--- a/tests/master/test_provisioning.py
+++ b/tests/master/test_provisioning.py
@@ -103,6 +103,22 @@ def test_parse_provision_text_accepts_existing_resources() -> None:
     )
 
 
+def test_parse_provision_text_defaults_to_creating_missing_repo_and_channel() -> None:
+    parsed = parse_provision_text("payments")
+    assert parsed.repo_path is None
+    assert parsed.channel_id is None
+    assert parsed.create_repo is True
+    assert parsed.create_channel is True
+
+
+def test_parse_provision_text_defaults_to_creating_only_missing_resource() -> None:
+    parsed = parse_provision_text("payments /tmp/repo")
+    assert parsed.repo_path == "/tmp/repo"
+    assert parsed.channel_id is None
+    assert parsed.create_repo is False
+    assert parsed.create_channel is True
+
+
 def test_parse_provision_text_accepts_create_flags() -> None:
     parsed = parse_provision_text(
         'payments --branch main --create-repo --repo-owner pandazxx --repo-name pay-api --repo-visibility public '


### PR DESCRIPTION
## Summary
- add `/master-agent-provision` with GitHub repo creation and Slack/Discord channel creation orchestration
- default provisioning to create missing repo/channel resources, initialize provisioned GitHub repos, and use SSH clone URLs
- add provisioning diagnostics plus Discord permission/setup guidance, ADRs, detailed designs, and base-agent image workflow/docs updates

## Why
Issue #37 needs an operator-friendly provisioning path instead of requiring an existing repo and mapped channel up front.

Issue #38 needs the minimal agent image contract, publication workflow, and project-extension guidance to be explicit and testable.

## What Changed
- new provisioning core in `src/master/provisioning.py`
- new `/master-agent-provision` command parsing and dispatch wiring
- Slack and Discord frontend integration for provisioning
- GitHub repo auto-creation now initializes the repo and uses SSH URLs for the bound repo source
- provisioning defaults now infer `create_repo=true` / `create_channel=true` when repo/channel are omitted
- publish workflow for `Dockerfile.agent-minimal` now smoke-tests the image before push
- docs updated for ADRs, detailed design, Discord channel-creation setup, runtime/base-image contract, FAQ, and UAT notes

## Test Evidence
- `./.venv/bin/python -m pytest -q tests/master/test_provisioning.py tests/master/test_command_runtime.py tests/master/test_slack_app.py tests/master/test_discord_app.py tests/master/test_master_service.py`
  - `75 passed, 0 failed`
- `./.venv/bin/python -m pytest -q tests/master/test_provisioning.py tests/master/test_command_runtime.py tests/master/test_master_service.py`
  - `39 passed, 0 failed`
- `./.venv/bin/python -m pytest -q tests/master/test_provisioning.py tests/master/test_command_runtime.py`
  - `14 passed, 0 failed`
- `python -m py_compile src/master/provisioning.py src/master/command_dispatch.py src/master/command_runtime.py src/master/slack_app.py src/master/discord_app.py src/master/main.py`

## Manual Notes
- Discord provisioning creates the new channel in the same guild/category as the invoking admin channel.
- The bot must have `Manage Channels` in that category or Discord will return `50013 Missing Permissions`.
- Current release candidate tags on this branch include `v3.7-rc1` through `v3.7-rc5`.
