### PR TITLE
fix: pull newer base layers for project images

### DIFF
--- a/src/master/runtime_adapter.py
+++ b/src/master/runtime_adapter.py
@@ -90,6 +90,7 @@ class PodmanRuntimeAdapter:
             [
                 "podman",
                 "build",
+                "--pull=newer",
                 "-t",
                 image_tag,
                 "-f",

--- a/tests/master/test_runtime_adapter.py
+++ b/tests/master/test_runtime_adapter.py
@@ -94,6 +94,41 @@ def test_create_or_update_agent_adds_extra_mounts(monkeypatch) -> None:  # type:
     ]
 
 
+def test_build_image_pulls_newer_base_layers(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    adapter = PodmanRuntimeAdapter()
+    seen: list[list[str]] = []
+    repo = tmp_path / "repo"
+    image_dir = repo / ".prj_assistant" / "image"
+    image_dir.mkdir(parents=True)
+    dockerfile = image_dir / "Dockerfile"
+    dockerfile.write_text("FROM ghcr.io/pandazxx/codex-slack-agent-minimal:latest\n", encoding="utf-8")
+
+    def fake_run(cmd: list[str], cwd: str | None = None, check: bool = True):  # type: ignore[no-untyped-def]
+        seen.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(adapter, "_run", fake_run)
+
+    image = adapter.build_image(
+        name="payments-api",
+        repo_path=str(repo),
+        context_rel=".prj_assistant/image",
+        dockerfile_rel=".prj_assistant/image/Dockerfile",
+    )
+
+    assert image == "codex-agent-payments-api:latest"
+    assert seen == [[
+        "podman",
+        "build",
+        "--pull=newer",
+        "-t",
+        "codex-agent-payments-api:latest",
+        "-f",
+        str(dockerfile),
+        str(image_dir),
+    ]]
+
+
 def test_refresh_agent_auth_replaces_auth_file_without_deleting_codex_home(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     adapter = PodmanRuntimeAdapter()
     seen: list[list[str]] = []


### PR DESCRIPTION
## Summary
- add `--pull=newer` to the master-side `podman build` path for project-specific agent images
- prevent repo-local `.prj_assistant/image/Dockerfile` builds from silently reusing stale cached copies of `ghcr.io/pandazxx/codex-slack-agent-minimal:<tag>`
- add runtime-adapter test coverage for the exact build command arguments

Closes #42.

## Why
Project-specific agent image builds could succeed while still using an older cached base image layer set from the host, which can leave missing binaries such as `claude` in the final image even after the upstream base image was fixed.

## What Changed
- `src/master/runtime_adapter.py`
  - `podman build` now uses `--pull=newer`
- `tests/master/test_runtime_adapter.py`
  - added a direct assertion that the build command includes `--pull=newer`

## Test Evidence
- `./.venv/bin/python -m pytest -q tests/master/test_runtime_adapter.py tests/master/test_master_service.py tests/master/test_command_runtime.py`
  - `39 passed, 0 failed`
- `python -m py_compile src/master/runtime_adapter.py`

## Manual Verification Notes
A repo-local Dockerfile that starts from `ghcr.io/pandazxx/codex-slack-agent-minimal:<tag>` will now refresh newer base layers during `/master-agent-start` instead of relying entirely on host cache state.
