### PR TITLE
fix: revert mistaken direct master commit

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,9 +19,9 @@ mkdir -p "${CODEX_HOME_PATH}"
 # Copy global codex config into CODEX_HOME so codex has a writable user-scope config dir.
 # Prefer the host-mounted path, fall back to the baked-in image path.
 if [[ -d "/run/secrets/master_codex_config" ]]; then
-  cp -af /run/secrets/master_codex_config/. "${CODEX_HOME_PATH}/"
+  cp -an /run/secrets/master_codex_config/. "${CODEX_HOME_PATH}/"
 elif [[ -d "/opt/codex-slack/config/codex-global" ]]; then
-  cp -af /opt/codex-slack/config/codex-global/. "${CODEX_HOME_PATH}/"
+  cp -an /opt/codex-slack/config/codex-global/. "${CODEX_HOME_PATH}/"
 fi
 
 if [[ -f "/run/secrets/codex_auth.json" && ! -f "${CODEX_HOME_PATH}/auth.json" ]]; then
@@ -44,10 +44,10 @@ fi
 CLAUDE_HOME="${HOME:-/workspace/home}/.claude"
 if [[ -d "/run/secrets/master_claude_config" ]]; then
   mkdir -p "${CLAUDE_HOME}"
-  cp -af /run/secrets/master_claude_config/. "${CLAUDE_HOME}/"
+  cp -a /run/secrets/master_claude_config/. "${CLAUDE_HOME}/"
 elif [[ -d "/opt/codex-slack/config/claude-global" ]]; then
   mkdir -p "${CLAUDE_HOME}"
-  cp -af /opt/codex-slack/config/claude-global/. "${CLAUDE_HOME}/"
+  cp -a /opt/codex-slack/config/claude-global/. "${CLAUDE_HOME}/"
 fi
 
 if [[ -n "${GIT_USER_NAME:-}" ]]; then

--- a/src/agent/worker.py
+++ b/src/agent/worker.py
@@ -161,7 +161,7 @@ def stage_workspace_prepare(settings: WorkerSettings) -> None:
     )
 
     if global_codex_config_raw:
