### PR TITLE
docs: add container design references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ pip install -r requirements.txt
 pytest -q                  # run full test suite
 ```
 
-For containerised development, start with `docs/manuals/ops-manual.md` and `docs/guides/container-runtime.md`.
+For containerised development, start with [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md) and [`docs/guides/container-runtime.md`](docs/guides/container-runtime.md).
 
 ## Coding Style & Naming Conventions
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -4,10 +4,10 @@ This file is a compatibility entry point.
 
 The canonical setup and operations documentation now lives under `docs/`:
 
-- `docs/manuals/ops-manual.md`
-- `docs/guides/slack-setup.md`
-- `docs/guides/discord-setup.md`
-- `docs/guides/container-runtime.md`
-- `docs/guides/runbooks/master-agent.md`
+- [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md)
+- [`docs/guides/slack-setup.md`](docs/guides/slack-setup.md)
+- [`docs/guides/discord-setup.md`](docs/guides/discord-setup.md)
+- [`docs/guides/container-runtime.md`](docs/guides/container-runtime.md)
+- [`docs/guides/runbooks/master-agent.md`](docs/guides/runbooks/master-agent.md)
 
-Start with `docs/manuals/ops-manual.md` for the current setup path.
+Start with [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md) for the current setup path.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export UID="$(id -u)" GID="$(id -g)"
 podman compose -f docker-compose.yml -f docker-compose.podman.yml up --build -d
 ```
 
-Full setup and runtime guides live under `docs/`; use `docs/manuals/ops-manual.md` as the primary entry point.
+Full setup and runtime guides live under `docs/`; use [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md) as the primary entry point.
 For Codex contributors, repository workflow instructions live in `AGENTS.md` and repo-local skills live under `.agents/skills/`.
 
 ## Project structure
@@ -86,14 +86,14 @@ For Codex contributors, repository workflow instructions live in `AGENTS.md` and
 
 ## Further reading
 
-- `docs/README.md` — documentation map and category index
-- `docs/manuals/ops-manual.md` — setup, deployment, and operations entry point
-- `docs/manuals/user-manual.md` — day-to-day usage entry point
-- `docs/guides/slack-setup.md` — detailed Slack app configuration
-- `docs/guides/discord-setup.md` — Discord app setup for master mode
-- `docs/guides/container-runtime.md` — container runtime, Podman socket, and mounts
-- `docs/guides/runbooks/master-agent.md` — master-agent operational runbook
-- `docs/guides/runbooks/cd-daemon.md` — CD daemon operational runbook
-- `docs/guides/tutorials.md` — step-by-step tutorials and checklists
-- `docs/references/api.md` — implemented command surface
-- `docs/references/config.md` — configuration keys and defaults
+- [`docs/README.md`](docs/README.md) — documentation map and category index
+- [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md) — setup, deployment, and operations entry point
+- [`docs/manuals/user-manual.md`](docs/manuals/user-manual.md) — day-to-day usage entry point
+- [`docs/guides/slack-setup.md`](docs/guides/slack-setup.md) — detailed Slack app configuration
+- [`docs/guides/discord-setup.md`](docs/guides/discord-setup.md) — Discord app setup for master mode
+- [`docs/guides/container-runtime.md`](docs/guides/container-runtime.md) — container runtime, Podman socket, and mounts
+- [`docs/guides/runbooks/master-agent.md`](docs/guides/runbooks/master-agent.md) — master-agent operational runbook
+- [`docs/guides/runbooks/cd-daemon.md`](docs/guides/runbooks/cd-daemon.md) — CD daemon operational runbook
+- [`docs/guides/tutorials.md`](docs/guides/tutorials.md) — step-by-step tutorials and checklists
+- [`docs/references/api.md`](docs/references/api.md) — implemented command surface
+- [`docs/references/config.md`](docs/references/config.md) — configuration keys and defaults

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,9 +4,9 @@ This file is a compatibility entry point.
 
 The canonical day-to-day usage documentation now lives under `docs/`:
 
-- `docs/manuals/user-manual.md`
-- `docs/guides/tutorials.md`
-- `docs/references/api.md`
-- `docs/references/logging.md`
+- [`docs/manuals/user-manual.md`](docs/manuals/user-manual.md)
+- [`docs/guides/tutorials.md`](docs/guides/tutorials.md)
+- [`docs/references/api.md`](docs/references/api.md)
+- [`docs/references/logging.md`](docs/references/logging.md)
 
-Start with `docs/manuals/user-manual.md` for the current usage path.
+Start with [`docs/manuals/user-manual.md`](docs/manuals/user-manual.md) for the current usage path.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,64 +4,64 @@ This directory is the canonical home for repository documentation.
 
 ## Manuals
 
-- `docs/manuals/user-manual.md` — end-user and day-to-day operator walkthrough
-- `docs/manuals/ops-manual.md` — setup, deployment, runtime, and recovery entrypoint
+- [`docs/manuals/user-manual.md`](docs/manuals/user-manual.md) — end-user and day-to-day operator walkthrough
+- [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md) — setup, deployment, runtime, and recovery entrypoint
 
 ## Guides
 
-- `docs/guides/onboarding.md` — contributor onboarding
-- `docs/guides/container-runtime.md` — container runtime behavior and mounts
-- `docs/guides/slack-setup.md` — Slack application setup
-- `docs/guides/discord-setup.md` — Discord application setup
-- `docs/guides/project-agent-image.md` — standalone guide for project-specific agent images
-- `docs/guides/multi-agent-setup.md` — historical pre-master multi-agent setup
-- `docs/guides/tutorials.md` — tutorials and guided examples
-- `docs/guides/runbooks/master-agent.md` — master-agent operational runbook
-- `docs/guides/runbooks/cd-daemon.md` — CD daemon operational runbook
+- [`docs/guides/onboarding.md`](guides/onboarding.md) — contributor onboarding
+- [`docs/guides/container-runtime.md`](guides/container-runtime.md) — container runtime behavior and mounts
+- [`docs/guides/slack-setup.md`](guides/slack-setup.md) — Slack application setup
+- [`docs/guides/discord-setup.md`](guides/discord-setup.md) — Discord application setup
+- [`docs/guides/project-agent-image.md`](guides/project-agent-image.md) — standalone guide for project-specific agent images
+- [`docs/guides/multi-agent-setup.md`](guides/multi-agent-setup.md) — historical pre-master multi-agent setup
+- [`docs/guides/tutorials.md`](guides/tutorials.md) — tutorials and guided examples
+- [`docs/guides/runbooks/master-agent.md`](guides/runbooks/master-agent.md) — master-agent operational runbook
+- [`docs/guides/runbooks/cd-daemon.md`](guides/runbooks/cd-daemon.md) — CD daemon operational runbook
 
 ## References
 
-- `docs/references/api.md` — implemented command surfaces and interaction contracts
-- `docs/references/config.md` — configuration keys and defaults
-- `docs/references/logging.md` — logging behavior and verbosity controls
-- `docs/references/schemas/README.md` — placeholder for future schema docs
+- [`docs/references/api.md`](references/api.md) — implemented command surfaces and interaction contracts
+- [`docs/references/config.md`](references/config.md) — configuration keys and defaults
+- [`docs/references/logging.md`](references/logging.md) — logging behavior and verbosity controls
+- [`docs/references/schemas/README.md`](references/schemas/README.md) — placeholder for future schema docs
 
 ## Knowledge Base
 
-- `docs/knowledge-base/faq.md` — frequently asked questions
-- `docs/knowledge-base/lessons-learned.md` — append-only lessons learned
+- [`docs/knowledge-base/faq.md`](knowledge-base/faq.md) — frequently asked questions
+- [`docs/knowledge-base/lessons-learned.md`](knowledge-base/lessons-learned.md) — append-only lessons learned
 
 ## Design
 
-- `docs/design/containers/master-container-design.md` — master container startup, interfaces, lifecycle, and storage
-- `docs/design/containers/agent-container-design.md` — agent container entrypoint, worker lifecycle, and runtime contract
-- `docs/design/containers/cd-container-design.md` — CD daemon container startup, deploy loop, rollback, and state
-- `docs/design/containers/environment-variable-passdown-design.md` — environment variable loading, normalization, and passdown across CD, master, and agent
-- `docs/design/agent-container-runtime-design.md` — canonical runtime contract for agent containers
-- `docs/design/agent-provisioning-detailed-design.md` — detailed design for agent/channel/repo provisioning
-- `docs/design/master-agent-interface-design.md` — canonical interface between master and agent containers
-- `docs/design/frontend-master-interface-design.md` — canonical interface between Slack/Discord and master
-- `docs/design/master-agent-architecture.md` — architecture background and constraints
-- `docs/design/master-agent-implementation-plan.md` — phased implementation plan
-- `docs/design/message-split-hint-detailed-design.md` — detailed design for agent-authored message split hints
-- `docs/design/separate-base-agent-image-detailed-design.md` — detailed design for publishing and consuming the base agent image
-- `docs/design/v3-0-multi-adapter-frontend-plan.md` — v3.0 adapter/frontend design plan
+- [`docs/design/containers/master-container-design.md`](design/containers/master-container-design.md) — master container startup, interfaces, lifecycle, and storage
+- [`docs/design/containers/agent-container-design.md`](design/containers/agent-container-design.md) — agent container entrypoint, worker lifecycle, and runtime contract
+- [`docs/design/containers/cd-container-design.md`](design/containers/cd-container-design.md) — CD daemon container startup, deploy loop, rollback, and state
+- [`docs/design/containers/environment-variable-passdown-design.md`](design/containers/environment-variable-passdown-design.md) — environment variable loading, normalization, and passdown across CD, master, and agent
+- [`docs/design/agent-container-runtime-design.md`](design/agent-container-runtime-design.md) — canonical runtime contract for agent containers
+- [`docs/design/agent-provisioning-detailed-design.md`](design/agent-provisioning-detailed-design.md) — detailed design for agent/channel/repo provisioning
+- [`docs/design/master-agent-interface-design.md`](design/master-agent-interface-design.md) — canonical interface between master and agent containers
+- [`docs/design/frontend-master-interface-design.md`](design/frontend-master-interface-design.md) — canonical interface between Slack/Discord and master
+- [`docs/design/master-agent-architecture.md`](design/master-agent-architecture.md) — architecture background and constraints
+- [`docs/design/master-agent-implementation-plan.md`](design/master-agent-implementation-plan.md) — phased implementation plan
+- [`docs/design/message-split-hint-detailed-design.md`](design/message-split-hint-detailed-design.md) — detailed design for agent-authored message split hints
+- [`docs/design/separate-base-agent-image-detailed-design.md`](design/separate-base-agent-image-detailed-design.md) — detailed design for publishing and consuming the base agent image
+- [`docs/design/v3-0-multi-adapter-frontend-plan.md`](design/v3-0-multi-adapter-frontend-plan.md) — v3.0 adapter/frontend design plan
 
 ## Decisions
 
-- `docs/decisions/README.md` — ADR directory conventions
+- [`docs/decisions/README.md`](decisions/README.md) — ADR directory conventions
 
 ## Test Plans
 
-- `docs/test-plans/master-agent-uat.md` — current master-agent UAT checklist
+- [`docs/test-plans/master-agent-uat.md`](test-plans/master-agent-uat.md) — current master-agent UAT checklist
 
 ## Releases
 
-- `docs/releases/v3.2.md`
-- `docs/releases/v3.3.md`
+- [`docs/releases/v3.2.md`](releases/v3.2.md)
+- [`docs/releases/v3.3.md`](releases/v3.3.md)
 
 ## Compatibility Entry Points
 
-- `README.md` — project overview and top-level navigation
-- `BUILD.md` — short pointer to the ops manual and setup guides
-- `USAGE.md` — short pointer to the user manual and tutorials
+- [`README.md`](../README.md) — project overview and top-level navigation
+- [`BUILD.md`](../BUILD.md) — short pointer to the ops manual and setup guides
+- [`USAGE.md`](../USAGE.md) — short pointer to the user manual and tutorials

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ This directory is the canonical home for repository documentation.
 - [`docs/design/master-agent-interface-design.md`](design/master-agent-interface-design.md) — canonical interface between master and agent containers
 - [`docs/design/frontend-master-interface-design.md`](design/frontend-master-interface-design.md) — canonical interface between Slack/Discord and master
 - [`docs/design/master-agent-architecture.md`](design/master-agent-architecture.md) — architecture background and constraints
-- [`docs/design/master-agent-implementation-plan.md`](design/master-agent-implementation-plan.md) — phased implementation plan
+- [`docs/design/master-agent-implementation-plan.md`](design/master-agent-implementation-plan.md) — archived historical implementation plan
 - [`docs/design/message-split-hint-detailed-design.md`](design/message-split-hint-detailed-design.md) — detailed design for agent-authored message split hints
 - [`docs/design/separate-base-agent-image-detailed-design.md`](design/separate-base-agent-image-detailed-design.md) — detailed design for publishing and consuming the base agent image
 - [`docs/design/v3-0-multi-adapter-frontend-plan.md`](design/v3-0-multi-adapter-frontend-plan.md) — v3.0 adapter/frontend design plan

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,14 +42,17 @@ This directory is the canonical home for repository documentation.
 - [`docs/design/master-agent-interface-design.md`](design/master-agent-interface-design.md) — canonical interface between master and agent containers
 - [`docs/design/frontend-master-interface-design.md`](design/frontend-master-interface-design.md) — canonical interface between Slack/Discord and master
 - [`docs/design/master-agent-architecture.md`](design/master-agent-architecture.md) — architecture background and constraints
-- [`docs/design/master-agent-implementation-plan.md`](design/master-agent-implementation-plan.md) — archived historical implementation plan
 - [`docs/design/message-split-hint-detailed-design.md`](design/message-split-hint-detailed-design.md) — detailed design for agent-authored message split hints
 - [`docs/design/separate-base-agent-image-detailed-design.md`](design/separate-base-agent-image-detailed-design.md) — detailed design for publishing and consuming the base agent image
-- [`docs/design/v3-0-multi-adapter-frontend-plan.md`](design/v3-0-multi-adapter-frontend-plan.md) — archived historical v3.0 adapter/frontend plan
 
 ## Decisions
 
 - [`docs/decisions/README.md`](decisions/README.md) — ADR directory conventions
+
+## Archive
+
+- [`docs/archive/design/master-agent-implementation-plan.md`](archive/design/master-agent-implementation-plan.md) — archived historical implementation plan
+- [`docs/archive/design/v3-0-multi-adapter-frontend-plan.md`](archive/design/v3-0-multi-adapter-frontend-plan.md) — archived historical v3.0 adapter/frontend plan
 
 ## Test Plans
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,9 @@ This directory is the canonical home for repository documentation.
 
 ## Design
 
+- `docs/design/containers/master-container-design.md` — master container startup, interfaces, lifecycle, and storage
+- `docs/design/containers/agent-container-design.md` — agent container entrypoint, worker lifecycle, and runtime contract
+- `docs/design/containers/cd-container-design.md` — CD daemon container startup, deploy loop, rollback, and state
 - `docs/design/agent-container-runtime-design.md` — canonical runtime contract for agent containers
 - `docs/design/agent-provisioning-detailed-design.md` — detailed design for agent/channel/repo provisioning
 - `docs/design/master-agent-interface-design.md` — canonical interface between master and agent containers

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ This directory is the canonical home for repository documentation.
 
 - [`docs/releases/v3.2.md`](releases/v3.2.md)
 - [`docs/releases/v3.3.md`](releases/v3.3.md)
+- [`docs/releases/v3.9.md`](releases/v3.9.md)
 
 ## Compatibility Entry Points
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ This directory is the canonical home for repository documentation.
 - `docs/design/containers/master-container-design.md` — master container startup, interfaces, lifecycle, and storage
 - `docs/design/containers/agent-container-design.md` — agent container entrypoint, worker lifecycle, and runtime contract
 - `docs/design/containers/cd-container-design.md` — CD daemon container startup, deploy loop, rollback, and state
+- `docs/design/containers/environment-variable-passdown-design.md` — environment variable loading, normalization, and passdown across CD, master, and agent
 - `docs/design/agent-container-runtime-design.md` — canonical runtime contract for agent containers
 - `docs/design/agent-provisioning-detailed-design.md` — detailed design for agent/channel/repo provisioning
 - `docs/design/master-agent-interface-design.md` — canonical interface between master and agent containers

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ This directory is the canonical home for repository documentation.
 - [`docs/design/master-agent-implementation-plan.md`](design/master-agent-implementation-plan.md) — archived historical implementation plan
 - [`docs/design/message-split-hint-detailed-design.md`](design/message-split-hint-detailed-design.md) — detailed design for agent-authored message split hints
 - [`docs/design/separate-base-agent-image-detailed-design.md`](design/separate-base-agent-image-detailed-design.md) — detailed design for publishing and consuming the base agent image
-- [`docs/design/v3-0-multi-adapter-frontend-plan.md`](design/v3-0-multi-adapter-frontend-plan.md) — v3.0 adapter/frontend design plan
+- [`docs/design/v3-0-multi-adapter-frontend-plan.md`](design/v3-0-multi-adapter-frontend-plan.md) — archived historical v3.0 adapter/frontend plan
 
 ## Decisions
 

--- a/docs/archive/design/master-agent-implementation-plan.md
+++ b/docs/archive/design/master-agent-implementation-plan.md
@@ -1,7 +1,7 @@
 # Master-Agent Implementation Plan
 
 **Status:** archived historical plan  
-**Superseded by:** [`docs/design/master-agent-architecture.md`](master-agent-architecture.md), [`docs/design/master-agent-interface-design.md`](master-agent-interface-design.md), [`docs/design/frontend-master-interface-design.md`](frontend-master-interface-design.md), and the container design set under [`docs/design/containers/`](containers/)
+**Superseded by:** [`docs/design/master-agent-architecture.md`](../../design/master-agent-architecture.md), [`docs/design/master-agent-interface-design.md`](../../design/master-agent-interface-design.md), [`docs/design/frontend-master-interface-design.md`](../../design/frontend-master-interface-design.md), and the container design set under [`docs/design/containers/`](../../design/containers/)
 
 This document is preserved as historical implementation planning context for the
 initial master -> agent rollout.
@@ -9,7 +9,7 @@ initial master -> agent rollout.
 It is no longer the canonical source for the current architecture or runtime
 contracts.
 
-For current operator-facing behavior and command surface, use [`docs/README.md`](../README.md), [`docs/references/api.md`](../references/api.md), and [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md).
+For current operator-facing behavior and command surface, use [`docs/README.md`](../../README.md), [`docs/references/api.md`](../../references/api.md), and [`docs/guides/runbooks/master-agent.md`](../../guides/runbooks/master-agent.md).
 
 ## Design Freeze Status (v1)
 - Status: frozen for implementation.
@@ -38,8 +38,8 @@ For current operator-facing behavior and command surface, use [`docs/README.md`]
 - Finalize agent initialization stages and status reporting contract (no in-agent control service).
 
 Deliverables:
-- [`docs/design/master-agent-architecture.md`](master-agent-architecture.md)
-- [`docs/design/master-agent-implementation-plan.md`](master-agent-implementation-plan.md)
+- [`docs/design/master-agent-architecture.md`](../../design/master-agent-architecture.md)
+- [`docs/archive/design/master-agent-implementation-plan.md`](master-agent-implementation-plan.md)
 - sample registry JSON
 - sample project manifest (`.prj_assistant/agent.toml`)
 - master command contract + idempotency rules

--- a/docs/archive/design/v3-0-multi-adapter-frontend-plan.md
+++ b/docs/archive/design/v3-0-multi-adapter-frontend-plan.md
@@ -1,7 +1,7 @@
 # v3.0 Plan: Multi-Adapter + Multi-Frontend Master Runtime
 
 **Status:** archived historical plan  
