### PR TITLE
fix: install gh in minimal agent image

### DIFF
--- a/.github/workflows/publish-agent-minimal.yml
+++ b/.github/workflows/publish-agent-minimal.yml
@@ -58,6 +58,7 @@ jobs:
           docker run --rm codex-slack-agent-minimal:smoke sh -lc '
             codex --version &&
             claude --version &&
+            gh --version &&
             python -m src.agent.main --help >/dev/null
           '
 

--- a/Dockerfile.agent-minimal
+++ b/Dockerfile.agent-minimal
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
     curl \
+    gh \
     git \
     nodejs \
     npm \

--- a/tests/test_image_contract.py
+++ b/tests/test_image_contract.py
@@ -8,6 +8,11 @@ def test_agent_minimal_image_copies_config_directory() -> None:
     assert "COPY --chown=appuser:appuser config ./config" in dockerfile
 
 
+def test_agent_minimal_image_installs_github_cli() -> None:
+    dockerfile = Path("Dockerfile.agent-minimal").read_text(encoding="utf-8")
+    assert "gh \\" in dockerfile
+
+
 def test_entrypoint_has_baked_in_codex_and_claude_global_fallbacks() -> None:
     entrypoint = Path("docker/entrypoint.sh").read_text(encoding="utf-8")
     assert "set -x" in entrypoint


### PR DESCRIPTION
## Summary
- install `gh` in `Dockerfile.agent-minimal`
- extend the minimal-agent publish workflow smoke test to verify `gh --version`
- add image-contract coverage so the minimal image keeps the GitHub CLI available

## Testing
- `./.venv/bin/python -m pytest -q tests/test_image_contract.py`
- result: `3 passed in 0.02s`

## Issue
- closes #52