-        _copy_tree(global_codex_config_path, codex_home, overwrite=True)
+        _copy_tree(global_codex_config_path, codex_home, overwrite=False)
         LOGGER.info(
             "agent.workspace_prepare_copied target=%s source=%s target_entries=%d",
             codex_home,
@@ -172,7 +172,7 @@ def stage_workspace_prepare(settings: WorkerSettings) -> None:
     # Codex reads it as project-scope config from the working directory, which takes
     # precedence over user-scope settings in CODEX_HOME per the Codex scope hierarchy.
     if global_claude_config_raw:
-        _copy_tree(global_claude_config_path, home_claude_dir, overwrite=True)
+        _copy_tree(global_claude_config_path, home_claude_dir, overwrite=False)
         LOGGER.info(
             "agent.workspace_prepare_copied target=%s source=%s target_entries=%d",
             home_claude_dir,

--- a/tests/agent/test_worker.py
+++ b/tests/agent/test_worker.py
@@ -254,37 +254,6 @@ def test_stage_workspace_prepare_leaves_repo_codex_as_project_scope(tmp_path, mo
     assert (repo_path / ".codex" / "config.toml").read_text(encoding="utf-8") == "source = 'repo'\n"
 
 
-def test_stage_workspace_prepare_overwrites_stale_global_codex_files(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_codex = tmp_path / "global-codex"
-    global_codex.mkdir()
-    (global_codex / "instructions.md").write_text("new instructions\n", encoding="utf-8")
-    (global_codex / "config.toml").write_text("source = 'new'\n", encoding="utf-8")
-    monkeypatch.setenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", str(global_codex))
-
-    codex_home = tmp_path / "codex-home"
-    codex_home.mkdir()
-    (codex_home / "instructions.md").write_text("old instructions\n", encoding="utf-8")
-    (codex_home / "config.toml").write_text("source = 'old'\n", encoding="utf-8")
-    (codex_home / "auth.json").write_text('{"token":"keep"}\n', encoding="utf-8")
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(codex_home),
-        ready_poll_seconds=0.1,
-    )
-
-    stage_workspace_prepare(settings)
-
-    assert (codex_home / "instructions.md").read_text(encoding="utf-8") == "new instructions\n"
-    assert (codex_home / "config.toml").read_text(encoding="utf-8") == "source = 'new'\n"
-    assert (codex_home / "auth.json").read_text(encoding="utf-8") == '{"token":"keep"}\n'
-
-
 def test_stage_workspace_prepare_leaves_repo_claude_as_project_scope(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """Repo .claude/ is NOT copied to ~/.claude/; Claude Code reads it as project-scope config
     from the working directory, which takes precedence over user-scope settings in ~/.claude/."""
@@ -340,40 +309,6 @@ def test_stage_workspace_prepare_applies_global_claude_config_to_home(tmp_path, 
     stage_workspace_prepare(settings)
 
     assert (home_dir / ".claude" / "settings.json").read_text(encoding="utf-8") == '{"theme":"global"}\n'
-
-
-def test_stage_workspace_prepare_overwrites_stale_global_claude_files(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_claude = tmp_path / "global-claude"
-    global_claude.mkdir()
-    (global_claude / "settings.json").write_text('{"theme":"new"}\n', encoding="utf-8")
-    (global_claude / "CLAUDE.md").write_text("# New global instructions\n", encoding="utf-8")
-
-    home_dir = tmp_path / "home"
-    home_claude = home_dir / ".claude"
-    home_claude.mkdir(parents=True)
-    (home_claude / "settings.json").write_text('{"theme":"old"}\n', encoding="utf-8")
-    (home_claude / "CLAUDE.md").write_text("# Old global instructions\n", encoding="utf-8")
-    (home_claude / "sessions.json").write_text('{"keep":true}\n', encoding="utf-8")
-
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.setenv("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", str(global_claude))
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(tmp_path / "codex"),
-        ready_poll_seconds=0.1,
-    )
-
-    stage_workspace_prepare(settings)
-
-    assert (home_claude / "settings.json").read_text(encoding="utf-8") == '{"theme":"new"}\n'
-    assert (home_claude / "CLAUDE.md").read_text(encoding="utf-8") == "# New global instructions\n"
-    assert (home_claude / "sessions.json").read_text(encoding="utf-8") == '{"keep":true}\n'
 
 
 def test_load_worker_settings_uses_writable_default_status_path(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_image_contract.py
+++ b/tests/test_image_contract.py
@@ -14,5 +14,3 @@ def test_entrypoint_has_baked_in_codex_and_claude_global_fallbacks() -> None:
     assert "/opt/codex-slack/config/codex-global" in entrypoint
     assert "/run/secrets/master_claude_config" in entrypoint
     assert "/opt/codex-slack/config/claude-global" in entrypoint
-    assert 'cp -af /run/secrets/master_codex_config/. "${CODEX_HOME_PATH}/"' in entrypoint
-    assert 'cp -af /opt/codex-slack/config/codex-global/. "${CODEX_HOME_PATH}/"' in entrypoint


### PR DESCRIPTION
## Summary
- revert commit `5faaea7` from `master`
- restore the pre-change startup config refresh behavior on `master`
- keep the intended fix isolated on `feat/message-split-hint`

## Why
A config refresh fix was accidentally committed directly to `master`, which violates the repository workflow. This PR rolls that change back from `master` so the fix can continue through the normal branch/PR path.

## Reverted Commit
- `5faaea7` `fix: refresh global agent config on startup`

## Notes
- The same fix has already been moved onto `feat/message-split-hint` as commit `bbe3e08`.
- This rollback PR is only for cleaning `master` through the normal review process.