-**Superseded by:** [`docs/design/frontend-master-interface-design.md`](frontend-master-interface-design.md), [`docs/design/master-agent-architecture.md`](master-agent-architecture.md), and the container design set under [`docs/design/containers/`](containers/)
+**Superseded by:** [`docs/design/frontend-master-interface-design.md`](../../design/frontend-master-interface-design.md), [`docs/design/master-agent-architecture.md`](../../design/master-agent-architecture.md), and the container design set under [`docs/design/containers/`](../../design/containers/)
 
 This document is preserved as historical planning context for the v3.0
 multi-adapter frontend rollout.

--- a/docs/design/agent-provisioning-detailed-design.md
+++ b/docs/design/agent-provisioning-detailed-design.md
@@ -1,6 +1,6 @@
 # Agent Provisioning Detailed Design
 
-**Status:** proposed  
+**Status:** canonical design  
 **Issue:** [#37](https://github.com/pandazxx/codex-slack/issues/37)  
 **ADR:** [`docs/decisions/0001-agent-provisioning-orchestration.md`](../decisions/0001-agent-provisioning-orchestration.md)
 
@@ -34,9 +34,9 @@ This design covers:
 
 ## Product Decision
 
-The provisioning workflow should be a new command, not a change to `/master-agent-load`.
+The provisioning workflow is a new command, not a change to `/master-agent-load`.
 
-Recommended command:
+Command:
 
 - `/master-agent-provision`
 
@@ -116,9 +116,9 @@ This layer is the orchestration boundary. It should not directly own frontend SD
 
 ### RepoProvisioner
 
-GitHub-specific repository creation should be implemented behind a provider interface.
+GitHub-specific repository creation is implemented behind a provider interface.
 
-Recommended v1 provider:
+Current provider:
 
 - GitHub REST API provider using `GH_TOKEN` or `GITHUB_TOKEN`
 
@@ -132,7 +132,7 @@ Why REST API instead of `gh repo create`:
 
 ### Slack
 
-Recommended text form:
+Current text form:
 
 ```text
 /master-agent-provision <name> [repo_spec] [--create-repo] [--repo-owner <owner>] [--repo-name <name>] [--repo-visibility private|public] [--create-channel] [--channel-name <name>] [--adapter codex|claude-code] [--branch <branch>]
@@ -140,7 +140,7 @@ Recommended text form:
 
 ### Discord
 
-Recommended application command arguments:
+Current application command arguments:
 
 - `name`
 - `repo_spec`
@@ -161,7 +161,7 @@ Recommended application command arguments:
 
 ## Request Model
 
-Recommended internal request shape:
+Current internal request shape:
 
 ```json
 {
@@ -218,7 +218,7 @@ Rules:
 
 ### Slack
 
-Recommended v1 behavior:
+Current behavior:
 
 - create a text channel named `agent-<name>`
 - default to a policy-driven channel type:
@@ -239,7 +239,7 @@ Provider output:
 
 ### Discord
 
-Recommended v1 behavior:
+Current behavior:
 
 - create a text channel, not a thread
 - create it in a configured guild/category
@@ -291,7 +291,8 @@ Provider output:
   "repo_name": "payments-api",
   "visibility": "private",
   "html_url": "https://github.com/pandazxx/payments-api",
-  "clone_url": "https://github.com/pandazxx/payments-api.git"
+  "clone_url": "https://github.com/pandazxx/payments-api.git",
+  "ssh_url": "git@github.com:pandazxx/payments-api.git"
 }
 ```
 
@@ -301,19 +302,21 @@ Default resolution rules:
 - if the token belongs to a user account, create the repository under that user by default
 - if the token is scoped for org automation and repo creation should target an org, require an explicit owner override in v1
 - if `visibility` is omitted, default to `private`
+- new repositories are auto-initialized so the requested default branch exists before `load_agent()` binds the repo
+- when provisioning creates a repo, the final agent bind uses `ssh_url` rather than `clone_url`
 
 ### Existing repo reuse
 
-Recommended behavior:
+Current behavior:
 
-- if repo creation was requested but the repo already exists and is accessible, return a structured conflict or explicit reuse path
-- do not silently adopt an existing repo without confirming the ownership/name match expected by the request
+- if repo creation was requested and the target repo already exists, provisioning fails instead of silently reusing it
+- there is no explicit reuse-if-exists mode yet
 
 ## Persistence Design
 
 ### Immediate result payload
 
-The provisioning response should return:
+The provisioning response returns:
 
 - final `channel_id`
 - final `repo_source`
@@ -324,7 +327,7 @@ The provisioning response should return:
 
 ### Registry extension
 
-Recommended optional registry fields:
+Optional registry fields:
 
 - `channel_name`
 - `provisioned_channel`
@@ -336,7 +339,7 @@ These fields are useful for later operator visibility and diagnostics but are no
 
 ## Error Handling
 
-Recommended stable provisioning error codes:
+Stable provisioning error codes:
 
 - `ERR_PROVISION_INVALID_ARGS`
 - `ERR_CHANNEL_CREATE_FAILED`
@@ -367,7 +370,7 @@ Example:
 
 ## Rollout Strategy
 
-Recommended delivery order:
+Rollout order used:
 
 1. request/result types and coordinator
 2. GitHub repo provisioner
@@ -403,9 +406,11 @@ Recommended delivery order:
 
 ## Open Questions
 
-These do not block the design, but they must be decided before implementation:
+Current resolved decisions and remaining gaps:
 
-- Slack default channel type: private or public?
-- Discord target guild/category source: config-driven or inferred from invoking admin channel?
-- should repo/channel creation support an explicit "reuse existing if present" mode?
-- should provisioning immediately call `/master-agent-start`, or remain load-only in v1?
+- Discord target guild/category is inferred from the invoking admin channel
+- provisioning remains load-only in v1 and does not auto-start the agent
+- omitted repo input defaults to create-repo
+- omitted channel input defaults to create-channel
+- explicit reuse-if-exists mode is still not implemented
+- Slack default channel type still depends on the current frontend implementation and runtime permissions; operators should treat it as an implementation detail unless a stronger product rule is added

--- a/docs/design/agent-provisioning-detailed-design.md
+++ b/docs/design/agent-provisioning-detailed-design.md
@@ -2,7 +2,7 @@
 
 **Status:** proposed  
 **Issue:** [#37](https://github.com/pandazxx/codex-slack/issues/37)  
-**ADR:** `docs/decisions/0001-agent-provisioning-orchestration.md`
+**ADR:** [`docs/decisions/0001-agent-provisioning-orchestration.md`](../decisions/0001-agent-provisioning-orchestration.md)
 
 ## Goal
 

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -270,6 +270,9 @@ Claude auth:
       - `git reset --hard origin/<AGENT_REPO_REF>`
     - this is not a merge-style `git pull`; it forcibly aligns the local repo to
       the requested remote ref
+    - later-phase cleanup target:
+      - remove this destructive hard-reset update behavior and replace it with a
+        less destructive repo refresh strategy
 - prepare workspace/home directories
 - copy shared global config into writable user scope again from the mounted env
   path when configured

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -1,0 +1,294 @@
+# Agent Container Design
+
+**Status:** canonical design  
+**Scope:** worker containers started by master for `codex` or `claude-code`
+
+## Goal
+
+Define the agent container as a runtime unit:
+
+- shell entrypoint behavior
+- worker startup stages
+- master-to-agent interface contract
+- storage layout and ownership
+- lifecycle and failure boundaries
+
+This is the container-focused companion to:
+
+- `docs/design/agent-container-runtime-design.md`
+- `docs/design/master-agent-interface-design.md`
+
+## Responsibilities
+
+The agent container is the worker plane. It is responsible for:
+
+- receiving a prepared environment from master
+- selecting and preparing writable user-scope runtime state
+- syncing the target repository into `/workspace/repo`
+- executing the configured agent adapter
+- consuming transient request manifests and staged files
+- writing durable work back into the repo workspace
+
+It is not responsible for:
+
+- Slack or Discord connectivity
+- container orchestration
+- registry ownership
+- cross-agent routing
+
+## Entry Point Model
+
+The agent container uses the shell entrypoint at `docker/entrypoint.sh`.
+
+That entrypoint is responsible for:
+
+- selecting `CODEX_HOME`
+- seeding global Codex config into writable user scope
+- seeding Codex auth and sessions when available
+- seeding global Claude config into writable user scope
+- applying global Git identity if configured
+- selecting the runtime mode
+- launching either `src.agent.main` or another provided command
+
+## Startup Flow
+
+```mermaid
+flowchart TD
+    A[Container starts] --> B[docker/entrypoint.sh]
+    B --> C[resolve CODEX_HOME]
+    C --> D[copy global Codex config]
+    D --> E[copy Codex auth and sessions]
+    E --> F[copy global Claude config]
+    F --> G[apply git user.name and user.email]
+    G --> H{CODEX_CONTAINER_MODE}
+    H -->|agent-worker| I[python -m src.agent.main]
+    H -->|other| J[exec provided command]
+    I --> K[preflight]
+    K --> L[repo sync]
+    L --> M[workspace prepare]
+    M --> N[ready]
+```
+
+## Runtime Modes
+
+The image can participate in multiple modes, but the normal master-managed mode
+is:
+
+- `CODEX_CONTAINER_MODE=agent-worker`
+
+In that mode, the entrypoint converts the default bot launch into:
+
+- `python -m src.agent.main`
+
+The entrypoint can also exec an explicit command, which is how adapter dispatch
+and testing paths stay flexible.
+
+## Interface Contract
+
+### Required Inputs from Master
+
+The agent container depends on master-provided env vars such as:
+
+- `HOME=/workspace/home`
+- `XDG_CONFIG_HOME=/workspace/home/.config`
+- `CODEX_HOME=/workspace/home/.codex`
+- `AGENT_REPO_DIR=repo`
+- `AGENT_REPO_URL`
+- `AGENT_REPO_REF`
+- `AGENT_FRONTEND`
+- `AGENT_ADAPTER`
+
+Optional but common inputs:
+
+- `GH_TOKEN` / `GITHUB_TOKEN`
+- `OPENAI_API_KEY`
+- `CLAUDE_CODE_OAUTH_TOKEN`
+- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+- `SSH_AUTH_SOCK`
+- `GIT_SSH_COMMAND`
+- `AGENT_REQUEST_MANIFEST`
+
+### Mount Contract
+
+The master typically mounts:
+
+- workspace volume at `/workspace`
+- global Codex config at `/run/secrets/master_codex_config`
+- global Claude config at `/run/secrets/master_claude_config`
+- Codex auth seed at `/run/secrets/codex_auth.json`
+- Codex sessions seed at `/run/secrets/codex_sessions` when applicable
+- SSH agent socket at `/run/secrets/ssh-auth.sock`
+- transient request data under `/workspace/message/...`
+
+## Storage Layout
+
+Important paths inside the running container:
+
+- `/workspace/repo`
+  - durable checked-out project state
+- `/workspace/home/.codex`
+  - writable Codex user-scope home
+- `/workspace/home/.claude`
+  - writable Claude user-scope home
+- `/workspace/home/.config`
+  - XDG config home
+- `/workspace/message/...`
+  - transient request-scoped staged input
+
+Repo-local project scope remains inside the repo:
+
+- `/workspace/repo/.codex`
+- `/workspace/repo/.claude`
+- repo-root `AGENTS.md`
+
+## Storage Ownership
+
+| Path | Owner | Durability | Purpose |
+|---|---|---|---|
+| `/workspace/repo` | agent workspace volume | durable | checked-out project and committed changes |
+| `/workspace/home/.codex` | agent workspace volume | durable | writable Codex user scope |
+| `/workspace/home/.claude` | agent workspace volume | durable | writable Claude user scope |
+| `/workspace/message/...` | master-staged | transient | request-scoped files and manifest |
+| `/run/secrets/...` | master-mounted | transient/read-only | seed inputs only |
+
+## Worker Lifecycle
+
+The worker process emits staged lifecycle states:
+
+- `preflight`
+- `repo_sync`
+- `workspace_prepare`
+- `ready`
+
+```mermaid
+stateDiagram-v2
+    [*] --> Starting
+    Starting --> Preflight
+    Preflight --> RepoSync: checks passed
+    Preflight --> Failed: missing prerequisites
+    RepoSync --> WorkspacePrepare: repo ready
+    RepoSync --> Failed: clone/fetch failure
+    WorkspacePrepare --> Ready: config and workspace ready
+    WorkspacePrepare --> Failed: copy/setup failure
+    Ready --> Dispatching: master execs adapter command
+    Dispatching --> Ready: request complete
+    Failed --> [*]
+```
+
+## Startup Behavior in Detail
+
+### 1. User-scope setup
+
+The entrypoint chooses `CODEX_HOME` in this order:
+
+1. explicit `CODEX_HOME`
+2. project-level `/workspace/.codex` if present
+3. default `/home/appuser/.codex`
+
+It then ensures the directory exists and refreshes global config into it.
+
+### 2. Global config refresh
+
+Codex:
+
+- prefers `/run/secrets/master_codex_config`
+- falls back to baked-in `/opt/codex-slack/config/codex-global`
+- copies into writable `CODEX_HOME`
+
+Claude:
+
+- prefers `/run/secrets/master_claude_config`
+- falls back to baked-in `/opt/codex-slack/config/claude-global`
+- copies into writable `~/.claude`
+
+### 3. Auth/session seeding
+
+Codex auth:
+
+- copies `/run/secrets/codex_auth.json` into `CODEX_HOME/auth.json` when the
+  target auth file is missing
+
+Codex sessions:
+
+- copies `/run/secrets/codex_sessions` into `CODEX_HOME/sessions` only when the
+  target session directory is absent or empty
+
+Claude auth:
+
+- remains env-driven, not file-copy driven
+
+### 4. Repo sync and workspace prepare
+
+`src.agent.main` and the worker then:
+
+- verify prerequisites
+- clone or update the target repo into `/workspace/repo`
+- prepare workspace/home directories
+- copy shared global config into writable user scope again from the mounted env
+  path when configured
+- record status for master-side inspection
+
+## Request Handling Contract
+
+When master stages request input, the agent should treat:
+
+- `/workspace/message/...`
+
+as transient input only. The manifest pointed to by `AGENT_REQUEST_MANIFEST` is
+the canonical request descriptor.
+
+Rules:
+
+- prefer manifest-derived Markdown and staged image paths
+- do not treat request storage as durable state
+- copy anything that must survive into `/workspace/repo/...`
+
+## Observability
+
+The agent container is intentionally verbose at startup.
+
+Important logs include:
+
+- `agent.entrypoint startup`
+- `agent.entrypoint codex_config`
+- `agent.entrypoint codex_config_result`
+- `agent.entrypoint codex_home_result`
+- `agent.entrypoint claude_config_result`
+- `agent.worker_settings`
+- `agent.stage ...`
+- `agent.workspace_prepare_state`
+- `agent.workspace_prepare_copied`
+- `agent.workspace_prepare_copy_skipped`
+
+The entrypoint also runs with shell tracing enabled to make copy and launch
+behavior diagnosable.
+
+## Failure Model
+
+Typical failure classes:
+
+- missing auth or SSH prerequisites
+- repo clone/fetch failures
+- missing or stale shared config inputs
+- adapter command failure during dispatch
+
+The agent container should fail fast on startup preconditions and return request
+errors through master for per-dispatch failures.
+
+## Operational Invariants
+
+The agent container must preserve these invariants:
+
+- user-scope config is writable inside the workspace volume
+- read-only secret mounts are seed inputs, not live writable homes
+- repo-local config remains project scope
+- request-scoped staged files remain transient
+- master remains the only orchestrator
+
+## Related Documents
+
+- `docs/design/agent-container-runtime-design.md`
+- `docs/design/master-agent-interface-design.md`
+- `docs/guides/container-runtime.md`
+- `docs/guides/runbooks/master-agent.md`

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -123,6 +123,11 @@ The master typically mounts:
 - SSH agent socket at `/run/secrets/ssh-auth.sock`
 - transient request data under `/workspace/message/...`
 
+Later-phase cleanup target:
+
+- remove the mounted Codex session-seed passthrough and simplify startup so
+  session state is no longer seeded from `/run/secrets/codex_sessions`
+
 ## Storage Layout
 
 Important paths inside the running container:
@@ -185,10 +190,16 @@ stateDiagram-v2
 The entrypoint chooses `CODEX_HOME` in this order:
 
 1. explicit `CODEX_HOME`
-2. project-level `/workspace/.codex` if present
+2. project-level `/workspace/.codex` if it already exists in the mounted
+   workspace volume before the entrypoint runs
 3. default `/home/appuser/.codex`
 
-It then ensures the directory exists and refreshes global config into it.
+In normal master-managed agent startup, `/workspace` is a named volume and
+usually starts empty, so the second case normally does not apply unless
+something created `/workspace/.codex` in that volume earlier.
+
+It then ensures the selected directory exists and refreshes global config into
+it.
 
 ### 2. Global config refresh
 
@@ -198,11 +209,21 @@ Codex:
 - falls back to baked-in `/opt/codex-slack/config/codex-global`
 - copies into writable `CODEX_HOME`
 
+Later-phase cleanup target:
+
+- remove the mounted global Codex config passthrough and rely on baked-in global
+  Codex config as the single shared-default source
+
 Claude:
 
 - prefers `/run/secrets/master_claude_config`
 - falls back to baked-in `/opt/codex-slack/config/claude-global`
 - copies into writable `~/.claude`
+
+Later-phase cleanup target:
+
+- remove the mounted global Claude config passthrough and rely on baked-in
+  global Claude config as the single shared-default source
 
 ### 3. Auth/session seeding
 
@@ -216,19 +237,44 @@ Codex sessions:
 - copies `/run/secrets/codex_sessions` into `CODEX_HOME/sessions` only when the
   target session directory is absent or empty
 
+Later-phase cleanup target:
+
+- remove the mounted Codex session seed and stop treating session data as a
+  startup passthrough concern
+
 Claude auth:
 
 - remains env-driven, not file-copy driven
+- master passes `CLAUDE_CODE_OAUTH_TOKEN` when present
+- if that is absent, master falls back to `ANTHROPIC_API_KEY`
 
 ### 4. Repo sync and workspace prepare
 
 `src.agent.main` and the worker then:
 
 - verify prerequisites
+  - repo auth is accepted from any one of:
+    - `SSH_AUTH_SOCK` pointing to an existing socket
+    - `GH_TOKEN`
+    - `GITHUB_TOKEN`
+    - `GH_TOKEN_FILE` pointing to an absolute existing file
 - clone or update the target repo into `/workspace/repo`
+  - clone path:
+    - used when `/workspace/repo/.git` does not exist
+    - command: `git clone --branch <AGENT_REPO_REF> <AGENT_REPO_URL> /workspace/repo`
+  - update path:
+    - used when `/workspace/repo/.git` already exists
+    - commands:
+      - `git fetch origin <AGENT_REPO_REF>`
+      - `git checkout <AGENT_REPO_REF>`
+      - `git reset --hard origin/<AGENT_REPO_REF>`
+    - this is not a merge-style `git pull`; it forcibly aligns the local repo to
+      the requested remote ref
 - prepare workspace/home directories
 - copy shared global config into writable user scope again from the mounted env
   path when configured
+  - `AGENT_GLOBAL_CODEX_CONFIG_DIR` for Codex
+  - `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` for Claude
 - record status for master-side inspection
 
 ## Request Handling Contract

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -17,6 +17,8 @@ This is the container-focused companion to:
 
 - `docs/design/agent-container-runtime-design.md`
 - `docs/design/master-agent-interface-design.md`
+- `docs/references/config.md`
+- `docs/references/logging.md`
 
 ## Responsibilities
 
@@ -290,5 +292,8 @@ The agent container must preserve these invariants:
 
 - `docs/design/agent-container-runtime-design.md`
 - `docs/design/master-agent-interface-design.md`
+- `docs/design/containers/environment-variable-passdown-design.md`
 - `docs/guides/container-runtime.md`
+- `docs/references/config.md`
+- `docs/references/logging.md`
 - `docs/guides/runbooks/master-agent.md`

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -15,10 +15,10 @@ Define the agent container as a runtime unit:
 
 This is the container-focused companion to:
 
-- `docs/design/agent-container-runtime-design.md`
-- `docs/design/master-agent-interface-design.md`
-- `docs/references/config.md`
-- `docs/references/logging.md`
+- [`docs/design/agent-container-runtime-design.md`](../agent-container-runtime-design.md)
+- [`docs/design/master-agent-interface-design.md`](../master-agent-interface-design.md)
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
 
 ## Responsibilities
 
@@ -290,10 +290,10 @@ The agent container must preserve these invariants:
 
 ## Related Documents
 
-- `docs/design/agent-container-runtime-design.md`
-- `docs/design/master-agent-interface-design.md`
-- `docs/design/containers/environment-variable-passdown-design.md`
-- `docs/guides/container-runtime.md`
-- `docs/references/config.md`
-- `docs/references/logging.md`
-- `docs/guides/runbooks/master-agent.md`
+- [`docs/design/agent-container-runtime-design.md`](../agent-container-runtime-design.md)
+- [`docs/design/master-agent-interface-design.md`](../master-agent-interface-design.md)
+- [`docs/design/containers/environment-variable-passdown-design.md`](environment-variable-passdown-design.md)
+- [`docs/guides/container-runtime.md`](../../guides/container-runtime.md)
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
+- [`docs/guides/runbooks/master-agent.md`](../../guides/runbooks/master-agent.md)

--- a/docs/design/containers/cd-container-design.md
+++ b/docs/design/containers/cd-container-design.md
@@ -15,6 +15,8 @@ Define the CD daemon container as a runtime unit:
 This document complements:
 
 - `docs/guides/runbooks/cd-daemon.md`
+- `docs/references/config.md`
+- `docs/references/logging.md`
 
 ## Responsibilities
 
@@ -251,4 +253,7 @@ The CD container must preserve these invariants:
 ## Related Documents
 
 - `docs/guides/runbooks/cd-daemon.md`
+- `docs/design/containers/environment-variable-passdown-design.md`
+- `docs/references/config.md`
+- `docs/references/logging.md`
 - `docs/manuals/ops-manual.md`

--- a/docs/design/containers/cd-container-design.md
+++ b/docs/design/containers/cd-container-design.md
@@ -1,0 +1,254 @@
+# CD Container Design
+
+**Status:** canonical design  
+**Scope:** the CD daemon container started with `python -m src.cd.main`
+
+## Goal
+
+Define the CD daemon container as a runtime unit:
+
+- startup behavior and deploy loop
+- interface contracts to GHCR, compose, and the master container
+- lifecycle and rollback behavior
+- persisted state and failure handling
+
+This document complements:
+
+- `docs/guides/runbooks/cd-daemon.md`
+
+## Responsibilities
+
+The CD daemon is a deployment automation container. It is responsible for:
+
+- loading CD settings
+- polling the registry for new image digests
+- redeploying the master container when the tracked digest changes
+- rolling back to the previous digest when the new deployment is unhealthy
+- persisting deploy state
+- sending deployment notifications
+
+It is not responsible for:
+
+- running frontend logic
+- owning the agent registry
+- dispatching user prompts
+- managing agent containers directly
+
+## Process Model
+
+Like the master container, the CD container is Python-process driven rather than
+shell-entrypoint driven for its core logic.
+
+Startup sequence:
+
+1. load default `.env`
+2. if `CD_ENV_FILE` is set, load that env file with override
+3. configure logging
+4. load `CdSettings`
+5. enter the blocking deploy loop
+
+## Startup Flow
+
+```mermaid
+flowchart TD
+    A[Container starts] --> B[python -m src.cd.main]
+    B --> C[load_dotenv]
+    C --> D[load CD_ENV_FILE override if set]
+    D --> E[configure logging]
+    E --> F[load_cd_settings]
+    F --> G[run_loop]
+    G --> H[load persisted state]
+    H --> I{have deployed digest?}
+    I -->|yes| J[startup force-recreate master]
+    I -->|no| K[startup restart master]
+    J --> L[poll registry forever]
+    K --> L
+```
+
+## External Interfaces
+
+The CD daemon depends on:
+
+- GHCR or another OCI registry for image pulls
+- compose tooling on the host or in the container
+- a compose file that defines the master service
+- an env file for master runtime variables
+- optional Slack and Discord webhooks for notifications
+
+It drives only one runtime target:
+
+- the master container defined by `CD_CONTAINER_NAME` and the compose service
+
+## Interface Contract
+
+### Required Inputs
+
+The CD container depends on configuration such as:
+
+- `CD_IMAGE`
+- `CD_IMAGE_TAG`
+- `CD_CONTAINER_NAME`
+- `CD_COMPOSE_FILE`
+- `CD_COMPOSE_SERVICE`
+- `CD_COMPOSE_BINARY`
+- `CD_STATE_FILE`
+
+Optional but common inputs:
+
+- `CD_ENV_FILE`
+- `CD_NOTIFY_SLACK_WEBHOOK_URL`
+- `CD_NOTIFY_DISCORD_WEBHOOK_URL`
+- `CD_DRY_RUN`
+- `CD_ROLLBACK_ON_FAILURE`
+
+### Outbound Actions
+
+The daemon performs:
+
+- image pull operations
+- compose redeploy operations
+- direct restart/force-recreate operations
+- health checks against the master container
+- webhook notifications
+- persisted state updates
+
+## Lifecycle
+
+### Container Lifecycle
+
+The daemon container itself is host-managed:
+
+- created
+- running
+- restarted
+- replaced
+
+Its internal service loop is long-lived.
+
+### Deploy Loop Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Startup
+    Startup --> Reconciling
+    Reconciling --> Polling
+    Polling --> Deploying: new digest found
+    Polling --> Polling: digest unchanged
+    Deploying --> Healthy: deploy + health check passed
+    Deploying --> RollingBack: deploy failed or unhealthy
+    RollingBack --> Healthy: rollback succeeded
+    RollingBack --> Failed: rollback unhealthy or failed
+    Healthy --> Polling
+    Failed --> Polling
+```
+
+## Startup Reconciliation Behavior
+
+On startup the daemon reloads `CD_STATE_FILE` and reconciles the master
+container:
+
+- if `deployed_digest` exists
+  - force-recreate the master container using that digest
+- if no `deployed_digest` exists
+  - restart the named master container
+
+This makes daemon startup self-healing after daemon restarts and helps ensure
+the master picks up the env and image currently represented by daemon state.
+
+## Polling and Deployment Behavior
+
+Normal loop behavior:
+
+1. pull `<image>:<tag>`
+2. read the resolved repo digest
+3. compare against `state.deployed_digest`
+4. if unchanged, sleep until next poll
+5. if changed, deploy the new digest through compose
+6. wait the configured health delay
+7. inspect the master container health/running state
+8. persist success or trigger rollback
+
+## Rollback Contract
+
+Rollback uses `state.previous_digest`.
+
+Rules:
+
+- rollback happens only when enabled and a previous digest exists
+- the daemon redeploys the previous digest via compose
+- the rolled-back container is health-checked again
+- a rollback that is also unhealthy becomes a manual-intervention case
+
+## Storage Model
+
+Primary durable state:
+
+- `CD_STATE_FILE`
+
+This file persists:
+
+- `deployed_digest`
+- `previous_digest`
+- `deployed_at`
+- `consecutive_failures`
+
+The daemon should treat container-local ephemeral files as disposable. Durable
+behavior depends on the mounted state file and compose/env inputs.
+
+## Storage Boundaries
+
+| Path / resource | Owner | Durability | Purpose |
+|---|---|---|---|
+| `CD_STATE_FILE` | CD daemon | durable | last known-good deploy state |
+| compose file | host/config repo | durable | defines master deployment |
+| env file | host/config repo | durable | feeds master and daemon runtime config |
+| process memory | daemon | transient | current loop state |
+
+## Failure Model
+
+Failure classes the daemon is designed to tolerate:
+
+- image pull failures
+- compose deploy failures
+- master health-check failures
+- webhook notification failures
+
+Handling rules:
+
+- webhook failures are logged and swallowed
+- deploy failures increment failure state and may trigger rollback
+- unchanged digests do not redeploy
+- exceptions in the poll loop are logged and the loop continues
+
+## Observability
+
+Important logs include:
+
+- `cd.daemon_start`
+- `cd.daemon_loaded_state`
+- `cd.startup_force_recreate`
+- `cd.startup_restart`
+- `cd.new_image`
+- `cd.deploy_success`
+- `cd.deploy_failed`
+- `cd.health_check_failed`
+- `cd.rollback_also_unhealthy`
+- `cd.loop_error`
+
+The daemon is designed so its deploy reasoning can be reconstructed from logs
+plus `CD_STATE_FILE`.
+
+## Operational Invariants
+
+The CD container must preserve these invariants:
+
+- it manages only the master deployment, not agents directly
+- the repo digest is the authoritative deploy identity
+- startup reconciliation must use persisted state when available
+- a failed notification must not block deployment logic
+- rollback targets the last known-good digest, not the moving tag
+
+## Related Documents
+
+- `docs/guides/runbooks/cd-daemon.md`
+- `docs/manuals/ops-manual.md`

--- a/docs/design/containers/cd-container-design.md
+++ b/docs/design/containers/cd-container-design.md
@@ -14,9 +14,9 @@ Define the CD daemon container as a runtime unit:
 
 This document complements:
 
-- `docs/guides/runbooks/cd-daemon.md`
-- `docs/references/config.md`
-- `docs/references/logging.md`
+- [`docs/guides/runbooks/cd-daemon.md`](../../guides/runbooks/cd-daemon.md)
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
 
 ## Responsibilities
 
@@ -252,8 +252,8 @@ The CD container must preserve these invariants:
 
 ## Related Documents
 
-- `docs/guides/runbooks/cd-daemon.md`
-- `docs/design/containers/environment-variable-passdown-design.md`
-- `docs/references/config.md`
-- `docs/references/logging.md`
-- `docs/manuals/ops-manual.md`
+- [`docs/guides/runbooks/cd-daemon.md`](../../guides/runbooks/cd-daemon.md)
+- [`docs/design/containers/environment-variable-passdown-design.md`](environment-variable-passdown-design.md)
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
+- [`docs/manuals/ops-manual.md`](../../manuals/ops-manual.md)

--- a/docs/design/containers/environment-variable-passdown-design.md
+++ b/docs/design/containers/environment-variable-passdown-design.md
@@ -1,0 +1,267 @@
+# Environment Variable Passdown Design
+
+**Status:** canonical design  
+**Scope:** how environment variables are loaded, renamed, persisted, and passed
+between the CD, master, and agent container runtimes
+
+## Goal
+
+Explain the end-to-end environment-variable flow with explicit ownership:
+
+- which container reads which environment variable
+- which module loads and normalizes it
+- which internal field name stores it
+- whether the value stays local or is passed down to another runtime
+- what final name the downstream runtime sees
+
+This document focuses on environment flow. It complements:
+
+- `docs/references/config.md`
+- `docs/design/containers/master-container-design.md`
+- `docs/design/containers/agent-container-design.md`
+- `docs/design/containers/cd-container-design.md`
+
+## High-Level Flow
+
+```mermaid
+flowchart LR
+    A[Host env / compose env / .env] --> B[CD container]
+    A --> C[Master container]
+    B -->|compose + env file| C
+    C -->|create_or_update_agent env + mounts| D[Agent container]
+    D -->|entrypoint + worker load env| E[Agent runtime behavior]
+```
+
+## Design Rules
+
+- CD env stays in the CD process and is not passed directly into the agent.
+- Master env is normalized into `MasterSettings` before use.
+- Agent container env is built by master from registry state plus selected master
+  settings.
+- Some host inputs are passed as env vars.
+- Other host inputs are passed as mounts and then represented inside the agent as
+  mount paths such as `/run/secrets/...`.
+
+## 1. CD Container Env Flow
+
+The CD container loads env in `src/cd/main.py` and normalizes it in
+`src/cd/config.py`.
+
+| Host env key | Loaded by | Stored as | Used by | Passed further |
+|---|---|---|---|---|
+| `CD_IMAGE` | `load_cd_settings()` | `CdSettings.image` | registry polling and deploy selection | no |
+| `CD_IMAGE_TAG` | `load_cd_settings()` | `CdSettings.image_tag` | tracked tag | no |
+| `CD_CONTAINER_NAME` | `load_cd_settings()` | `CdSettings.container_name` | health checks and startup reconcile | no |
+| `CD_COMPOSE_FILE` | `load_cd_settings()` | `CdSettings.compose_file` | compose deploy/restart operations | no |
+| `CD_COMPOSE_SERVICE` | `load_cd_settings()` | `CdSettings.compose_service` | compose target service | no |
+| `CD_COMPOSE_BINARY` | `load_cd_settings()` | `CdSettings.compose_binary` | compose command execution | no |
+| `CD_ENV_FILE` | `src.cd.main` and `load_cd_settings()` | `CdSettings.env_file` | daemon env override and compose `--env-file` | indirectly to master via compose |
+| `CD_STATE_FILE` | `load_cd_settings()` | `CdSettings.state_file` | persisted daemon state | no |
+| `CD_POLL_INTERVAL_SECONDS` | `load_cd_settings()` | `CdSettings.poll_interval_seconds` | polling loop | no |
+| `CD_HEALTH_CHECK_DELAY_SECONDS` | `load_cd_settings()` | `CdSettings.health_check_delay_seconds` | post-deploy checks | no |
+| `CD_ROLLBACK_ON_FAILURE` | `load_cd_settings()` | `CdSettings.rollback_on_failure` | rollback behavior | no |
+| `CD_DRY_RUN` | `load_cd_settings()` | `CdSettings.dry_run` | side-effect guard | no |
+| `CD_NOTIFY_SLACK_WEBHOOK_URL` | `load_cd_settings()` | `CdSettings.notify_slack_webhook_url` | notifications | no |
+| `CD_NOTIFY_DISCORD_WEBHOOK_URL` | `load_cd_settings()` | `CdSettings.notify_discord_webhook_url` | notifications | no |
+
+Important nuance:
+
+- `CD_ENV_FILE` is the bridge to master runtime config because the daemon passes
+  that file to compose when redeploying the master container.
+- The CD process does not translate `CD_*` vars into `MASTER_*` vars itself.
+
+## 2. Master Container Env Flow
+
+The master container loads env in `src/master/main.py` and normalizes it in
+`src/master/config.py` into `MasterSettings`.
+
+### Frontend and process-local settings
+
+| Host env key | Loaded by | Stored as | Used by | Passed to agent |
+|---|---|---|---|---|
+| `MASTER_FRONTENDS` | `load_master_settings()` | `MasterSettings.frontends` | decide which frontend threads start | no |
+| `SLACK_BOT_TOKEN` | `load_master_settings()` | `MasterSettings.slack_bot_token` | Slack app and dispatcher URL access | not as agent env |
+| `SLACK_APP_TOKEN` | `load_master_settings()` | `MasterSettings.slack_app_token` | Slack Socket Mode | no |
+| `DISCORD_BOT_TOKEN` | `load_master_settings()` | `MasterSettings.discord_bot_token` | Discord frontend | no |
+| `MASTER_ADMIN_CHANNELS` | `load_master_settings()` | `MasterSettings.admin_channels` | Slack admin guard | no |
+| `DISCORD_ADMIN_CHANNELS` | `load_master_settings()` | `MasterSettings.discord_admin_channels` | Discord admin guard | no |
+| `MASTER_REGISTRY_PATH` | `load_master_settings()` | `MasterSettings.registry_path` | `AgentRegistry` | no |
+| `MASTER_THREAD_STATE_PATH` | `load_master_settings()` | `MasterSettings.thread_state_path` | `ChannelRouter` | no |
+| `MASTER_DRY_RUN` | `load_master_settings()` | `MasterSettings.dry_run` | `PodmanRuntimeAdapter` | no |
+| `MASTER_COMMAND_RATE_LIMIT_COUNT` | `load_master_settings()` | `MasterSettings.command_rate_limit_count` | `CommandRateLimiter` | no |
+| `MASTER_COMMAND_RATE_LIMIT_WINDOW_SECONDS` | `load_master_settings()` | `MasterSettings.command_rate_limit_window_seconds` | `CommandRateLimiter` | no |
+
+### Agent-runtime seed settings
+
+These host env vars are loaded into `MasterSettings`, then later transformed by
+`MasterService._build_agent_env()` and `_build_agent_mounts()` into agent env
+vars or mount points.
+
+| Host env key | Stored as | Agent sees env name | Agent sees mount / value |
+|---|---|---|---|
+| `MASTER_AGENT_BASE_IMAGE` | `agent_base_image` | none | image reference used at container create/start time |
+| `MASTER_CODEX_AUTH_JSON_PATH` | `agent_codex_auth_json_path` | none | mount at `/run/secrets/codex_auth.json` |
+| `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | env value `/run/secrets/master_codex_config` plus matching mount |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `agent_claude_config_dir_path` | `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | env value `/run/secrets/master_claude_config` plus matching mount |
+| `MASTER_SSH_AUTH_SOCK_PATH` | `agent_ssh_auth_sock_path` | `SSH_AUTH_SOCK` | env value `/run/secrets/ssh-auth.sock` plus matching mount |
+| `MASTER_SSH_KNOWN_HOSTS_PATH` | `agent_ssh_known_hosts_path` | `GIT_SSH_COMMAND` | env embeds known-hosts path if configured |
+| `MASTER_GIT_USER_NAME` | `git_user_name` | `AGENT_GIT_USER_NAME` and `GIT_USER_NAME` | string passed through |
+| `MASTER_GIT_USER_EMAIL` | `git_user_email` | `AGENT_GIT_USER_EMAIL` and `GIT_USER_EMAIL` | string passed through |
+| `MASTER_DEFAULT_AGENT_ADAPTER` | `default_agent_adapter` | `AGENT_ADAPTER` | selected per agent record |
+| `MASTER_CODEX_COMMAND_TEMPLATE` | `codex_command_template` | none | used only by master dispatcher |
+| `MASTER_CLAUDE_COMMAND_TEMPLATE` | `claude_command_template` | none | used only by master dispatcher |
+| `MASTER_AGENT_TIMEOUT_SECONDS` | `dispatch_timeout_seconds` | none | used only by master dispatcher |
+
+### Auto-detected master env
+
+`MASTER_PROJECT_DIR` is special:
+
+- it is loaded by `load_master_settings()`
+- it may be used to auto-detect:
+  - `MASTER_CODEX_CONFIG_DIR_PATH`
+  - `MASTER_CLAUDE_CONFIG_DIR_PATH`
+- it is not passed to the agent directly
+
+## 3. Master-to-Agent Env Construction
+
+The master builds the agent container env in `MasterService`.
+
+```mermaid
+flowchart TD
+    A[Master host env] --> B[load_master_settings]
+    B --> C[MasterSettings]
+    C --> D[MasterService._build_agent_env]
+    C --> E[MasterService._build_agent_mounts]
+    F[Agent registry record] --> D
+    D --> G[env dict for create_or_update_agent]
+    E --> H[mount list for create_or_update_agent]
+    G --> I[Agent container env]
+    H --> I
+```
+
+The important agent env keys built by master are:
+
+| Agent env key | Built from | Consumed by |
+|---|---|---|
+| `HOME` | fixed runtime contract | entrypoint and worker |
+| `XDG_CONFIG_HOME` | fixed runtime contract | entrypoint and worker |
+| `CODEX_HOME` | fixed runtime contract | entrypoint and worker |
+| `AGENT_REPO_DIR` | fixed runtime contract / registry | worker |
+| `AGENT_REPO_URL` | agent record `repo_source` | worker |
+| `AGENT_REPO_REF` | agent record `repo_ref` | worker |
+| `AGENT_ADAPTER` | agent record or master default | dispatch-time semantics and logs |
+| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | master mount contract | worker |
+| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | master mount contract | worker |
+| `AGENT_GIT_USER_NAME` | `MASTER_GIT_USER_NAME` | worker |
+| `AGENT_GIT_USER_EMAIL` | `MASTER_GIT_USER_EMAIL` | worker |
+| `SSH_AUTH_SOCK` | SSH mount contract | worker / git |
+| `GIT_SSH_COMMAND` | known-hosts handling | git subprocesses |
+| `GH_TOKEN` | host runtime env | worker preflight / git auth |
+| `OPENAI_API_KEY` | host runtime env | Codex runtime |
+| `CLAUDE_CODE_OAUTH_TOKEN` | host runtime env | Claude runtime |
+
+Important nuance:
+
+- some values are pass-through from the master process environment at container
+  creation time
+- some values come from the logical agent record
+- some values are stable runtime constants
+
+## 4. Agent Container Env Consumption
+
+The agent consumes env in two stages:
+
+### Stage 1: shell entrypoint
+
+`docker/entrypoint.sh` reads:
+
+- `CODEX_WORKSPACE_PATH`
+- `CODEX_HOME`
+- `HOME`
+- `XDG_CONFIG_HOME`
+- `CODEX_CONTAINER_MODE`
+- `CODEX_SESSION_ID`
+- `GIT_USER_NAME`
+- `GIT_USER_EMAIL`
+
+It uses those values to:
+
+- choose the writable Codex home
+- seed global config and auth from mounted sources
+- configure global Git identity
+- decide whether to launch `src.agent.main`
+
+### Stage 2: worker runtime
+
+`src/agent/worker.py` loads a smaller normalized settings object:
+
+| Agent env key | Stored as | Used for |
+|---|---|---|
+| `CODEX_WORKSPACE_PATH` | `WorkerSettings.workspace_path` | workspace root |
+| `AGENT_REPO_URL` | `WorkerSettings.repo_url` | clone/fetch source |
+| `AGENT_REPO_REF` | `WorkerSettings.repo_ref` | branch/ref sync |
+| `AGENT_REPO_DIR` | `WorkerSettings.repo_dir_name` | repo checkout dir |
+| `AGENT_STATUS_FILE` | `WorkerSettings.status_file` | status JSON path |
+| `CODEX_HOME` | `WorkerSettings.codex_home` | writable Codex home |
+| `AGENT_READY_POLL_SECONDS` | `WorkerSettings.ready_poll_seconds` | readiness polling |
+
+The worker also reads some env directly instead of storing them in
+`WorkerSettings`:
+
+- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+- `SSH_AUTH_SOCK`
+- `GH_TOKEN`
+- `GITHUB_TOKEN`
+- `GH_TOKEN_FILE`
+- `HOME`
+- `XDG_CONFIG_HOME`
+
+## 5. Name Translation Rules
+
+The main env-name translation patterns are:
+
+| Host-side name | Agent-side name | Reason |
+|---|---|---|
+| `MASTER_CODEX_CONFIG_DIR_PATH` | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | host path becomes in-container mounted source path |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | same pattern for Claude |
+| `MASTER_GIT_USER_NAME` | `AGENT_GIT_USER_NAME` | explicit agent-scoped identity input |
+| `MASTER_GIT_USER_EMAIL` | `AGENT_GIT_USER_EMAIL` | explicit agent-scoped identity input |
+| `CD_*` | none | CD settings stay local to the daemon |
+
+Mount-path translation is just as important as env translation:
+
+| Host path env | In-container mounted path |
+|---|---|
+| `MASTER_CODEX_AUTH_JSON_PATH` | `/run/secrets/codex_auth.json` |
+| `MASTER_CODEX_CONFIG_DIR_PATH` | `/run/secrets/master_codex_config` |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `/run/secrets/master_claude_config` |
+| `MASTER_SSH_AUTH_SOCK_PATH` | `/run/secrets/ssh-auth.sock` |
+
+## 6. Observability
+
+These logs are the main passdown diagnostics:
+
+- `cd.env_load ...`
+- `master.env ...`
+- `master.startup ...`
+- `master.start_agent_config ...`
+- `runtime.create_or_update_agent ...`
+- `agent.entrypoint ...`
+- `agent.worker_settings ...`
+- `agent.workspace_prepare_paths ...`
+
+Use them in order:
+
+1. confirm the container loaded the source env
+2. confirm normalization into settings
+3. confirm master rendered the expected agent env/mount contract
+4. confirm the agent saw the final in-container values
+
+## Related Documents
+
+- `docs/references/config.md`
+- `docs/references/logging.md`
+- `docs/design/containers/master-container-design.md`
+- `docs/design/containers/agent-container-design.md`
+- `docs/design/containers/cd-container-design.md`

--- a/docs/design/containers/environment-variable-passdown-design.md
+++ b/docs/design/containers/environment-variable-passdown-design.md
@@ -16,10 +16,10 @@ Explain the end-to-end environment-variable flow with explicit ownership:
 
 This document focuses on environment flow. It complements:
 
-- `docs/references/config.md`
-- `docs/design/containers/master-container-design.md`
-- `docs/design/containers/agent-container-design.md`
-- `docs/design/containers/cd-container-design.md`
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/design/containers/master-container-design.md`](master-container-design.md)
+- [`docs/design/containers/agent-container-design.md`](agent-container-design.md)
+- [`docs/design/containers/cd-container-design.md`](cd-container-design.md)
 
 ## High-Level Flow
 
@@ -260,8 +260,8 @@ Use them in order:
 
 ## Related Documents
 
-- `docs/references/config.md`
-- `docs/references/logging.md`
-- `docs/design/containers/master-container-design.md`
-- `docs/design/containers/agent-container-design.md`
-- `docs/design/containers/cd-container-design.md`
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
+- [`docs/design/containers/master-container-design.md`](master-container-design.md)
+- [`docs/design/containers/agent-container-design.md`](agent-container-design.md)
+- [`docs/design/containers/cd-container-design.md`](cd-container-design.md)

--- a/docs/design/containers/environment-variable-passdown-design.md
+++ b/docs/design/containers/environment-variable-passdown-design.md
@@ -87,6 +87,19 @@ Important nuance:
 The master container loads env in `src/master/main.py` and normalizes it in
 `src/master/config.py` into `MasterSettings`.
 
+The source of those env vars is:
+
+- `.env` loaded by `load_dotenv()` in `src/master/main.py`
+- the process environment already present in the master container
+- values injected by compose or the container runtime when the master container
+  starts
+
+After that initial load:
+
+- `load_master_settings()` reads and normalizes the source env into
+  `MasterSettings`
+- `MasterService` then passes a selected subset down into agent env or mounts
+
 ### Frontend and process-local settings
 
 | Host env key | Loaded by | Stored as | Used by | Passed to agent |
@@ -110,7 +123,7 @@ These host env vars are loaded into `MasterSettings`, then later transformed by
 vars or mount points.
 
 | Host env key | Stored as | Path type at source | Agent sees env name | Agent sees mount / value |
-|---|---|---|---|
+|---|---|---|---|---|
 | `MASTER_AGENT_BASE_IMAGE` | `agent_base_image` | not a path | none | image reference used at container create/start time |
 | `MASTER_CODEX_AUTH_JSON_PATH` | `agent_codex_auth_json_path` | host path | none | mount at `/run/secrets/codex_auth.json` |
 | `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | host path | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | env value `/run/secrets/master_codex_config` plus matching mount |

--- a/docs/design/containers/environment-variable-passdown-design.md
+++ b/docs/design/containers/environment-variable-passdown-design.md
@@ -42,6 +42,18 @@ flowchart LR
 - Other host inputs are passed as mounts and then represented inside the agent as
   mount paths such as `/run/secrets/...`.
 
+## Path Semantics
+
+For any env var that carries a filesystem path, this document uses three
+different meanings:
+
+- host path
+  - a path on the machine running Podman or compose
+- container-visible path
+  - a path as seen inside the current container process
+- mounted in-container path
+  - the final path exposed inside a downstream container after bind-mounting
+
 ## 1. CD Container Env Flow
 
 The CD container loads env in `src/cd/main.py` and normalizes it in
@@ -97,20 +109,20 @@ These host env vars are loaded into `MasterSettings`, then later transformed by
 `MasterService._build_agent_env()` and `_build_agent_mounts()` into agent env
 vars or mount points.
 
-| Host env key | Stored as | Agent sees env name | Agent sees mount / value |
+| Host env key | Stored as | Path type at source | Agent sees env name | Agent sees mount / value |
 |---|---|---|---|
-| `MASTER_AGENT_BASE_IMAGE` | `agent_base_image` | none | image reference used at container create/start time |
-| `MASTER_CODEX_AUTH_JSON_PATH` | `agent_codex_auth_json_path` | none | mount at `/run/secrets/codex_auth.json` |
-| `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | env value `/run/secrets/master_codex_config` plus matching mount |
-| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `agent_claude_config_dir_path` | `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | env value `/run/secrets/master_claude_config` plus matching mount |
-| `MASTER_SSH_AUTH_SOCK_PATH` | `agent_ssh_auth_sock_path` | `SSH_AUTH_SOCK` | env value `/run/secrets/ssh-auth.sock` plus matching mount |
-| `MASTER_SSH_KNOWN_HOSTS_PATH` | `agent_ssh_known_hosts_path` | `GIT_SSH_COMMAND` | env embeds known-hosts path if configured |
-| `MASTER_GIT_USER_NAME` | `git_user_name` | `AGENT_GIT_USER_NAME` and `GIT_USER_NAME` | string passed through |
-| `MASTER_GIT_USER_EMAIL` | `git_user_email` | `AGENT_GIT_USER_EMAIL` and `GIT_USER_EMAIL` | string passed through |
-| `MASTER_DEFAULT_AGENT_ADAPTER` | `default_agent_adapter` | `AGENT_ADAPTER` | selected per agent record |
-| `MASTER_CODEX_COMMAND_TEMPLATE` | `codex_command_template` | none | used only by master dispatcher |
-| `MASTER_CLAUDE_COMMAND_TEMPLATE` | `claude_command_template` | none | used only by master dispatcher |
-| `MASTER_AGENT_TIMEOUT_SECONDS` | `dispatch_timeout_seconds` | none | used only by master dispatcher |
+| `MASTER_AGENT_BASE_IMAGE` | `agent_base_image` | not a path | none | image reference used at container create/start time |
+| `MASTER_CODEX_AUTH_JSON_PATH` | `agent_codex_auth_json_path` | host path | none | mount at `/run/secrets/codex_auth.json` |
+| `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | host path | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | env value `/run/secrets/master_codex_config` plus matching mount |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `agent_claude_config_dir_path` | host path | `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | env value `/run/secrets/master_claude_config` plus matching mount |
+| `MASTER_SSH_AUTH_SOCK_PATH` | `agent_ssh_auth_sock_path` | host path | `SSH_AUTH_SOCK` | env value `/run/secrets/ssh-auth.sock` plus matching mount |
+| `MASTER_SSH_KNOWN_HOSTS_PATH` | `agent_ssh_known_hosts_path` | host path | `GIT_SSH_COMMAND` | env embeds mounted in-container path `/run/secrets/ssh_known_hosts` if configured |
+| `MASTER_GIT_USER_NAME` | `git_user_name` | not a path | `AGENT_GIT_USER_NAME` | string passed through |
+| `MASTER_GIT_USER_EMAIL` | `git_user_email` | not a path | `AGENT_GIT_USER_EMAIL` | string passed through |
+| `MASTER_DEFAULT_AGENT_ADAPTER` | `default_agent_adapter` | not a path | `AGENT_ADAPTER` | selected per agent record |
+| `MASTER_CODEX_COMMAND_TEMPLATE` | `codex_command_template` | not a path | none | used only by master dispatcher |
+| `MASTER_CLAUDE_COMMAND_TEMPLATE` | `claude_command_template` | not a path | none | used only by master dispatcher |
+| `MASTER_AGENT_TIMEOUT_SECONDS` | `dispatch_timeout_seconds` | not a path | none | used only by master dispatcher |
 
 ### Auto-detected master env
 
@@ -144,21 +156,21 @@ The important agent env keys built by master are:
 | Agent env key | Built from | Consumed by |
 |---|---|---|
 | `HOME` | fixed runtime contract | entrypoint and worker |
-| `XDG_CONFIG_HOME` | fixed runtime contract | entrypoint and worker |
-| `CODEX_HOME` | fixed runtime contract | entrypoint and worker |
-| `AGENT_REPO_DIR` | fixed runtime contract / registry | worker |
-| `AGENT_REPO_URL` | agent record `repo_source` | worker |
-| `AGENT_REPO_REF` | agent record `repo_ref` | worker |
-| `AGENT_ADAPTER` | agent record or master default | dispatch-time semantics and logs |
-| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | master mount contract | worker |
-| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | master mount contract | worker |
-| `AGENT_GIT_USER_NAME` | `MASTER_GIT_USER_NAME` | worker |
-| `AGENT_GIT_USER_EMAIL` | `MASTER_GIT_USER_EMAIL` | worker |
-| `SSH_AUTH_SOCK` | SSH mount contract | worker / git |
-| `GIT_SSH_COMMAND` | known-hosts handling | git subprocesses |
-| `GH_TOKEN` | host runtime env | worker preflight / git auth |
-| `OPENAI_API_KEY` | host runtime env | Codex runtime |
-| `CLAUDE_CODE_OAUTH_TOKEN` | host runtime env | Claude runtime |
+| `XDG_CONFIG_HOME` | fixed runtime contract; container path | entrypoint and worker |
+| `CODEX_HOME` | fixed runtime contract; container path | entrypoint and worker |
+| `AGENT_REPO_DIR` | fixed runtime contract / registry; relative container path fragment | worker |
+| `AGENT_REPO_URL` | agent record `repo_source`; not a path | worker |
+| `AGENT_REPO_REF` | agent record `repo_ref`; not a path | worker |
+| `AGENT_ADAPTER` | agent record or master default; not a path | dispatch-time semantics and logs |
+| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | master mount contract; mounted in-container path | worker |
+| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | master mount contract; mounted in-container path | worker |
+| `AGENT_GIT_USER_NAME` | `MASTER_GIT_USER_NAME`; not a path | worker |
+| `AGENT_GIT_USER_EMAIL` | `MASTER_GIT_USER_EMAIL`; not a path | worker |
+| `SSH_AUTH_SOCK` | SSH mount contract; mounted in-container path | worker / git |
+| `GIT_SSH_COMMAND` | known-hosts handling; string containing mounted in-container path when configured | git subprocesses |
+| `GH_TOKEN` | host runtime env; not a path | worker preflight / git auth |
+| `OPENAI_API_KEY` | host runtime env; not a path | Codex runtime |
+| `CLAUDE_CODE_OAUTH_TOKEN` | host runtime env; not a path | Claude runtime |
 
 Important nuance:
 
@@ -176,9 +188,13 @@ The agent consumes env in two stages:
 `docker/entrypoint.sh` reads:
 
 - `CODEX_WORKSPACE_PATH`
+  - container-visible path inside the agent
 - `CODEX_HOME`
+  - container-visible path inside the agent
 - `HOME`
+  - container-visible path inside the agent
 - `XDG_CONFIG_HOME`
+  - container-visible path inside the agent
 - `CODEX_CONTAINER_MODE`
 - `CODEX_SESSION_ID`
 - `GIT_USER_NAME`
@@ -197,12 +213,12 @@ It uses those values to:
 
 | Agent env key | Stored as | Used for |
 |---|---|---|
-| `CODEX_WORKSPACE_PATH` | `WorkerSettings.workspace_path` | workspace root |
-| `AGENT_REPO_URL` | `WorkerSettings.repo_url` | clone/fetch source |
+| `CODEX_WORKSPACE_PATH` | `WorkerSettings.workspace_path` | container path for workspace root |
+| `AGENT_REPO_URL` | `WorkerSettings.repo_url` | repo source string, not a path |
 | `AGENT_REPO_REF` | `WorkerSettings.repo_ref` | branch/ref sync |
-| `AGENT_REPO_DIR` | `WorkerSettings.repo_dir_name` | repo checkout dir |
-| `AGENT_STATUS_FILE` | `WorkerSettings.status_file` | status JSON path |
-| `CODEX_HOME` | `WorkerSettings.codex_home` | writable Codex home |
+| `AGENT_REPO_DIR` | `WorkerSettings.repo_dir_name` | relative checkout dir name inside the workspace |
+| `AGENT_STATUS_FILE` | `WorkerSettings.status_file` | container path for the status JSON file |
+| `CODEX_HOME` | `WorkerSettings.codex_home` | container path for the writable Codex home |
 | `AGENT_READY_POLL_SECONDS` | `WorkerSettings.ready_poll_seconds` | readiness polling |
 
 The worker also reads some env directly instead of storing them in

--- a/docs/design/containers/master-container-design.md
+++ b/docs/design/containers/master-container-design.md
@@ -18,6 +18,8 @@ This document describes the container itself. It complements:
 - `docs/design/master-agent-interface-design.md`
 - `docs/design/frontend-master-interface-design.md`
 - `docs/guides/runbooks/master-agent.md`
+- `docs/references/config.md`
+- `docs/references/logging.md`
 
 ## Responsibilities
 
@@ -253,5 +255,8 @@ The master container must preserve these invariants:
 
 - `docs/design/master-agent-interface-design.md`
 - `docs/design/frontend-master-interface-design.md`
+- `docs/design/containers/environment-variable-passdown-design.md`
 - `docs/guides/runbooks/master-agent.md`
+- `docs/references/config.md`
+- `docs/references/logging.md`
 - `docs/guides/runbooks/cd-daemon.md`

--- a/docs/design/containers/master-container-design.md
+++ b/docs/design/containers/master-container-design.md
@@ -15,11 +15,11 @@ Define the behavior of the master container as a runtime unit:
 
 This document describes the container itself. It complements:
 
-- `docs/design/master-agent-interface-design.md`
-- `docs/design/frontend-master-interface-design.md`
-- `docs/guides/runbooks/master-agent.md`
-- `docs/references/config.md`
-- `docs/references/logging.md`
+- [`docs/design/master-agent-interface-design.md`](../master-agent-interface-design.md)
+- [`docs/design/frontend-master-interface-design.md`](../frontend-master-interface-design.md)
+- [`docs/guides/runbooks/master-agent.md`](../../guides/runbooks/master-agent.md)
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
 
 ## Responsibilities
 
@@ -129,8 +129,8 @@ The master is the only control plane for agents. It injects:
 
 Detailed agent-side semantics belong in:
 
-- `docs/design/agent-container-runtime-design.md`
-- `docs/design/master-agent-interface-design.md`
+- [`docs/design/agent-container-runtime-design.md`](../agent-container-runtime-design.md)
+- [`docs/design/master-agent-interface-design.md`](../master-agent-interface-design.md)
 
 ## Lifecycle
 
@@ -253,10 +253,10 @@ The master container must preserve these invariants:
 
 ## Related Documents
 
-- `docs/design/master-agent-interface-design.md`
-- `docs/design/frontend-master-interface-design.md`
-- `docs/design/containers/environment-variable-passdown-design.md`
-- `docs/guides/runbooks/master-agent.md`
-- `docs/references/config.md`
-- `docs/references/logging.md`
-- `docs/guides/runbooks/cd-daemon.md`
+- [`docs/design/master-agent-interface-design.md`](../master-agent-interface-design.md)
+- [`docs/design/frontend-master-interface-design.md`](../frontend-master-interface-design.md)
+- [`docs/design/containers/environment-variable-passdown-design.md`](environment-variable-passdown-design.md)
+- [`docs/guides/runbooks/master-agent.md`](../../guides/runbooks/master-agent.md)
+- [`docs/references/config.md`](../../references/config.md)
+- [`docs/references/logging.md`](../../references/logging.md)
+- [`docs/guides/runbooks/cd-daemon.md`](../../guides/runbooks/cd-daemon.md)

--- a/docs/design/containers/master-container-design.md
+++ b/docs/design/containers/master-container-design.md
@@ -1,0 +1,257 @@
+# Master Container Design
+
+**Status:** canonical design  
+**Scope:** the `master` control-plane container started with `python -m src.master.main`
+
+## Goal
+
+Define the behavior of the master container as a runtime unit:
+
+- startup path and process model
+- external and internal interface contracts
+- lifecycle and state transitions
+- durable versus transient storage
+- operational observability and failure boundaries
+
+This document describes the container itself. It complements:
+
+- `docs/design/master-agent-interface-design.md`
+- `docs/design/frontend-master-interface-design.md`
+- `docs/guides/runbooks/master-agent.md`
+
+## Responsibilities
+
+The master container is the system control plane. It is responsible for:
+
+- loading runtime settings from environment
+- starting the configured frontends
+- accepting admin commands from Slack and Discord
+- owning the agent registry and thread-routing state
+- provisioning repos and channels when requested
+- creating, starting, stopping, removing, and inspecting agent containers
+- dispatching user prompts into running agent containers
+
+The master container does not:
+
+- execute coding work itself
+- keep durable repository workspaces for agents
+- act as the CD daemon
+
+## Process Model
+
+Unlike the agent image, the master container does not rely on a custom shell
+entrypoint flow for normal behavior. Its startup path is the Python process in
+`src/master/main.py`.
+
+Startup sequence:
+
+1. load `.env` values
+2. configure logging
+3. install the SIGTERM dispatch guard
+4. load `MasterSettings`
+5. initialize the registry and migrate schema if needed
+6. construct runtime, service, router, dispatcher, rate-limiter, and
+   provisioning components
+7. start the enabled frontends as background threads
+8. join those frontend threads for the life of the process
+
+## Startup Flow
+
+```mermaid
+flowchart TD
+    A[Container starts] --> B[python -m src.master.main]
+    B --> C[load_dotenv + configure_logging]
+    C --> D[install_sigterm_handler]
+    D --> E[load_master_settings]
+    E --> F[init AgentRegistry]
+    F --> G[migrate schema if needed]
+    G --> H[construct runtime/service/router/dispatchers]
+    H --> I{frontends enabled}
+    I -->|slack| J[start Slack Socket Mode thread]
+    I -->|discord| K[start Discord thread]
+    J --> L[join threads]
+    K --> L
+```
+
+## Runtime Components
+
+The master process composes these main subsystems:
+
+- `AgentRegistry`
+  - persists logical agent records and routing metadata
+- `MasterService`
+  - owns command-side lifecycle operations
+- `PodmanRuntimeAdapter`
+  - translates lifecycle operations into container runtime commands
+- `ChannelRouter`
+  - maps incoming frontend traffic to the correct agent
+- `PodmanExecDispatcher` / `ClaudeCodeDispatcher`
+  - executes the adapter command inside the target agent container
+- frontend adapters
+  - Slack Socket Mode app
+  - Discord bot client
+- provisioning helpers
+  - GitHub repo creation
+  - frontend-specific channel creation
+
+## Interface Contracts
+
+### Inbound Interfaces
+
+The master container accepts input through:
+
+- Slack events and slash-command style admin messages
+- Discord messages in configured admin or routed channels
+- environment variables at process startup
+- host Podman socket access for container control
+
+### Outbound Interfaces
+
+The master container emits output through:
+
+- Slack replies
+- Discord replies
+- GitHub API calls for provisioning flows
+- Podman operations against agent containers
+- structured logs to stdout/stderr
+
+### Internal Contract to Agent Containers
+
+The master is the only control plane for agents. It injects:
+
+- environment variables such as `HOME`, `CODEX_HOME`, `AGENT_REPO_URL`,
+  `AGENT_REPO_REF`, `AGENT_FRONTEND`, and adapter selection
+- shared mounts such as workspace volume, auth seed, global config, SSH agent
+  socket, and transient request storage
+- prompt dispatch via `podman exec`
+
+Detailed agent-side semantics belong in:
+
+- `docs/design/agent-container-runtime-design.md`
+- `docs/design/master-agent-interface-design.md`
+
+## Lifecycle
+
+### Container Lifecycle
+
+The master container has a simple host-managed lifecycle:
+
+- created
+- running
+- stopped
+- replaced by CD or operator action
+
+It is intentionally stateless in memory. Durable state lives on mounted storage.
+
+### Service Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Starting
+    Starting --> Running: settings loaded and frontend threads started
+    Running --> Draining: SIGTERM received
+    Draining --> Stopped: process exits
+    Running --> Failed: uncaught startup/thread failure
+    Failed --> [*]
+    Stopped --> [*]
+```
+
+### Agent Lifecycle Owned by Master
+
+The master also owns the logical lifecycle of agents:
+
+- `loaded`
+- `running`
+- `stopped`
+- `error`
+
+Those are registry states, not master-container states.
+
+## Storage Model
+
+The master container should treat all durable state as mounted host-backed data.
+
+Primary durable paths:
+
+- `data/master/agents.json`
+  - agent registry
+- `data/master/thread_state.json` or configured equivalent
+  - tracked conversation threads and routing continuity
+
+Operationally important mounted inputs:
+
+- compose-provided environment
+- Podman socket
+- host auth/config paths
+- optional SSH socket and known-hosts inputs
+
+The master container should not store durable agent repo state inside its own
+filesystem layer. Agent workspaces belong to agent containers and their volumes.
+
+## Storage Boundaries
+
+| Path / resource | Owner | Durability | Notes |
+|---|---|---|---|
+| `data/master/agents.json` | master | durable | registry source of truth |
+| thread state file | master | durable | routing continuity |
+| process memory | master | transient | rebuilt on restart |
+| agent workspace volumes | agent runtime | durable | not owned by master filesystem |
+| `/workspace/message/...` in agent | master-created input | transient | request-scoped only |
+
+## Failure Model
+
+The master container is expected to survive and report:
+
+- invalid configuration at startup
+- frontend authentication failure
+- agent build/start/stop/remove errors
+- prompt dispatch timeouts and command failures
+- provisioning failures
+
+Failure boundaries:
+
+- frontend/process startup failures can fail the whole container
+- agent runtime failures should not crash the master process
+- dispatch failures should be contained to the specific request
+
+## Observability
+
+Key startup and lifecycle logs include:
+
+- `master.startup`
+- `master.frontend_started`
+- `master.registry_schema_migrated`
+- `master.start_agent_config`
+- `runtime.create_or_update_agent`
+- command audit logs
+- router dispatch logs
+
+The master container should be diagnosable from logs plus:
+
+- registry file contents
+- thread state file contents
+- Podman container inspect output for the managed agents
+
+## Operational Invariants
+
+The master container must preserve these invariants:
+
+- it is the only control plane for agent containers
+- registry and thread state are durable across container restart
+- agent work happens in agent containers, not inside the master process
+- request staging is transient and isolated from durable repo state
+- frontend adapters may differ, but they share the same service and router core
+
+## Operator Notes
+
+- Restarting or replacing the master container must not wipe `agents.json` or
+  thread state if the data mount is correct.
+- The container must have access to the host Podman socket to manage agents.
+- Provisioning features additionally depend on GitHub and frontend permissions.
+
+## Related Documents
+
+- `docs/design/master-agent-interface-design.md`
+- `docs/design/frontend-master-interface-design.md`
+- `docs/guides/runbooks/master-agent.md`
+- `docs/guides/runbooks/cd-daemon.md`

--- a/docs/design/master-agent-architecture.md
+++ b/docs/design/master-agent-architecture.md
@@ -1,500 +1,311 @@
-# Master-Agent Architecture (Draft / Historical Context)
+# Master-Agent Architecture
 
-This is a living design document for extending this project from a single Slack-connected agent into a master -> agent orchestration model.
+**Status:** canonical design  
+**Scope:** system-level architecture for the master control plane, agent worker
+containers, frontends, and CD daemon
 
 ## Goal
-- Keep the current container as the **agent runtime**.
-- Introduce a **master container** that accepts control commands from Slack and manages agent containers for different repos/channels.
-- For v1, the master manages containers via host Podman (socket passthrough), not a nested container daemon.
-- v1 design decisions are frozen for implementation; only runtime-config editability remains open for follow-up.
 
-## Roles
-### Master Container (Control Plane)
-- Listens in one admin Slack channel.
-- Creates/starts/stops/removes agent containers.
-- Maintains agent registry/state on disk.
-- Applies policy checks (allowed repo paths, channel mapping, naming).
-- Surfaces status/logs back to Slack.
+Define the current architecture of the multi-agent system at the highest level:
 
-### Agent Container (Worker Plane)
-- Existing `codex-slack-bot` image.
-- One target repo per container.
-- Runs Codex prompts for that project only.
-- In v1 single-bot mode, does not connect to Slack directly (master forwards work).
+- major runtime components
+- control-plane and data-plane boundaries
+- startup and lifecycle relationships
+- storage and trust boundaries
+- how the more detailed design documents fit together
 
-## Core Principle
-- Separate orchestration from execution.
-- Master should not execute user coding prompts.
-- Agents should not manage other containers.
+This document is the system-level overview. It does not replace the lower-level
+contract documents.
 
-## Implemented Slack UX (Master v1)
-- `/master-agent-list`
-- `/master-agent-load <name> <repo_path> <channel_id> [branch]`
-- `/master-agent-start <name>`
-- `/master-agent-stop <name>`
-- `/master-agent-status <name>`
-- `/master-agent-remove <name>`
-- `/master-agent-refresh-auth <name>`
+## Architecture Summary
 
-Historical note:
-- Earlier options such as `/master-agent-rm`, `/master-agent-logs`, and bind/unbind commands are design artifacts and are not part of the current implemented v1 command set.
+The system is split into four runtime roles:
 
-## V1 Master Command Contract (Draft)
-This section defines the initial command surface to support the agreed v1 start flow.
+- frontend adapters
+  - Slack and Discord event intake and response emission
+- master container
+  - orchestration control plane
+- agent containers
+  - per-repository worker runtimes
+- CD daemon container
+  - deploy automation for the master container
 
-### Principles
-- Keep commands explicit and small.
-- Separate "register/load" from "start runtime" for clearer error handling.
-- Support idempotent retries from Slack.
-- Do not accept raw secrets in command arguments.
+Core principle:
 
-### Commands (v1)
-#### `/master-agent-load <name> <repo_path> <channel_id>`
-Purpose:
-- Register or update an agent definition.
-- Validate repo path and channel mapping.
-- Load project `main` branch and evaluate `.prj_assistant/image/Dockerfile`.
-- Resolve build-vs-default image plan (build is executed by `start` in v1).
+- orchestration belongs to master
+- execution belongs to agents
+- deployment automation belongs to CD
+- platform-specific chat behavior belongs to the frontend adapters
 
-Effects:
-- Mutates registry.
-- May create/update rendered config.
-- Does not need to start container (recommended default).
-- Binds `channel_id` to `name` if binding is available and not already owned by another agent.
+## Runtime Roles
 
-Input rules:
-- `name`: `^[a-z0-9][a-z0-9-]{1,30}$`
-- `repo_path`: Git URL or approved repo identifier (resolved by master policy)
-- `channel_id`: Slack channel ID (`C...`)
-- v1 requires `channel_id` as command input; channel-name resolution is out of scope.
+### Master Container
 
-#### `/master-agent-start <name>`
-Purpose:
-- Build project image if required by resolved plan, then start agent container from built/default image and rendered config.
+The master container is the control plane. It is responsible for:
 
-Effects:
-- Mutates runtime state.
-- Updates observed status in registry.
+- starting frontend adapters
+- owning the agent registry and tracked thread state
+- handling admin commands such as load, start, stop, status, remove, and
+  provisioning
+- creating, recreating, inspecting, and removing agent containers through
+  Podman
+- routing prompts from mapped channels to the correct agent
+- staging transient request input
 
-#### `/master-agent-stop <name>`
-Purpose:
-- Stop a running agent container.
+### Agent Containers
 
-Effects:
-- Mutates runtime state.
-- Updates observed status in registry.
+Each agent container is a worker plane for exactly one repo at a time. It is
+responsible for:
 
-#### `/master-agent-status <name>`
-Purpose:
-- Show registry data + observed runtime/container status.
+- preparing writable runtime homes
+- syncing the target repo into its workspace
+- consuming mounted auth, config, and request-manifest inputs
+- executing Codex or Claude Code
+- writing durable work back into the repo workspace
 
-Effects:
-- Read-only.
+### Frontend Adapters
 
-#### `/master-agent-list`
-Purpose:
-- List registered agents and summarized states.
+Slack and Discord frontends are responsible for:
 
-Effects:
-- Read-only.
+- chat-platform event intake
+- admin-command parsing and validation at the platform boundary
+- attachment extraction and staging inputs
+- emitting platform-safe replies back to users
 
-#### `/master-agent-remove <name>`
-Purpose:
-- Remove agent registration and optionally remove container (stopped first if running).
+### CD Daemon
 
-Effects:
-- Mutates registry and runtime state.
+The CD daemon is a separate deployment runtime. It is responsible for:
 
-### Command Response Contract (v1)
-All command handlers should return a shared envelope:
+- polling the registry for new master images
+- redeploying the master container through compose
+- rolling back the master container if health checks fail
 
-```json
-{
-  "ok": true,
-  "command": "load",
-  "agent": "payments-api",
-  "code": "OK",
-  "message": "Agent loaded",
-  "data": {},
-  "request_id": "req_01HT...",
-  "at": "2026-02-27T00:00:00Z"
-}
+## System Diagram
+
+```mermaid
+flowchart LR
+    U[Operators / Users]
+    S[Slack Frontend]
+    D[Discord Frontend]
+    M[Master Container]
+    R[(Agent Registry\nThread State)]
+    P[Podman Runtime]
+    A1[Agent Container A]
+    A2[Agent Container B]
+    G[(GitHub / Git remotes)]
+    C[CD Daemon]
+    H[(GHCR / Image Registry)]
+
+    U --> S
+    U --> D
+    S --> M
+    D --> M
+    M <--> R
+    M --> P
+    P --> A1
+    P --> A2
+    A1 <--> G
+    A2 <--> G
+    C --> H
+    C --> M
 ```
 
-Fields:
-- `ok`: success/failure boolean.
-- `command`: normalized command (`list|load|start|stop|status|remove`).
-- `agent`: target agent when applicable.
-- `code`: stable machine code.
-- `message`: concise user-facing summary for Slack.
-- `data`: command-specific payload.
-- `request_id`: correlation ID for logs/debug.
-- `at`: RFC3339 timestamp.
+## Control Plane vs Data Plane
 
-`data` payload by command:
-- `load`: `state`, `image_plan`, `build_source`, `channel_id`.
-- `start`: `state`, `container_name`, `container_id`, `started_at`.
-- `stop`: `state`, `container_name`, `stopped_at`.
-- `status`: registry + observed runtime snapshot.
-- `list`: list of agents with summary status.
-- `remove`: `removed=true`, optional runtime cleanup notes.
+### Control Plane
 
-### Error Code Contract (v1)
-Use stable error codes in Slack and logs:
-- `ERR_INVALID_ARGS`: command argument validation failed.
-- `ERR_AGENT_NOT_FOUND`: target agent missing from registry.
-- `ERR_CHANNEL_CONFLICT`: channel already bound to another agent.
-- `ERR_REPO_NOT_ALLOWED`: repo outside policy or unresolvable.
-- `ERR_LOAD_FAILED`: repo load or manifest parse failed.
-- `ERR_BUILD_FAILED`: image build failed.
-- `ERR_RUNTIME_FAILED`: Podman start/stop/inspect failed.
-- `ERR_AGENT_NOT_RUNNING`: stop/status path expected running container but none found.
-- `ERR_INTERNAL`: unexpected master failure.
+The control plane covers:
 
-### Optional Convenience Command (v1.1)
-#### `/master-agent-up <name> <repo_path> <channel_id>`
-Wrapper for:
-1. `load`
-2. `start`
+- container lifecycle operations
+- registry updates
+- provisioning
+- command execution
+- thread and channel mapping
 
-This is optional sugar. Internally it should call the same service methods as `load` + `start`.
+Owner:
 
-## V1 Workflow / State Machine (Draft)
-Master manages agent lifecycle state independently from the container engine.
+- master container
 
-### Logical States
-- `registered`: repo/channel recorded, not yet resolved
-- `loaded`: repo checked, start plan resolved (default image or build plan)
-- `built`: custom image built successfully (only for Dockerfile path case)
-- `running`: container running
-- `stopped`: container exists but not running (or intentionally stopped)
-- `error`: last operation failed (registry retains error details)
+### Data Plane
 
-### Common Transitions
-- `load`:
-  - `registered|stopped|error -> loaded`
-  - `loaded -> loaded` (idempotent refresh)
-  - `running -> loaded` only if load is allowed to refresh config without restart (mark drift)
-- `start`:
-  - `loaded|built|stopped|error -> running` (if prerequisites met)
-  - `running -> running` (idempotent no-op)
-- `stop`:
-  - `running -> stopped`
-  - `stopped -> stopped` (idempotent no-op)
-- `remove`:
-  - any non-running state -> removed (registry deletion)
-  - `running` requires stop first or `--force` policy (not in v1 Slack command)
+The data plane covers:
 
-### Idempotency Rules (Important)
-- Repeating `load` should refresh and re-evaluate `.prj_assistant/image/Dockerfile` presence.
-- Repeating `start` on a running agent should return success with "already running".
-- Repeating `stop` on a stopped/missing runtime should return success with "already stopped".
-- `remove` on missing agent should return a not-found error (not success), to catch mistakes.
+- user prompts flowing from frontend to agent
+- staged attachments and request manifests
+- agent stdout/result text flowing back to the frontend
 
-### Error Reporting (Slack)
-Responses should include:
-- failed stage (`validate_repo`, `load_main_branch`, `build_image`, `start_container`, ...)
-- short error summary
-- suggested next action when obvious (`run load again`, `fix Dockerfile`, `check repo path`)
+Owners:
 
-### Slack Output Examples (v1)
-`/master-agent-load payments-api github.com/acme/payments C12345`
-- success: `OK load payments-api | state=loaded | image=ghcr.io/acme/codex-slack-bot:latest | channel=C12345`
-- conflict: `ERR_CHANNEL_CONFLICT load payments-api | channel C12345 is already bound to agent billing-api`
+- frontend adapters
+- master router/dispatcher
+- agent runtime
 
-`/master-agent-start payments-api`
-- success: `OK start payments-api | state=running | container=agent-payments-api`
-- idempotent: `OK start payments-api | already running`
+## Control-Plane Flow
 
-`/master-agent-stop payments-api`
-- success: `OK stop payments-api | state=stopped`
-- idempotent: `OK stop payments-api | already stopped`
+Example: `/master-agent-start <name>`
 
-## Slack Topology and Routing (V1, Selected)
-### Topology
-- One Slack app / bot token for the whole system.
-- Master is the only Slack client (single Socket Mode connection).
-- Agent containers are worker runtimes and do not connect to Slack directly.
+```mermaid
+sequenceDiagram
+    participant OP as Operator
+    participant FE as Frontend Adapter
+    participant M as MasterService
+    participant RT as PodmanRuntimeAdapter
+    participant REG as AgentRegistry
+    participant AG as Agent Container
 
-### Channel Roles
-- **Admin channel(s)**: accepted for master orchestration commands only.
-- **Agent channels**: user prompts routed to exactly one mapped agent.
-
-### Channel Ownership Rule
-- One channel maps to one agent.
-- Channel binding key is always Slack `channel_id` in v1.
-
-V1 default:
-- one channel <-> one agent (strict)
-
-### Channel Conflict Handling (V1)
-When `/master-agent-load ... <channel_id>` is called:
-- If channel is unbound: bind it to the agent.
-- If channel is already bound to the same agent: idempotent success.
-- If channel is bound to a different agent: reject with conflict error.
-- Rebinding is done manually in v1: unbind old mapping, then bind/load again.
-
-### Routing Rules (Agent Communication)
-For messages in non-admin channels:
-1. Master receives Slack event.
-2. Master resolves `channel_id -> agent`.
-3. If no mapping exists: ignore or reply with setup hint (policy configurable).
-4. If mapping exists: forward prompt to that agent worker.
-5. Agent returns response.
-6. Master posts response to Slack (same thread when applicable).
-
-### Thread Behavior (Recommended)
-- Reuse current thread semantics already implemented in this project:
-  - initial mention starts a tracked thread
-  - follow-up thread replies continue without repeated mention
-- Master owns thread tracking and routing in the single-bot model.
-
-## Runtime Interface (Master -> Container Engine)
-Use Podman in v1 via a thin runtime adapter:
-- `create_or_update_agent(config)`
-- `start_agent(name)`
-- `stop_agent(name)`
-- `remove_agent(name)`
-- `inspect_agent(name)`
-- `tail_logs(name, lines)`
-
-Start with CLI invocation (`podman`), not daemon APIs.
-
-## Master-In-Container Runtime Model (V1, Selected)
-Master runs as a container and controls host Podman through a mounted Podman socket.
-
-Execution model:
-1. Host exposes Podman service socket.
-2. Master container mounts that socket read/write.
-3. Master invokes `podman` client/remote against the mounted socket.
-4. Podman service on host creates/stops agent containers.
-
-Socket path options:
-- Rootful host Podman: `/run/podman/podman.sock`
-- Rootless host Podman: `/run/user/<uid>/podman/podman.sock`
-
-Required master container runtime wiring (v1):
-- Mount Podman socket into master container.
-- Provide Podman client binary in master image.
-- Set connection target (`CONTAINER_HOST=unix:///.../podman.sock`) or equivalent CLI flag.
-
-Guardrails:
-- Treat socket access as privileged control-plane capability.
-- Restrict which images/containers master may create (name prefix + project policy).
-- Keep master deployment limited to trusted infra/operators.
-
-## Registry (Initial)
-Store in repo-local data files:
-- `data/master/agents.json` (source of truth)
-- `build/agents/<name>.compose.yml` (rendered runtime config)
-
-Per-agent fields (v1):
-- `name`, `repo_path`, `channel_id`, `container_name`
-- `image`, `runtime` (`podman`)
-- `codex_session_id` (optional)
-- `git_user_name`, `git_user_email` (optional)
-- `gh_token_ref` (optional; do not store raw secret in registry)
-- `status` (observed), `created_at`, `updated_at`
-
-## Security Boundaries
-- One shared Slack app/token set for the system in v1; master is the only Slack client.
-- No raw secrets entered in Slack commands.
-- Secret references use file paths in v1 (host-mounted into master/agent).
-- Restrict master-managed repo paths to approved prefixes.
-- Restrict generated container names to safe pattern.
-
-## Failure Model
-- Master command succeeds but agent fails to start:
-  - Registry persists desired state + error message.
-- Agent crashes:
-  - Master reports status and restart option.
-- Slack outage:
-  - Master/agents continue local state; recover on reconnect.
-
-## Open Design Questions
-1. How much of runtime config should be user-editable from Slack?
-
-### Runtime Config Editability (Discussion Focus)
-For further discussion:
-- Which fields are editable from Slack after `load` (for example `git_user_*`, resource limits, image override)?
-- Which fields require re-`load` vs full `stop/start` to take effect?
-- Which fields are immutable post-create in v1 (for example `repo_path`, `channel_id`)?
-
-## Discussion Topics (Current)
-### 1. Per-Project Toolchains (C++, Go, etc.)
-- Option A: one generic agent image + project-provided image override (selected for v1).
-- Option B: language/profile-specific agent images managed by master (future hardening path).
-- Option C: devcontainer/Nix per project (powerful, higher complexity).
-
-Recommended direction (v1, private team):
-- Default to one base agent image.
-- Allow project manifest to specify a custom image or Dockerfile build context under policy.
-- Keep decisions simple because both master and project repos are team-controlled.
-
-#### Image Selection (Proposed Resolution Order, Simplified v1)
-When creating a new agent, master selects the image/profile using this precedence:
-1. Explicit `image_override` provided by admin (highest priority).
-2. Project manifest in repo (for example `.prj_assistant/agent.toml`) declaring image override/build config.
-3. Default image (`codex-slack-bot:latest` or configured team default).
-
-Master should persist both:
-- `resolved_profile` (optional in v1; may always be `default`)
-- `resolved_image`
-
-This makes decisions auditable and stable across restarts.
-
-#### Start Agent Flow (v1 Baseline, Agreed)
-This is the revised v1 start flow (managed clone workspace):
-
-1. Master is instructed to load a project repo (repo URL / repo identifier).
-2. Master resolves the project source and checks project `main` branch contents for `.prj_assistant/image/Dockerfile`.
-3. If found:
-   - record build plan (`.prj_assistant/image/`) in agent registry
-4. If not found:
-   - use the default agent image
-5. Master starts agent container with:
-   - image build step first when a project Dockerfile plan exists
-   - a named volume for workspace storage
-   - shared SSH agent and/or `GH_TOKEN` references for Git operations
-6. Agent container initialization clones/fetches the repo into its internal workspace volume.
-7. Agent completes initialization stages and then runs the worker process for prompt execution.
-
-Notes:
-- This flow intentionally avoids mutating a host repo working tree.
-- "Dirty repo" host working tree concerns are removed from the default path.
-- Branch strategy and sync policy are intentionally deferred to project-level decisions (out of current scope).
-- In v1, image build happens during `start`, not `load`.
-
-#### Agent Initialization Stages (Selected v1)
-In v1, agent container startup is a staged entrypoint flow with no always-on control service.
-
-Stages:
-1. `preflight`: verify required env and credentials (`SSH_AUTH_SOCK` and/or `GH_TOKEN` ref), verify writable workspace volume.
-2. `repo_sync`: clone repo if missing; otherwise fetch/reset according to project policy.
-3. `workspace_prepare`: apply repo-local setup needed for agent runtime (for example `.codex` bootstrap if configured).
-4. `ready`: launch the agent worker process (no Slack client in agent).
-
-Status feedback to master (without in-agent service):
-- Container lifecycle state via Podman inspect (`created`, `running`, `exited`).
-- Structured stage logs emitted to stdout/stderr (master tails and parses markers).
-- Optional init status file in shared control path (for example `/run/master-agent/status.json`) written during stages.
-
-Failure behavior:
-- Any failed stage exits container with non-zero code.
-- Master records failed stage + exit code + last log lines into registry and reports to Slack.
-
-#### Project Requirements Manifest (Proposed v1)
-Allow each repo to define non-secret requirements in a project-owned file, e.g. `.prj_assistant/agent.toml`:
-
-```toml
-image_override = ""
-
-[image]
-# One of:
-# - prebuilt image name
-# - Dockerfile path under `.prj_assistant/image/`
-name = "ghcr.io/myorg/codex-agent-cpp:team-v1"
-dockerfile = ".prj_assistant/image/Dockerfile"
-context = ".prj_assistant/image"
-
-[runtime]
-workspace_mode = "named_volume"
-codex_home_mode = "project"
+    OP->>FE: /master-agent-start <name>
+    FE->>M: start_agent(name)
+    M->>REG: load agent record
+    M->>RT: pull image or build project image
+    M->>RT: create_or_update_agent(...)
+    M->>RT: start_agent(...)
+    RT->>AG: container starts
+    M->>REG: persist status=running
+    M-->>FE: CommandResult
+    FE-->>OP: platform-safe response
 ```
 
-Rules:
-- Manifest is advisory, not authoritative.
-- Master validates values against policy (allowed image prefixes, allowed Dockerfile paths/contexts).
-- Secrets/tokens are not allowed in the project manifest.
-- Project-specific image build assets live under `.prj_assistant/image/`.
-- In v1, presence of `.prj_assistant/image/Dockerfile` is the primary image-build trigger.
-- Branch strategy / sync behavior are intentionally not defined by this manifest in v1.
+## Routed Prompt Flow
 
-#### Managing Images in v1 (Team-Controlled)
-Given a private, team-controlled environment:
-- Master may accept project manifest image overrides and Dockerfile-based builds.
-- Dockerfile path and build context must be constrained to repo-local paths.
-- Master should record the resolved image/build source for auditability.
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Frontend Adapter
+    participant RT as ChannelRouter
+    participant DISP as Dispatcher
+    participant AG as Agent Container
 
-Safety guardrails still recommended (even in private use):
-- Restrict Dockerfile/context to under repo root after `realpath` resolution.
-- Optional allowlist for image prefixes (e.g. `ghcr.io/myorg/`).
-- Build/run with explicit resource limits where possible.
+    U->>FE: mention / follow-up message
+    FE->>RT: normalized prompt + attachments
+    RT->>RT: validate mapping and thread continuity
+    RT->>RT: stage request input if needed
+    RT->>DISP: dispatch prompt
+    DISP->>AG: podman exec / adapter command
+    AG-->>DISP: response text
+    DISP-->>RT: normalized result
+    RT-->>FE: routed response
+    FE-->>U: platform-safe reply
+```
 
-### 3. Workspace Storage Model (Host Mount vs Container Internal)
-- **Selected for revised v1:** named volume per agent (container-managed workspace storage).
-- Agent clones/fetches the repo during initialization instead of using a host bind mount.
-- Host bind mount mode can remain as an optional fallback/debug mode later.
+## Container Startup Relationships
 
-Why this was selected:
-- Removes host dirty-working-tree risk.
-- Makes agent behavior more reproducible.
-- Aligns with frequent commit/push workflow where GitHub is the primary outcome store.
+### Master Startup
 
-### 4. AI Login and Session Management
-- Shared Codex token/auth reference is used across master and agents in v1.
-- Each agent uses an isolated local writable `CODEX_HOME`.
-- Master and agent use the same SSH agent mechanism and/or `GH_TOKEN` references.
-- Branch strategy and repo sync policy are deferred to project-level decisions (not in current scope).
+The master startup path is:
 
-#### Future Hardening Path (v2+)
-Move to a managed image catalog when team scale/reliability needs increase:
-- static catalog file
-- profile-based image selection
-- CI-built/published images only
+1. load env
+2. configure logging
+3. load settings
+4. initialize registry/runtime/router/service
+5. start frontend threads
 
-### 2. Slack Integration Ownership (User vs Master)
-- Single Slack bot for both master and agent communications (selected for v1 to reduce setup overhead).
-- Channel-based forwarding determines which agent receives a user message.
-- Limitation: one channel maps to one agent at a time.
-- Master-managed Slack app creation/install remains out of scope.
+The master does not use the shell-entrypoint-heavy startup model used by the
+agent image.
 
-Recommended direction (v1):
-- Use one Slack app/bot token for the whole system.
-- Use admin channel only for master control commands in v1.
-- Maintain a channel -> agent mapping registry.
-- Master routes non-admin channel messages to the mapped agent container.
-- Revisit multi-bot isolation later if security/scale requires it.
+### Agent Startup
 
-#### Channel-Based Forwarding Model (Selected v1)
-Core rule:
-- One Slack channel can be attached to exactly one agent.
+The agent startup path is:
 
-Implications:
-- Lower Slack app setup overhead (single app, single install, single token set).
-- Simpler operator onboarding.
-- Stronger need for routing correctness in master.
-- Agents do not have direct Slack connectivity in v1; master proxies all communication.
+1. container starts from image selected by master
+2. shell entrypoint prepares writable runtime homes and seed inputs
+3. worker preflight checks auth prerequisites
+4. repo sync clones or refreshes `/workspace/repo`
+5. workspace prepare applies global config and repo-local runtime state
+6. container becomes ready for dispatch
 
-Two implementation variants:
-1. **Master-only Slack integration (recommended for this model)**
-   - Master receives all Slack events.
-   - Master forwards prompts/results to agent containers over an internal control interface.
-   - Agents do not need Slack tokens.
-2. **Shared Slack bot token across master + agents (possible but less clean)**
-   - Multiple containers connect to Slack with same app credentials.
-   - Routing ambiguity and duplicate event handling become harder.
+### CD Startup
 
-Recommended v1:
-- Master-only Slack integration with channel->agent routing.
-- Treat agent containers as worker runtimes, not Slack clients.
+The CD daemon startup path is:
 
-### 3. Workspace Storage Model (Host Mount vs Container Internal)
-- Managed named volumes: selected default for v1 (agent clones/fetches repo internally).
-- Host bind mounts: optional fallback/debug mode later.
-- Container internal storage without managed lifecycle: not used in v1.
+1. load env
+2. load persisted state
+3. reconcile the master container on startup
+4. enter the poll / deploy / health-check / rollback loop
 
-Recommended direction (v1):
-- Use named volume per agent workspace.
-- Agent initializes repo clone/fetch inside container startup.
-- Keep host bind mounts as optional later mode only.
+## Lifecycle Model
 
-### 4. AI Login and Session Management
-- Shared host Codex auth/session mounts are simple but broad.
-- Per-agent project-local `CODEX_HOME` is safer and isolates sessions.
-- Token-based auth via env is easiest to automate but user may prefer auth cache.
+```mermaid
+stateDiagram-v2
+    [*] --> MasterRunning
+    MasterRunning --> AgentLoaded: /master-agent-load
+    AgentLoaded --> AgentRunning: /master-agent-start
+    AgentRunning --> AgentStopped: /master-agent-stop
+    AgentStopped --> AgentRunning: /master-agent-start
+    AgentLoaded --> AgentRemoved: /master-agent-remove
+    AgentStopped --> AgentRemoved: /master-agent-remove
+    AgentRunning --> AgentError: runtime or dispatch failure
+    AgentError --> AgentRunning: successful restart
+```
 
-Recommended direction (v1):
-- Use one shared Codex token/auth reference across master and agents.
-- Use isolated per-agent `CODEX_HOME` by default.
-- Master stores only session IDs / auth references, never raw secrets.
+Important separation:
+
+- master-container lifecycle is independent from individual agent logical state
+- CD manages master deployment lifecycle, not agent lifecycle directly
+
+## Storage Model
+
+### Master-Owned Durable State
+
+- agent registry file
+- tracked thread state file
+
+### Agent-Owned Durable State
+
+- named workspace volume per agent
+- checked-out repo under `/workspace/repo`
+- writable user-scope runtime homes under `/workspace/home`
+
+### Transient State
+
+- request-staged input under `/workspace/message/...`
+- process memory in all runtimes
+- read-only mounted seed inputs under `/run/secrets/...`
+
+## Trust Boundaries
+
+### Master Trust Boundary
+
+The master container is privileged relative to agents because it can:
+
+- control Podman
+- create and remove agent containers
+- inject runtime env and mounts
+
+This makes the Podman socket mount a privileged control-plane capability.
+
+### Agent Trust Boundary
+
+Agents are isolated worker runtimes:
+
+- one repo workspace per agent volume
+- no direct Slack or Discord credentials required for normal operation
+- request-scoped inputs are transient and must not be treated as durable state
+
+### CD Trust Boundary
+
+The CD daemon is trusted to redeploy the master container but not to operate on
+agent workspaces or routing state directly.
+
+## Security and Operational Invariants
+
+The architecture preserves these invariants:
+
+- master is the only orchestrator of agent containers
+- frontend adapters do not manage containers directly
+- agents do not manage other agents or the master
+- request-scoped attachment input is transient
+- durable repo state stays in agent workspaces, not the master container
+- deployment automation is separated from prompt-routing logic
+
+## Canonical Detail Documents
+
+Use these for the lower-level contracts:
+
+- [docs/design/containers/master-container-design.md](containers/master-container-design.md)
+- [docs/design/containers/agent-container-design.md](containers/agent-container-design.md)
+- [docs/design/containers/cd-container-design.md](containers/cd-container-design.md)
+- [docs/design/containers/environment-variable-passdown-design.md](containers/environment-variable-passdown-design.md)
+- [docs/design/master-agent-interface-design.md](master-agent-interface-design.md)
+- [docs/design/frontend-master-interface-design.md](frontend-master-interface-design.md)
+- [docs/guides/runbooks/master-agent.md](../guides/runbooks/master-agent.md)
+- [docs/guides/runbooks/cd-daemon.md](../guides/runbooks/cd-daemon.md)

--- a/docs/design/master-agent-implementation-plan.md
+++ b/docs/design/master-agent-implementation-plan.md
@@ -1,6 +1,14 @@
-# Master-Agent Implementation Plan (Draft)
+# Master-Agent Implementation Plan
 
-This is a living phased plan for the master -> agent orchestration feature.
+**Status:** archived historical plan  
+**Superseded by:** [`docs/design/master-agent-architecture.md`](master-agent-architecture.md), [`docs/design/master-agent-interface-design.md`](master-agent-interface-design.md), [`docs/design/frontend-master-interface-design.md`](frontend-master-interface-design.md), and the container design set under [`docs/design/containers/`](containers/)
+
+This document is preserved as historical implementation planning context for the
+initial master -> agent rollout.
+
+It is no longer the canonical source for the current architecture or runtime
+contracts.
+
 For current operator-facing behavior and command surface, use [`docs/README.md`](../README.md), [`docs/references/api.md`](../references/api.md), and [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md).
 
 ## Design Freeze Status (v1)

--- a/docs/design/master-agent-implementation-plan.md
+++ b/docs/design/master-agent-implementation-plan.md
@@ -1,7 +1,7 @@
 # Master-Agent Implementation Plan (Draft)
 
 This is a living phased plan for the master -> agent orchestration feature.
-For current operator-facing behavior and command surface, use `docs/README.md`, `docs/references/api.md`, and `docs/guides/runbooks/master-agent.md`.
+For current operator-facing behavior and command surface, use [`docs/README.md`](../README.md), [`docs/references/api.md`](../references/api.md), and [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md).
 
 ## Design Freeze Status (v1)
 - Status: frozen for implementation.
@@ -30,8 +30,8 @@ For current operator-facing behavior and command surface, use `docs/README.md`, 
 - Finalize agent initialization stages and status reporting contract (no in-agent control service).
 
 Deliverables:
-- `docs/design/master-agent-architecture.md`
-- `docs/design/master-agent-implementation-plan.md`
+- [`docs/design/master-agent-architecture.md`](master-agent-architecture.md)
+- [`docs/design/master-agent-implementation-plan.md`](master-agent-implementation-plan.md)
 - sample registry JSON
 - sample project manifest (`.prj_assistant/agent.toml`)
 - master command contract + idempotency rules

--- a/docs/design/master-agent-interface-design.md
+++ b/docs/design/master-agent-interface-design.md
@@ -13,7 +13,7 @@ Define the authoritative contract between master and agent so that:
 - agents know which inputs are durable versus transient
 - testing and implementation can target stable boundaries
 
-This document complements `docs/design/agent-container-runtime-design.md` by
+This document complements [`docs/design/agent-container-runtime-design.md`](agent-container-runtime-design.md) by
 focusing on the cross-runtime interface rather than the internal agent home
 layout.
 

--- a/docs/design/message-split-hint-detailed-design.md
+++ b/docs/design/message-split-hint-detailed-design.md
@@ -2,7 +2,7 @@
 
 **Status:** proposed  
 **Issue:** [#39](https://github.com/pandazxx/codex-slack/issues/39)  
-**ADR:** `docs/decisions/0003-message-split-hint-protocol.md`
+**ADR:** [`docs/decisions/0003-message-split-hint-protocol.md`](../decisions/0003-message-split-hint-protocol.md)
 
 ## Goal
 

--- a/docs/design/message-split-hint-detailed-design.md
+++ b/docs/design/message-split-hint-detailed-design.md
@@ -1,12 +1,13 @@
 # Message Split Hint Detailed Design
 
-**Status:** proposed  
+**Status:** canonical design  
 **Issue:** [#39](https://github.com/pandazxx/codex-slack/issues/39)  
 **ADR:** [`docs/decisions/0003-message-split-hint-protocol.md`](../decisions/0003-message-split-hint-protocol.md)
 
 ## Goal
 
-Implement a minimal split-hint protocol that lets agents choose semantic message boundaries while preserving the current size-based fallback path.
+Document the implemented split-hint protocol that lets agents choose semantic
+message boundaries while preserving the current size-based fallback path.
 
 The primary product goal is to avoid ugly frontend auto-splitting or truncation. The secondary goal is to improve readability of long answers.
 
@@ -35,7 +36,8 @@ The agent may separate intended sections with an exact standalone marker line:
 🔹🔹🔹
 ```
 
-The master treats a line as a split hint only when the line content is exactly `🔹🔹🔹`.
+The master treats a line as a split hint only when the line content is exactly
+`🔹🔹🔹`.
 
 No looser variant is accepted in v1:
 
@@ -55,25 +57,26 @@ Today, long responses are split heuristically by frontend-specific size helpers:
 
 Issue `#39` adds semantic split hints ahead of those heuristics. It does not remove the size-based fallback path.
 
-## Design
+## Current Design
 
 ### Shared Parsing, Frontend-Owned Delivery
 
-Introduce a shared split-hint parser in master, but keep transport delivery decisions in each frontend.
+The shared split-hint parser lives in `src/master/response_split.py`, while
+transport delivery decisions remain frontend-owned.
 
-Recommended shared helper shape:
+Current shared helper:
 
 ```python
 split_on_hint_lines(text: str) -> list[str]
 ```
 
-The parser should:
+The parser:
 
 - split only on exact `🔹🔹🔹` lines
 - preserve section order
 - preserve the marker line within the emitted chunk text
 
-Each frontend should then decide how to deliver those parsed sections, including:
+Each frontend then decides how to deliver those parsed sections, including:
 
 - size-based fallback splitting when no hint lines are present
 - frontend-specific hard limits
@@ -86,7 +89,7 @@ The product decision is to keep the visible token if it leaks. The simplest impl
 - use the marker line as the boundary between sections
 - keep it attached to either the end of the previous section or the start of the next section
 
-Recommended v1 behavior:
+Current behavior:
 
 - attach the marker line to the following section when splitting on boundaries
 
@@ -94,33 +97,41 @@ That keeps the separator visually associated with the new section and avoids sil
 
 ### Frontend Integration
 
-Both Slack and Discord should consume the same parsed hint sections before sending responses, but each frontend remains responsible for its own transport behavior.
+Both Slack and Discord consume the same parsed hint sections before sending
+responses, but each frontend remains responsible for its own transport
+behavior.
 
 #### Discord
 
-Update the routed-reply path in `src/master/discord_app.py`:
+The routed-reply path in `src/master/discord_app.py` uses:
 
-- use the shared hint parser
-- remove `[1/2]` chunk labels from routed replies
-- if no exact hint lines are present, keep current size-based message splitting
-- if any hinted section exceeds the Discord fallback threshold, send the whole response as a markdown file
+- `build_discord_reply_plan(text)`
+- the shared hint parser from `response_split.py`
+- no `[1/2]` chunk labels in routed replies
+- current size-based fallback splitting when no exact hint lines are present
+- whole-response markdown file fallback when any hinted section exceeds the
+  Discord fallback threshold
 
-Recommended v1 threshold:
+Current threshold:
 
 - `2000` characters per hinted section
 
 This keeps the implementation simple and avoids mixing semantic sections with additional partial splitting inside a section.
 
-`label_discord_chunks()` should not be part of the routed reply flow after this change.
+`label_discord_chunks()` is not part of the routed reply flow.
 
 #### Slack
 
-Slack should use the same shared hint parser, but the Slack frontend should own the final delivery strategy.
+Slack uses the same shared hint parser, but the Slack frontend owns the final
+delivery strategy.
 
-Slack v1 behavior should mirror the same high-level rule:
+The Slack routed reply path uses:
 
-- if no exact hint lines are present, use Slack's current size-based delivery path
-- if hinted sections are present and any section exceeds the Slack fallback threshold, send the whole response using Slack's file fallback path instead of partially splitting hinted sections
+- `build_slack_reply_plan(text)`
+- the shared hint parser from `response_split.py`
+- current size-based delivery when no exact hint lines are present
+- whole-response file fallback when any hinted section exceeds the Slack
+  fallback threshold instead of partially splitting a hinted section
 
 This boundary is intentionally frontend-owned so Slack and Discord can diverge later without changing the shared protocol.
 
@@ -132,7 +143,9 @@ Fallback behavior is frontend-owned:
 - if exact hint lines are present and every section is within the frontend threshold, send one message per section
 - if exact hint lines are present and any section exceeds the frontend threshold, fall back to a single markdown file for the whole response
 
-V1 should not size-split an individual hinted section after parsing. Oversized hinted sections trigger whole-response file fallback instead.
+The current implementation does not size-split an individual hinted section
+after parsing. Oversized hinted sections trigger whole-response file fallback
+instead.
 
 ## Length Guidance
 
@@ -143,11 +156,13 @@ Instead, it is a static instruction for the agent under:
 - `config/codex-global/AGENTS.md`
 - `config/claude-global/CLAUDE.md`
 
-The implementation should not reject, warn, or reflow content purely because a section exceeds `1700` characters. The master only needs to honor hints where possible and then keep transport-safe behavior.
+The implementation does not reject, warn, or reflow content purely because a
+section exceeds `1700` characters. The master only needs to honor hints where
+possible and then keep transport-safe behavior.
 
 ## Static Instruction Contract
 
-Global instructions should tell the agent:
+Global instructions tell the agent:
 
 - when producing a long reply, organize it into short sections
 - place `🔹🔹🔹` on its own line between sections
@@ -170,7 +185,7 @@ Examples:
 
 ## Tests
 
-Required test coverage:
+Test coverage:
 
 - exact marker line produces multiple sections
 - non-exact variants such as ` 🔹🔹🔹 ` do not trigger hint splitting
@@ -189,12 +204,19 @@ Expected operator-visible behavior:
 - when a hinted section is too long, the frontend falls back to sending the whole response as a markdown file
 - when no hints are present, behavior remains compatible with today’s heuristic splitting
 
-## Implementation Notes
+## Implemented Components
 
-Recommended sequence:
+The current implementation is spread across:
 
-1. add shared split-hint parsing helpers in master
-2. wire Discord routed replies to that parser, remove chunk labeling, and apply frontend-owned fallback
-3. wire Slack routed replies to the same parser with Slack-owned fallback
-4. update static global instructions for Codex and Claude
-5. add unit coverage for the splitter and frontend integration paths
+1. `src/master/response_split.py`
+   - `SPLIT_HINT_LINE`
+   - `split_on_hint_lines()`
+   - `split_by_size()`
+   - `ReplyDeliveryPlan`
+2. `src/master/discord_app.py`
+   - `build_discord_reply_plan()`
+3. `src/master/slack_app.py`
+   - `build_slack_reply_plan()`
+4. static global instructions:
+   - `config/codex-global/AGENTS.md`
+   - `config/claude-global/CLAUDE.md`

--- a/docs/design/separate-base-agent-image-detailed-design.md
+++ b/docs/design/separate-base-agent-image-detailed-design.md
@@ -1,6 +1,6 @@
 # Separate Base Agent Image Detailed Design
 
-**Status:** proposed  
+**Status:** canonical design  
 **Issue:** [#38](https://github.com/pandazxx/codex-slack/issues/38)  
 **ADR:** [`docs/decisions/0002-separate-base-agent-image.md`](../decisions/0002-separate-base-agent-image.md)
 
@@ -17,9 +17,9 @@ This design covers:
 
 ## Product Decision
 
-The canonical published agent base image should come from `Dockerfile.agent-minimal`.
+The canonical published agent base image comes from `Dockerfile.agent-minimal`.
 
-Projects should customize agent runtime through:
+Projects customize agent runtime through:
 
 - `.prj_assistant/image/Dockerfile`
 
@@ -35,13 +35,13 @@ The repository currently has:
 - `Dockerfile.agent-minimal`
   - leaner image closer to agent-worker needs
 
-The docs already reference a published base image, but the workflow is not yet defined as a complete contract.
+The publication workflow and the project-consumption contract are now implemented.
 
-## Desired State
+## Current Canonical State
 
 ### Base image role
 
-The base image should provide only the stable runtime needed by agent containers:
+The base image provides the stable runtime needed by agent containers:
 
 - Python runtime
 - `codex` CLI
@@ -61,7 +61,7 @@ Do not include master-only tooling by default:
 - `jq`
 - `make`
 
-Projects that need additional tools should extend the base image in their own `.prj_assistant/image/Dockerfile`.
+Projects that need additional tools extend the base image in their own `.prj_assistant/image/Dockerfile`.
 
 ## Architecture Boundary
 
@@ -103,7 +103,7 @@ Required tags:
 
 ### Trigger policy
 
-Recommended workflow triggers:
+Current workflow triggers:
 
 - pushes to default branch affecting agent runtime/image inputs
 - git tags for release and RC builds
@@ -111,7 +111,7 @@ Recommended workflow triggers:
 
 ### Build inputs
 
-Workflow should build from:
+The workflow builds from:
 
 - `Dockerfile.agent-minimal`
 
@@ -132,7 +132,7 @@ Publish image metadata including:
 
 ### Required path
 
-Project repos should customize through:
+Project repos customize through:
 
 - `.prj_assistant/image/Dockerfile`
 
@@ -183,7 +183,7 @@ The master-side contract remains:
 
 ## Documentation Deliverables
 
-Implementation should produce or update:
+The implementation produces and updates:
 
 1. project-facing guide for using the base image
 2. clear example `.prj_assistant/image/Dockerfile`
@@ -191,7 +191,7 @@ Implementation should produce or update:
 4. explanation of which runtime invariants must be preserved
 5. clarification that "project specific manifest" means `.prj_assistant/image/Dockerfile`
 
-Recommended doc touch points:
+Current doc touch points:
 
 - [`docs/guides/tutorials.md`](../guides/tutorials.md)
 - [`docs/guides/container-runtime.md`](../guides/container-runtime.md)
@@ -205,7 +205,7 @@ Recommended doc touch points:
 - build the base image
 - log in to GHCR
 - publish required tags
-- optionally emit a summary with pushed image references
+- emit a standard GitHub Actions job summary and pushed image references through the workflow run
 
 ### Inputs and secrets
 
@@ -214,7 +214,7 @@ Recommended doc touch points:
 
 ### Validation
 
-The workflow should verify:
+The workflow verifies:
 
 - image builds successfully from `Dockerfile.agent-minimal`
 - `python -m src.agent.main` remains runnable
@@ -227,7 +227,7 @@ The workflow should verify:
 - build test for `Dockerfile.agent-minimal`
 - smoke check that `codex` and `claude` binaries exist
 - smoke check that entrypoint can launch `src.agent.main`
-- image tag calculation tests if implemented in scripts
+- image tag calculation through the GitHub Actions metadata step
 
 ### Manual / UAT
 
@@ -235,17 +235,19 @@ The workflow should verify:
 - master loads and starts an agent using the project image path
 - agent still honors auth/config injection and workspace layout
 
-## Rollout Plan
+## Delivery State
 
-Recommended delivery order:
+Delivered order:
 
 1. finalize base image package contents
 2. add GHCR publication workflow
 3. update docs with project consumption guidance
 4. verify one sample project image build from the published base
 
-## Open Questions
+## Current Resolved Decisions and Remaining Gaps
 
-- should `latest` track only default branch, or only accepted releases?
-- should GHCR publication include both public and internal/private package guidance?
-- do we want a sample project repo or only in-repo docs/examples?
+- `latest` tracks the default branch through the publish workflow
+- git tags, including RC tags, are mirrored as published image tags
+- immutable `sha-*` tags are published for traceability
+- project customization remains the repo-local `.prj_assistant/image/Dockerfile` contract
+- the current docs rely on in-repo guides and examples rather than a separate sample project repo

--- a/docs/design/separate-base-agent-image-detailed-design.md
+++ b/docs/design/separate-base-agent-image-detailed-design.md
@@ -2,7 +2,7 @@
 
 **Status:** proposed  
 **Issue:** [#38](https://github.com/pandazxx/codex-slack/issues/38)  
-**ADR:** `docs/decisions/0002-separate-base-agent-image.md`
+**ADR:** [`docs/decisions/0002-separate-base-agent-image.md`](../decisions/0002-separate-base-agent-image.md)
 
 ## Goal
 
@@ -193,9 +193,9 @@ Implementation should produce or update:
 
 Recommended doc touch points:
 
-- `docs/guides/tutorials.md`
-- `docs/guides/container-runtime.md`
-- `docs/guides/runbooks/master-agent.md`
+- [`docs/guides/tutorials.md`](../guides/tutorials.md)
+- [`docs/guides/container-runtime.md`](../guides/container-runtime.md)
+- [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md)
 - FAQ entry if needed
 
 ## CI/CD Design

--- a/docs/design/v3-0-multi-adapter-frontend-plan.md
+++ b/docs/design/v3-0-multi-adapter-frontend-plan.md
@@ -1,5 +1,14 @@
 # v3.0 Plan: Multi-Adapter + Multi-Frontend Master Runtime
 
+**Status:** archived historical plan  
+**Superseded by:** [`docs/design/frontend-master-interface-design.md`](frontend-master-interface-design.md), [`docs/design/master-agent-architecture.md`](master-agent-architecture.md), and the container design set under [`docs/design/containers/`](containers/)
+
+This document is preserved as historical planning context for the v3.0
+multi-adapter frontend rollout.
+
+It is no longer the canonical source for the current frontend or architecture
+contract.
+
 ## Scope and Decisions (Locked)
 This plan implements the following confirmed decisions:
 

--- a/docs/guides/container-runtime.md
+++ b/docs/guides/container-runtime.md
@@ -4,7 +4,7 @@ This project includes a containerized runtime for the Slack bot.
 
 This guide is operational. The canonical runtime contract for master-managed
 agent containers lives in
-`docs/design/agent-container-runtime-design.md`.
+[`docs/design/agent-container-runtime-design.md`](../design/agent-container-runtime-design.md).
 
 ## Runtime Images
 This repository currently has two container-image roles:
@@ -28,7 +28,7 @@ The published minimal agent base image from `Dockerfile.agent-minimal` ships wit
 It intentionally does not include master-only tooling like `podman`, `gh`, `jq`, or `make`.
 
 For detailed master-agent operational steps, see
-`docs/guides/runbooks/master-agent.md`.
+[`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md).
 
 ## Required Mounts
 The provided `docker-compose.yml` mounts:
@@ -234,7 +234,7 @@ podman exec -it agent-<name> sh -lc 'ls -la /workspace/repo/.codex /workspace/re
 
 For auth/config injection details, user-scope vs project-scope paths, and
 request-manifest behavior, refer to
-`docs/design/agent-container-runtime-design.md`.
+[`docs/design/agent-container-runtime-design.md`](../design/agent-container-runtime-design.md).
 
 ## Published Base Image Contract
 Use the published minimal base image when a project needs extra packages or CLIs but should keep the standard agent runtime contract.

--- a/docs/guides/multi-agent-setup.md
+++ b/docs/guides/multi-agent-setup.md
@@ -1,6 +1,6 @@
 # Multi-Agent Setup (Same Slack Workspace)
 
-> **Historical reference.** This document describes the manual multi-agent setup approach predating the master-agent system. For current multi-agent deployments use the master-agent commands (`/master-agent-load`, `/master-agent-start`, etc.) documented in `docs/guides/runbooks/master-agent.md`.
+> **Historical reference.** This document describes the manual multi-agent setup approach predating the master-agent system. For current multi-agent deployments use the master-agent commands (`/master-agent-load`, `/master-agent-start`, etc.) documented in [`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md).
 
 This guide runs multiple Codex agents in separate containers, each mapped to a different repository, while sharing one Slack workspace.
 

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -11,9 +11,9 @@ Getting started as a new contributor to this project.
 
 ## First steps
 
-1. Read `README.md` for a project overview.
-2. Read `docs/manuals/ops-manual.md` to understand setup and deployment.
-3. Read `docs/manuals/user-manual.md` to understand day-to-day operation.
+1. Read [`README.md`](../../README.md) for a project overview.
+2. Read [`docs/manuals/ops-manual.md`](../manuals/ops-manual.md) to understand setup and deployment.
+3. Read [`docs/manuals/user-manual.md`](../manuals/user-manual.md) to understand day-to-day operation.
 4. Run the test suite: `pytest -q`
 
 ## Agent framework
@@ -22,7 +22,7 @@ This repository uses both the Claude Code framework in `.claude/` and the Codex 
 
 1. Read `.claude/CLAUDE.md` for project-scope workflow rules.
 2. Read `AGENTS.md` for the repo-level Codex workflow contract.
-3. Read `docs/knowledge-base/lessons-learned.md` for prior learnings.
+3. Read [`docs/knowledge-base/lessons-learned.md`](../knowledge-base/lessons-learned.md) for prior learnings.
 4. Check `docs/decisions/` for any Architecture Decision Records relevant to your area.
 
 The standard feature workflow (design → build → test → review → document → release) is defined in `.claude/CLAUDE.md` under *Common Workflow*.
@@ -38,8 +38,8 @@ pytest -q
 
 ## Key contacts and references
 
-- Documentation map: `docs/README.md`
-- Operational runbook: `docs/guides/runbooks/master-agent.md`
-- Slack app setup: `docs/guides/slack-setup.md`
-- Discord app setup: `docs/guides/discord-setup.md`
-- User manual: `docs/manuals/user-manual.md`
+- Documentation map: [`docs/README.md`](../README.md)
+- Operational runbook: [`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md)
+- Slack app setup: [`docs/guides/slack-setup.md`](slack-setup.md)
+- Discord app setup: [`docs/guides/discord-setup.md`](discord-setup.md)
+- User manual: [`docs/manuals/user-manual.md`](../manuals/user-manual.md)

--- a/docs/guides/project-agent-image.md
+++ b/docs/guides/project-agent-image.md
@@ -182,7 +182,7 @@ If you used `USER root` during package install:
 
 ## Related Docs
 
-- `docs/guides/container-runtime.md`
-- `docs/guides/tutorials.md`
-- `docs/decisions/0002-separate-base-agent-image.md`
-- `docs/design/separate-base-agent-image-detailed-design.md`
+- [`docs/guides/container-runtime.md`](container-runtime.md)
+- [`docs/guides/tutorials.md`](tutorials.md)
+- [`docs/decisions/0002-separate-base-agent-image.md`](../decisions/0002-separate-base-agent-image.md)
+- [`docs/design/separate-base-agent-image-detailed-design.md`](../design/separate-base-agent-image-detailed-design.md)

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -6,7 +6,7 @@ Operational guide for the master->agent v3.0 stack:
 - agent worker containers (no direct Slack connection)
 - Podman host socket control path
 
-See `docs/test-plans/master-agent-uat.md` for step-by-step user acceptance test cases.
+See [`docs/test-plans/master-agent-uat.md`](../../test-plans/master-agent-uat.md) for step-by-step user acceptance test cases.
 Containerized UAT is required for v3.0 sign-off.
 
 ## Prerequisites
@@ -203,7 +203,7 @@ Omit the model argument to clear the override:
   - rerun the command from an admin channel in a category where the bot can create channels
   - or grant the bot `Manage Channels` on the intended category before retrying
 - Setup reference:
-  - `docs/guides/discord-setup.md`, section `Enable Bot-Driven Channel Creation`
+  - [`docs/guides/discord-setup.md`](../discord-setup.md), section `Enable Bot-Driven Channel Creation`
 - Useful provisioning logs:
   - `master.provision_command_parsed`
   - `provision.start`

--- a/docs/knowledge-base/lessons-learned.md
+++ b/docs/knowledge-base/lessons-learned.md
@@ -6,7 +6,7 @@ Append-only log. Each entry: date, summary, root cause, fix applied, prevention.
 
 ## 2026-03-24 — docs/knowledge-base directory initialised
 
-*Summary:* The project CLAUDE.md references `docs/knowledge-base/lessons-learned.md` and `docs/knowledge-base/faq.md` as required knowledge-persistence targets, but neither file nor the directory existed.
+*Summary:* The project `CLAUDE.md` references [`docs/knowledge-base/lessons-learned.md`](lessons-learned.md) and [`docs/knowledge-base/faq.md`](faq.md) as required knowledge-persistence targets, but neither file nor the directory existed.
 
 *Root cause:* The document layout was defined in v3.4 as a target structure; no initialisation step created the required stubs.
 

--- a/docs/manuals/ops-manual.md
+++ b/docs/manuals/ops-manual.md
@@ -10,15 +10,15 @@ This manual is the primary entry point for setting up, deploying, and operating 
 
 ## Start Here
 
-1. Read `README.md` for the project overview and deployment options.
-2. Follow `docs/guides/slack-setup.md` and `docs/guides/discord-setup.md` for chat frontend setup.
-3. Use `docs/guides/container-runtime.md` for container runtime details, mounts, and auth handling.
-4. Use `docs/guides/runbooks/master-agent.md` for production runtime operation.
-5. Use `docs/guides/runbooks/cd-daemon.md` when enabling automated deployments.
+1. Read [`README.md`](../../README.md) for the project overview and deployment options.
+2. Follow [`docs/guides/slack-setup.md`](../guides/slack-setup.md) and [`docs/guides/discord-setup.md`](../guides/discord-setup.md) for chat frontend setup.
+3. Use [`docs/guides/container-runtime.md`](../guides/container-runtime.md) for container runtime details, mounts, and auth handling.
+4. Use [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md) for production runtime operation.
+5. Use [`docs/guides/runbooks/cd-daemon.md`](../guides/runbooks/cd-daemon.md) when enabling automated deployments.
 
 ## Related References
 
-- `docs/references/config.md` for configuration keys
-- `docs/references/logging.md` for log destinations and verbosity
-- `docs/test-plans/master-agent-uat.md` for acceptance verification
+- [`docs/references/config.md`](../references/config.md) for configuration keys
+- [`docs/references/logging.md`](../references/logging.md) for log destinations and verbosity
+- [`docs/test-plans/master-agent-uat.md`](../test-plans/master-agent-uat.md) for acceptance verification
 - `docs/releases/` for release-specific changes and migration notes

--- a/docs/manuals/user-manual.md
+++ b/docs/manuals/user-manual.md
@@ -10,12 +10,12 @@ This manual is the primary entry point for using the bot and master runtime day 
 
 ## Start Here
 
-1. Read `README.md` for the product overview.
-2. Use `docs/guides/tutorials.md` for guided examples.
-3. Use `docs/references/api.md` for the implemented command set.
-4. Use `docs/references/logging.md` when debugging runtime behavior.
+1. Read [`README.md`](../../README.md) for the product overview.
+2. Use [`docs/guides/tutorials.md`](../guides/tutorials.md) for guided examples.
+3. Use [`docs/references/api.md`](../references/api.md) for the implemented command set.
+4. Use [`docs/references/logging.md`](../references/logging.md) when debugging runtime behavior.
 
 ## Related Operator Docs
 
-- `docs/manuals/ops-manual.md` for setup and deployment
-- `docs/guides/runbooks/master-agent.md` for operational procedures
+- [`docs/manuals/ops-manual.md`](ops-manual.md) for setup and deployment
+- [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md) for operational procedures

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -26,16 +26,16 @@ This page summarizes the main configuration keys loaded directly from the curren
 | `MASTER_ADMIN_CHANNELS` | Slack only | None | Slack admin channels |
 | `DISCORD_BOT_TOKEN` | Discord only | None | Discord bot token |
 | `DISCORD_ADMIN_CHANNELS` | Discord only | None | Discord admin channels |
-| `MASTER_REGISTRY_PATH` | No | `data/master/agents.json` | Agent registry file |
-| `MASTER_THREAD_STATE_PATH` | No | sibling of registry path | Thread tracking state |
+| `MASTER_REGISTRY_PATH` | No | `data/master/agents.json` | Container path inside the master container for the agent registry file |
+| `MASTER_THREAD_STATE_PATH` | No | sibling of registry path | Container path inside the master container for thread tracking state |
 | `MASTER_DRY_RUN` | No | `false` | Disable side-effecting runtime actions |
 | `MASTER_AGENT_BASE_IMAGE` | No | `codex-slack-bot:latest` | Default image for new agents |
-| `MASTER_CODEX_AUTH_JSON_PATH` | No | unset | Shared Codex auth file |
-| `MASTER_CODEX_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/codex-global`, fallback `config/codex`) | Shared Codex config directory |
-| `MASTER_CLAUDE_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/claude-global`) | Shared Claude config directory |
+| `MASTER_CODEX_AUTH_JSON_PATH` | No | unset | Host path to the shared Codex auth file mounted into agents |
+| `MASTER_CODEX_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/codex-global`, fallback `config/codex`) | Host path to the shared Codex config directory mounted into agents |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/claude-global`) | Host path to the shared Claude config directory mounted into agents |
 | `MASTER_PROJECT_DIR` | No | unset | Host project root used for global config auto-detection |
-| `MASTER_SSH_AUTH_SOCK_PATH` | No | unset | SSH agent socket path |
-| `MASTER_SSH_KNOWN_HOSTS_PATH` | No | unset | Known hosts path |
+| `MASTER_SSH_AUTH_SOCK_PATH` | No | unset | Host path to the SSH agent socket mounted into master/agents |
+| `MASTER_SSH_KNOWN_HOSTS_PATH` | No | unset | Host path to the SSH known-hosts file mounted into agents |
 | `MASTER_GIT_USER_NAME` | No | unset | Git author name for agent workspaces |
 | `MASTER_GIT_USER_EMAIL` | No | unset | Git author email for agent workspaces |
 | `MASTER_AGENT_COMMAND_TEMPLATE` | No | `codex exec --dangerously-bypass-approvals-and-sandbox resume --last -` | Legacy default command template |
@@ -50,20 +50,20 @@ This page summarizes the main configuration keys loaded directly from the curren
 
 | Key | Required | Default | Purpose |
 | --- | --- | --- | --- |
-| `CODEX_WORKSPACE_PATH` | No | `/workspace` | Agent workspace mount |
+| `CODEX_WORKSPACE_PATH` | No | `/workspace` | Container path inside the agent for the workspace mount |
 | `AGENT_REPO_URL` | No | empty | Repository to clone |
 | `AGENT_REPO_REF` | No | `main` | Ref to check out |
 | `AGENT_REPO_DIR` | No | `repo` | Checkout directory name |
-| `AGENT_STATUS_FILE` | No | `/tmp/master-agent/status.json` | Status file for readiness |
-| `CODEX_HOME` | No | `/home/appuser/.codex` | Writable Codex home inside the container |
+| `AGENT_STATUS_FILE` | No | `/tmp/master-agent/status.json` | Container path inside the agent for the readiness status file |
+| `CODEX_HOME` | No | `/home/appuser/.codex` | Container path inside the agent for the writable Codex home |
 | `AGENT_READY_POLL_SECONDS` | No | `5` | Readiness polling interval |
-| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | No | empty | Shared Codex config source |
-| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | No | empty | Shared Claude config source |
+| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | No | empty | Container path inside the agent pointing at the mounted shared Codex config source |
+| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | No | empty | Container path inside the agent pointing at the mounted shared Claude config source |
 | `AGENT_GIT_USER_NAME` | No | empty | Per-agent Git author name |
 | `AGENT_GIT_USER_EMAIL` | No | empty | Per-agent Git author email |
-| `SSH_AUTH_SOCK` | No | empty | SSH agent socket passed through |
-| `GH_TOKEN` / `GITHUB_TOKEN` | No | empty | GitHub token for repo access |
-| `GH_TOKEN_FILE` | No | empty | Token file for repo access |
+| `SSH_AUTH_SOCK` | No | empty | Container path inside the agent to the passed-through SSH agent socket |
+| `GH_TOKEN` / `GITHUB_TOKEN` | No | empty | Token value, not a path |
+| `GH_TOKEN_FILE` | No | empty | Container path inside the agent to a token file for repo access |
 
 ## CD Daemon
 
@@ -72,11 +72,11 @@ This page summarizes the main configuration keys loaded directly from the curren
 | `CD_IMAGE` | Yes | None | Image repository to track |
 | `CD_IMAGE_TAG` | No | `latest` | Tag to watch |
 | `CD_CONTAINER_NAME` | No | `codex-slack-master` | Target container name |
-| `CD_COMPOSE_FILE` | No | `docker-compose.master-agent.example.yml` | Compose file path |
+| `CD_COMPOSE_FILE` | No | `docker-compose.master-agent.example.yml` | Container-visible path inside the CD runtime to the compose file |
 | `CD_COMPOSE_SERVICE` | No | `codex-slack-master` | Compose service name |
 | `CD_COMPOSE_BINARY` | No | `podman-compose` | Compose command |
-| `CD_ENV_FILE` | No | unset | Optional env file passed to compose |
-| `CD_STATE_FILE` | No | `data/cd/state.json` | Persisted daemon state |
+| `CD_ENV_FILE` | No | unset | Container-visible path inside the CD runtime to the env file passed to compose |
+| `CD_STATE_FILE` | No | `data/cd/state.json` | Container path inside the CD runtime for persisted daemon state |
 | `CD_POLL_INTERVAL_SECONDS` | No | `300` | Registry poll interval |
 | `CD_HEALTH_CHECK_DELAY_SECONDS` | No | `30` | Post-deploy health delay |
 | `CD_ROLLBACK_ON_FAILURE` | No | `true` | Enable rollback on failed deploy |

--- a/docs/releases/v3.2.md
+++ b/docs/releases/v3.2.md
@@ -22,7 +22,7 @@ v3.2 is a major feature release that adds Discord support, claude-code agent ada
 - Discord slash commands registered in the admin guild with full parity to Slack commands.
 - Long replies (>8000 chars) sent as `.md` file attachments. Text file attachments from users are read and appended to the prompt.
 - New env vars: `DISCORD_BOT_TOKEN`, `DISCORD_ADMIN_CHANNELS`.
-- See `docs/guides/discord-setup.md` for full setup guide.
+- See [`docs/guides/discord-setup.md`](../guides/discord-setup.md) for full setup guide.
 
 ### 2. Discord Reply Quality Improvements
 
@@ -64,7 +64,7 @@ Persisted in `agents.json`, survives restarts. Injects `--model <model>` into th
 - CD env vars (including masked webhook URLs) logged at startup for diagnostics.
 - New compose file: `docker-compose.cd-daemon.example.yml`.
 - `gen-env.sh` script to generate `.env` from the current shell environment, including host timezone (`TZ`).
-- See `docs/guides/runbooks/cd-daemon.md` for operator guide.
+- See [`docs/guides/runbooks/cd-daemon.md`](../guides/runbooks/cd-daemon.md) for operator guide.
 
 ### 6. Global Agent Config Cascade (`MASTER_CODEX_CONFIG_DIR_PATH`, `MASTER_CLAUDE_CONFIG_DIR_PATH`)
 
@@ -296,7 +296,7 @@ Persisted in `agents.json`, survives restarts. Injects `--model <model>` into th
 
 | Area | Key files |
 |---|---|
-| **CD daemon** | `src/cd/` (6 files), `docker-compose.cd-daemon.example.yml`, `docs/guides/runbooks/cd-daemon.md` |
+| **CD daemon** | `src/cd/` (6 files), `docker-compose.cd-daemon.example.yml`, [`docs/guides/runbooks/cd-daemon.md`](../guides/runbooks/cd-daemon.md) |
 | **Discord frontend** | `src/master/discord_app.py` — threading, formatting pipeline, mermaid, table conversion |
 | **Command routing** | `src/master/command_dispatch.py`, `command_format.py`, `command_runtime.py` |
 | **Config** | `src/master/config.py` — multi-frontend, multi-adapter, claude config auto-detect |

--- a/docs/releases/v3.3.md
+++ b/docs/releases/v3.3.md
@@ -69,7 +69,7 @@ Users now see visual feedback while the agent is processing.
 
 - Removed `is_admin_channel()` duplicate from `slack_app.py` — canonical copy lives in `command_runtime.py`.
 - Removed no-op `select_thread_image_urls()` from `slack_app.py` (always returned the input unchanged; filter logic already handled upstream in `extract_image_urls`).
-- Marked `docs/guides/multi-agent-setup.md` as a historical reference document; added a header pointing operators to `docs/guides/runbooks/master-agent.md` for current multi-agent setup.
+- Marked [`docs/guides/multi-agent-setup.md`](../guides/multi-agent-setup.md) as a historical reference document; added a header pointing operators to [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md) for current multi-agent setup.
 
 ---
 
@@ -181,5 +181,5 @@ Run v3.2 UAT test cases T1 through T13. All should pass unchanged.
 | **Discord handler** | `src/master/discord_app.py` — `typing()` indicator, `in_flight_dispatch`, `is_shutting_down` guard, `refresh-config` slash command |
 | **Refresh config** | `src/master/runtime_adapter.py`, `src/master/service.py`, `src/master/command_dispatch.py` |
 | **Agent list** | `src/master/service.py` — `list_agents()` now calls `inspect_agent` per entry |
-| **Docs** | `docs/guides/runbooks/master-agent.md` — `/master-agent-refresh-config` command, updated step numbering |
-| **Historical** | `docs/guides/multi-agent-setup.md` — historical notice added |
+| **Docs** | [`docs/guides/runbooks/master-agent.md`](../guides/runbooks/master-agent.md) — `/master-agent-refresh-config` command, updated step numbering |
+| **Historical** | [`docs/guides/multi-agent-setup.md`](../guides/multi-agent-setup.md) — historical notice added |

--- a/docs/releases/v3.9.md
+++ b/docs/releases/v3.9.md
@@ -1,0 +1,162 @@
+# Release Notes — v3.9
+
+**Base:** `master` @ `6a88c34`  
+**Release branch:** `docs/document-grooming`  
+**Date:** 2026-04-07  
+**Latest tag:** not tagged yet
+
+---
+
+## Summary
+
+v3.9 is a documentation architecture release. It does not change runtime code,
+but it substantially reorganizes and canonicalizes the repository’s design
+documentation so operators and contributors can find the current system
+contracts faster.
+
+Highlights:
+
+- new canonical container design docs for master, agent, and CD
+- new canonical environment-variable passdown design
+- major historical docs moved out of the active design set into an archive
+- older “proposed” detailed design docs updated to canonical/current-state
+  wording
+- broad Markdown link cleanup across the docs tree
+
+---
+
+## New Documentation
+
+### 1. Container Design Set
+
+Added a container-focused design set under `docs/design/containers/`:
+
+- [`docs/design/containers/master-container-design.md`](../design/containers/master-container-design.md)
+- [`docs/design/containers/agent-container-design.md`](../design/containers/agent-container-design.md)
+- [`docs/design/containers/cd-container-design.md`](../design/containers/cd-container-design.md)
+- [`docs/design/containers/environment-variable-passdown-design.md`](../design/containers/environment-variable-passdown-design.md)
+
+These docs now describe:
+
+- startup behavior
+- interface contracts
+- lifecycle and state
+- storage ownership
+- observability and failure boundaries
+- env loading and passdown semantics
+
+### 2. Canonical System Architecture
+
+Rewrote [`docs/design/master-agent-architecture.md`](../design/master-agent-architecture.md)
+from draft/historical discussion into a canonical architecture document.
+
+It now focuses on:
+
+- runtime roles and boundaries
+- control plane vs data plane
+- startup relationships between master, agent, and CD
+- storage and trust boundaries
+- system-level diagrams and lifecycle views
+
+---
+
+## Canonicalization Updates
+
+These design docs were updated from `proposed` / planning language to
+current-state canonical language:
+
+- [`docs/design/agent-provisioning-detailed-design.md`](../design/agent-provisioning-detailed-design.md)
+- [`docs/design/message-split-hint-detailed-design.md`](../design/message-split-hint-detailed-design.md)
+- [`docs/design/separate-base-agent-image-detailed-design.md`](../design/separate-base-agent-image-detailed-design.md)
+
+Key improvements include:
+
+- implemented behavior described as current fact
+- outdated recommendation wording removed
+- actual current defaults and runtime behavior documented
+- implemented helper/module names called out where relevant
+
+---
+
+## Archive Reorganization
+
+Archived design docs were moved out of the active design area into
+`docs/archive/design/`:
+
+- [`docs/archive/design/master-agent-implementation-plan.md`](../archive/design/master-agent-implementation-plan.md)
+- [`docs/archive/design/v3-0-multi-adapter-frontend-plan.md`](../archive/design/v3-0-multi-adapter-frontend-plan.md)
+
+This separates:
+
+- active canonical design docs under `docs/design/`
+- historical planning context under `docs/archive/design/`
+
+The docs map in [`docs/README.md`](../README.md) now has a dedicated `Archive`
+section to make that distinction explicit.
+
+---
+
+## Documentation Quality Improvements
+
+### 1. Cross-Document Markdown Links
+
+A repo-wide docs sweep converted many plain path mentions into GitHub-friendly
+Markdown links across:
+
+- top-level compatibility docs (`README.md`, `BUILD.md`, `USAGE.md`, `AGENTS.md`)
+- manuals
+- guides
+- design docs
+- release notes
+
+### 2. Env Path Semantics
+
+[`docs/references/config.md`](../references/config.md) and
+[`docs/design/containers/environment-variable-passdown-design.md`](../design/containers/environment-variable-passdown-design.md)
+now explicitly state whether path-like env vars are:
+
+- host paths
+- container-visible paths
+- mounted in-container paths
+
+### 3. Agent Startup Clarifications
+
+[`docs/design/containers/agent-container-design.md`](../design/containers/agent-container-design.md)
+was expanded to clarify:
+
+- `CODEX_HOME` selection behavior
+- repo authentication sources
+- clone vs update behavior during repo sync
+- later-phase cleanup targets for destructive or transitional startup behavior
+
+---
+
+## Migration Notes
+
+No runtime migration is required for v3.9.
+
+Recommended documentation migration:
+
+1. use [`docs/README.md`](../README.md) as the primary doc index
+2. treat `docs/design/containers/` as the primary runtime design set
+3. treat `docs/archive/design/` as historical context only
+4. stop using archived planning docs as active implementation references
+
+---
+
+## Validation
+
+- docs-only branch
+- no automated tests run
+
+---
+
+## Files Added or Moved
+
+| Area | Key files |
+|---|---|
+| New canonical container docs | `docs/design/containers/*.md` |
+| Rewritten canonical architecture | [`docs/design/master-agent-architecture.md`](../design/master-agent-architecture.md) |
+| Canonicalized detailed designs | [`docs/design/agent-provisioning-detailed-design.md`](../design/agent-provisioning-detailed-design.md), [`docs/design/message-split-hint-detailed-design.md`](../design/message-split-hint-detailed-design.md), [`docs/design/separate-base-agent-image-detailed-design.md`](../design/separate-base-agent-image-detailed-design.md) |
+| Archived historical plans | [`docs/archive/design/master-agent-implementation-plan.md`](../archive/design/master-agent-implementation-plan.md), [`docs/archive/design/v3-0-multi-adapter-frontend-plan.md`](../archive/design/v3-0-multi-adapter-frontend-plan.md) |
+| Docs map and link cleanup | [`docs/README.md`](../README.md), `README.md`, `BUILD.md`, `USAGE.md`, `AGENTS.md`, manuals/guides/releases |


### PR DESCRIPTION
## Summary
- add container-specific design docs for the master, agent, and CD containers under `docs/design/containers/`
- document startup behavior, interface contracts, lifecycle, storage, observability, and failure boundaries for each container
- add flowchart and state-machine diagrams for each container type and link the new docs from `docs/README.md`

## Testing
- not run; docs-only change

## Notes
- this is intended to become the clearer per-container reference alongside the existing runtime, interface, and runbook docs
