### PR TITLE
fix: simplify agent runtime startup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,34 +16,26 @@ count_entries() {
 }
 
 WORKSPACE_PATH="${CODEX_WORKSPACE_PATH:-/workspace}"
-PROJECT_CODEX_HOME="${WORKSPACE_PATH}/.codex"
-DEFAULT_CODEX_HOME="/home/appuser/.codex"
+DEFAULT_CODEX_HOME="${WORKSPACE_PATH}/home/.codex"
 
 if [[ -n "${CODEX_HOME:-}" ]]; then
   CODEX_HOME_PATH="${CODEX_HOME}"
-elif [[ -d "${PROJECT_CODEX_HOME}" ]]; then
-  CODEX_HOME_PATH="${PROJECT_CODEX_HOME}"
 else
   CODEX_HOME_PATH="${DEFAULT_CODEX_HOME}"
 fi
 
 export CODEX_HOME="${CODEX_HOME_PATH}"
 mkdir -p "${CODEX_HOME_PATH}"
-entrypoint_log "startup workspace_path=${WORKSPACE_PATH} project_codex_home=${PROJECT_CODEX_HOME} default_codex_home=${DEFAULT_CODEX_HOME} selected_codex_home=${CODEX_HOME_PATH} home=${HOME:--} xdg_config_home=${XDG_CONFIG_HOME:--}"
+entrypoint_log "startup workspace_path=${WORKSPACE_PATH} default_codex_home=${DEFAULT_CODEX_HOME} selected_codex_home=${CODEX_HOME_PATH} home=${HOME:--} xdg_config_home=${XDG_CONFIG_HOME:--}"
 
-# Copy global codex config into CODEX_HOME so codex has a writable user-scope config dir.
-# Prefer the host-mounted path, fall back to the baked-in image path.
+# Copy baked-in codex config into CODEX_HOME so codex has a writable user-scope config dir.
 CODEX_CONFIG_SOURCE="-"
-if [[ -d "/run/secrets/master_codex_config" ]]; then
-  CODEX_CONFIG_SOURCE="/run/secrets/master_codex_config"
-  entrypoint_log "codex_config source=mounted path=${CODEX_CONFIG_SOURCE} entries=$(count_entries "${CODEX_CONFIG_SOURCE}") agents_md=$([[ -f "${CODEX_CONFIG_SOURCE}/AGENTS.md" ]] && echo true || echo false) config_toml=$([[ -f "${CODEX_CONFIG_SOURCE}/config.toml" ]] && echo true || echo false)"
-  cp -af /run/secrets/master_codex_config/. "${CODEX_HOME_PATH}/"
-elif [[ -d "/opt/codex-slack/config/codex-global" ]]; then
+if [[ -d "/opt/codex-slack/config/codex-global" ]]; then
   CODEX_CONFIG_SOURCE="/opt/codex-slack/config/codex-global"
   entrypoint_log "codex_config source=baked_in path=${CODEX_CONFIG_SOURCE} entries=$(count_entries "${CODEX_CONFIG_SOURCE}") agents_md=$([[ -f "${CODEX_CONFIG_SOURCE}/AGENTS.md" ]] && echo true || echo false) config_toml=$([[ -f "${CODEX_CONFIG_SOURCE}/config.toml" ]] && echo true || echo false)"
   cp -af /opt/codex-slack/config/codex-global/. "${CODEX_HOME_PATH}/"
 else
-  entrypoint_log "codex_config source=none mounted_exists=$([[ -d "/run/secrets/master_codex_config" ]] && echo true || echo false) baked_in_exists=$([[ -d "/opt/codex-slack/config/codex-global" ]] && echo true || echo false)"
+  entrypoint_log "codex_config source=none baked_in_exists=$([[ -d "/opt/codex-slack/config/codex-global" ]] && echo true || echo false)"
 fi
 entrypoint_log "codex_config_result target=${CODEX_HOME_PATH} entries=$(count_entries "${CODEX_HOME_PATH}") agents_md=$([[ -f "${CODEX_HOME_PATH}/AGENTS.md" ]] && echo true || echo false) config_toml=$([[ -f "${CODEX_HOME_PATH}/config.toml" ]] && echo true || echo false) auth_json=$([[ -f "${CODEX_HOME_PATH}/auth.json" ]] && echo true || echo false) source=${CODEX_CONFIG_SOURCE}"
 
@@ -55,36 +47,19 @@ else
   entrypoint_log "codex_auth action=skip source_exists=$([[ -f "/run/secrets/codex_auth.json" ]] && echo true || echo false) target_exists=$([[ -f "${CODEX_HOME_PATH}/auth.json" ]] && echo true || echo false)"
 fi
 
-if [[ -d "/run/secrets/codex_sessions" ]] && (
-  [[ ! -d "${CODEX_HOME_PATH}/sessions" ]] ||
-  [[ -z "$(ls -A "${CODEX_HOME_PATH}/sessions" 2>/dev/null)" ]]
-); then
-  entrypoint_log "codex_sessions action=copy source=/run/secrets/codex_sessions target=${CODEX_HOME_PATH}/sessions source_entries=$(count_entries /run/secrets/codex_sessions)"
-  mkdir -p "${CODEX_HOME_PATH}/sessions"
-  cp -a /run/secrets/codex_sessions/. "${CODEX_HOME_PATH}/sessions/"
-else
-  entrypoint_log "codex_sessions action=skip source_exists=$([[ -d "/run/secrets/codex_sessions" ]] && echo true || echo false) target_exists=$([[ -d "${CODEX_HOME_PATH}/sessions" ]] && echo true || echo false) target_entries=$(count_entries "${CODEX_HOME_PATH}/sessions")"
-fi
 entrypoint_log "codex_home_result target=${CODEX_HOME_PATH} entries=$(count_entries "${CODEX_HOME_PATH}") agents_md=$([[ -f "${CODEX_HOME_PATH}/AGENTS.md" ]] && echo true || echo false) config_toml=$([[ -f "${CODEX_HOME_PATH}/config.toml" ]] && echo true || echo false) auth_json=$([[ -f "${CODEX_HOME_PATH}/auth.json" ]] && echo true || echo false) sessions_dir=$([[ -d "${CODEX_HOME_PATH}/sessions" ]] && echo true || echo false)"
 
-# Copy global claude config into ~/.claude/ so claude has a writable config dir.
-# Prefer the host-mounted path (injected by master when MASTER_PROJECT_DIR is set),
-# fall back to the baked-in image path (always present when using the standard image).
-# Pointing CLAUDE_CONFIG_DIR at a read-only mount causes claude to hang on first write.
+# Copy baked-in claude config into ~/.claude/ so claude has a writable config dir.
+# Pointing CLAUDE_CONFIG_DIR at a read-only path causes claude to hang on first write.
 CLAUDE_HOME="${HOME:-/workspace/home}/.claude"
 CLAUDE_CONFIG_SOURCE="-"
-if [[ -d "/run/secrets/master_claude_config" ]]; then
-  mkdir -p "${CLAUDE_HOME}"
-  CLAUDE_CONFIG_SOURCE="/run/secrets/master_claude_config"
-  entrypoint_log "claude_config source=mounted path=${CLAUDE_CONFIG_SOURCE} entries=$(count_entries "${CLAUDE_CONFIG_SOURCE}") claude_md=$([[ -f "${CLAUDE_CONFIG_SOURCE}/CLAUDE.md" ]] && echo true || echo false) settings_json=$([[ -f "${CLAUDE_CONFIG_SOURCE}/settings.json" ]] && echo true || echo false)"
-  cp -af /run/secrets/master_claude_config/. "${CLAUDE_HOME}/"
-elif [[ -d "/opt/codex-slack/config/claude-global" ]]; then
+if [[ -d "/opt/codex-slack/config/claude-global" ]]; then
   mkdir -p "${CLAUDE_HOME}"
   CLAUDE_CONFIG_SOURCE="/opt/codex-slack/config/claude-global"
   entrypoint_log "claude_config source=baked_in path=${CLAUDE_CONFIG_SOURCE} entries=$(count_entries "${CLAUDE_CONFIG_SOURCE}") claude_md=$([[ -f "${CLAUDE_CONFIG_SOURCE}/CLAUDE.md" ]] && echo true || echo false) settings_json=$([[ -f "${CLAUDE_CONFIG_SOURCE}/settings.json" ]] && echo true || echo false)"
   cp -af /opt/codex-slack/config/claude-global/. "${CLAUDE_HOME}/"
 else
-  entrypoint_log "claude_config source=none mounted_exists=$([[ -d "/run/secrets/master_claude_config" ]] && echo true || echo false) baked_in_exists=$([[ -d "/opt/codex-slack/config/claude-global" ]] && echo true || echo false)"
+  entrypoint_log "claude_config source=none baked_in_exists=$([[ -d "/opt/codex-slack/config/claude-global" ]] && echo true || echo false)"
 fi
 entrypoint_log "claude_config_result target=${CLAUDE_HOME} entries=$(count_entries "${CLAUDE_HOME}") claude_md=$([[ -f "${CLAUDE_HOME}/CLAUDE.md" ]] && echo true || echo false) settings_json=$([[ -f "${CLAUDE_HOME}/settings.json" ]] && echo true || echo false) source=${CLAUDE_CONFIG_SOURCE}"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ This directory is the canonical home for repository documentation.
 - [`docs/design/containers/cd-container-design.md`](design/containers/cd-container-design.md) — CD daemon container startup, deploy loop, rollback, and state
 - [`docs/design/containers/environment-variable-passdown-design.md`](design/containers/environment-variable-passdown-design.md) — environment variable loading, normalization, and passdown across CD, master, and agent
 - [`docs/design/agent-container-runtime-design.md`](design/agent-container-runtime-design.md) — canonical runtime contract for agent containers
+- [`docs/design/agent-runtime-cleanup-detailed-design.md`](design/agent-runtime-cleanup-detailed-design.md) — proposed cleanup of transitional agent runtime startup behavior
 - [`docs/design/agent-provisioning-detailed-design.md`](design/agent-provisioning-detailed-design.md) — detailed design for agent/channel/repo provisioning
 - [`docs/design/master-agent-interface-design.md`](design/master-agent-interface-design.md) — canonical interface between master and agent containers
 - [`docs/design/frontend-master-interface-design.md`](design/frontend-master-interface-design.md) — canonical interface between Slack/Discord and master
@@ -48,6 +49,7 @@ This directory is the canonical home for repository documentation.
 ## Decisions
 
 - [`docs/decisions/README.md`](decisions/README.md) — ADR directory conventions
+- [`docs/decisions/0004-agent-runtime-cleanup.md`](decisions/0004-agent-runtime-cleanup.md) — proposed simplification of agent startup config, session, and repo-refresh behavior
 
 ## Archive
 

--- a/docs/decisions/0004-agent-runtime-cleanup.md
+++ b/docs/decisions/0004-agent-runtime-cleanup.md
@@ -88,7 +88,7 @@ should stop seeding `CODEX_HOME/sessions` from it.
 Session state becomes local runtime state inside the agent workspace volume,
 not startup passdown state.
 
-### 4. Non-destructive repo refresh
+### 4. Clone-only startup repo behavior
 
 The agent worker should stop force-aligning existing repos with:
 
@@ -97,8 +97,8 @@ The agent worker should stop force-aligning existing repos with:
 The cleanup target is:
 
 - clone when the repo is absent
-- when the repo already exists, update only if the working tree is clean
-- fail explicitly when local modifications or divergence would be overwritten
+- if `/workspace/repo` is already a valid git repo, do nothing during startup
+- treat repo startup as repo presence validation, not repo refresh
 
 This makes repo startup behavior safer and easier to diagnose.
 
@@ -114,8 +114,7 @@ flowchart TD
     F --> G[worker repo sync]
     G --> H{repo exists?}
     H -->|no| I[git clone]
-    H -->|yes and clean| J[safe fetch and checkout/update]
-    H -->|yes and dirty/diverged| K[fail with explicit status]
+    H -->|yes| J[leave existing repo unchanged]
 ```
 
 ## Target Runtime Contract
@@ -186,7 +185,7 @@ Positive:
 - startup behavior becomes deterministic
 - agent images become the single source of shared default instructions
 - durable session state is no longer injected from master
-- repo refresh is safer for durable workspaces
+- startup no longer mutates an existing durable repo checkout
 - troubleshooting becomes simpler because path precedence shrinks
 
 Tradeoffs:
@@ -204,14 +203,14 @@ Implementation should land in a coordinated slice:
 1. remove `/workspace/.codex` selection from `docker/entrypoint.sh`
 2. remove master-side mounted global config passdown
 3. remove session-seed mount and startup copy
-4. replace destructive repo refresh with a safe clean-tree-only update path
+4. replace destructive repo refresh with clone-only startup behavior
 5. update docs and startup diagnostics to reflect the simplified contract
 
 During rollout, operator guidance should explicitly note:
 
 - shared global instruction changes now require a newer agent image
 - `/master-agent-start` must refresh the image source before recreating agents
-- dirty repo worktrees will now fail startup instead of being silently reset
+- existing valid repo checkouts will now be left unchanged during startup
 
 ## Implementation Guidance
 
@@ -221,6 +220,7 @@ through `#56`:
 - remove `/workspace/.codex` support from master-managed startup
 - remove mounted global Codex and Claude config support
 - remove Codex session passthrough support
-- replace destructive repo reset with a non-destructive update policy
+- replace destructive repo reset with clone-only startup behavior for existing
+  valid repos
 - update tests and docs together because this changes the published runtime
   contract

--- a/docs/decisions/0004-agent-runtime-cleanup.md
+++ b/docs/decisions/0004-agent-runtime-cleanup.md
@@ -1,0 +1,226 @@
+# 0004 Agent Runtime Cleanup
+
+- Status: proposed
+- Date: 2026-04-07
+- Issues:
+  - [#53](https://github.com/pandazxx/codex-slack/issues/53)
+  - [#54](https://github.com/pandazxx/codex-slack/issues/54)
+  - [#55](https://github.com/pandazxx/codex-slack/issues/55)
+  - [#56](https://github.com/pandazxx/codex-slack/issues/56)
+
+## Context
+
+The current agent startup path still carries several transitional behaviors that
+make the runtime contract harder to reason about:
+
+1. `docker/entrypoint.sh` can select `CODEX_HOME` from either:
+   - explicit `CODEX_HOME`
+   - `/workspace/.codex`
+   - `/home/appuser/.codex`
+2. global Codex and Claude config can come from either:
+   - read-only mounts injected by master
+   - baked-in image content
+3. Codex sessions can be seeded from `/run/secrets/codex_sessions`
+4. repo refresh in `src/agent/worker.py` uses:
+   - `git fetch`
+   - `git checkout`
+   - `git reset --hard`
+
+These behaviors were useful during bring-up, but they now create ambiguity:
+
+- user-scope config can be sourced from more than one place
+- startup behavior differs depending on prior volume contents
+- mounted config and mounted sessions blur the boundary between secret seeding
+  and durable writable home state
+- repo refresh can discard uncommitted changes in a durable workspace volume
+
+The current canonical docs already call these out as later-phase cleanup
+targets:
+
+- [`docs/design/containers/agent-container-design.md`](../design/containers/agent-container-design.md)
+- [`docs/design/agent-container-runtime-design.md`](../design/agent-container-runtime-design.md)
+
+## Decision
+
+Simplify the agent runtime contract around a single writable home location,
+baked-in shared defaults, no session passthrough, and a non-destructive repo
+refresh model.
+
+### 1. Fixed writable home
+
+For master-managed agent containers, the canonical writable Codex home is:
+
+- `/workspace/home/.codex`
+
+`/workspace/.codex` should no longer participate in `CODEX_HOME` selection.
+
+The entrypoint should still honor an explicit `CODEX_HOME` env override for
+non-standard or test-only execution paths, but master-managed startup should not
+rely on dynamic home-path discovery.
+
+### 2. Baked-in shared global config only
+
+Shared default instructions and config should come only from baked-in image
+content:
+
+- `/opt/codex-slack/config/codex-global`
+- `/opt/codex-slack/config/claude-global`
+
+Master should stop mounting global Codex and Claude config directories into
+agents, and the agent should stop reading:
+
+- `/run/secrets/master_codex_config`
+- `/run/secrets/master_claude_config`
+- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+
+This keeps the runtime contract simple:
+
+- image content defines shared defaults
+- writable home stores runtime-local mutable state
+- repo-local config remains project scope
+
+### 3. Remove Codex session passthrough
+
+Master should stop mounting `/run/secrets/codex_sessions`, and the entrypoint
+should stop seeding `CODEX_HOME/sessions` from it.
+
+Session state becomes local runtime state inside the agent workspace volume,
+not startup passdown state.
+
+### 4. Non-destructive repo refresh
+
+The agent worker should stop force-aligning existing repos with:
+
+- `git reset --hard origin/<ref>`
+
+The cleanup target is:
+
+- clone when the repo is absent
+- when the repo already exists, update only if the working tree is clean
+- fail explicitly when local modifications or divergence would be overwritten
+
+This makes repo startup behavior safer and easier to diagnose.
+
+## Decision Diagram
+
+```mermaid
+flowchart TD
+    A[Master starts agent container] --> B[fixed CODEX_HOME=/workspace/home/.codex]
+    B --> C[entrypoint seeds baked-in Codex config]
+    C --> D[entrypoint seeds baked-in Claude config]
+    D --> E[no mounted global config passthrough]
+    E --> F[no Codex session passthrough]
+    F --> G[worker repo sync]
+    G --> H{repo exists?}
+    H -->|no| I[git clone]
+    H -->|yes and clean| J[safe fetch and checkout/update]
+    H -->|yes and dirty/diverged| K[fail with explicit status]
+```
+
+## Target Runtime Contract
+
+### User scope
+
+- Codex user scope: `/workspace/home/.codex`
+- Claude user scope: `/workspace/home/.claude`
+- XDG config home: `/workspace/home/.config`
+
+### Shared defaults
+
+- come from the built image, not master-mounted directories
+- are refreshed into writable home on startup
+
+### Project scope
+
+- remains repo-local:
+  - `/workspace/repo/.codex`
+  - `/workspace/repo/.claude`
+  - repo-root `AGENTS.md`
+
+### Secret/auth scope
+
+Startup may still seed auth materials that are true secrets, such as:
+
+- Codex auth file
+- SSH agent socket
+- token env vars
+
+But session history and global config are no longer treated as secret-mount
+startup inputs.
+
+## Alternatives Considered
+
+### 1. Keep the current mixed-source startup behavior
+
+Rejected.
+
+It preserves compatibility but keeps the runtime contract ambiguous and makes
+operator diagnosis harder.
+
+### 2. Remove only the destructive repo reset and keep the rest
+
+Rejected.
+
+That would address issue `#56` but would leave the broader startup contract
+split across mounts, image content, and volume state.
+
+### 3. Move all shared config fully into repo-local scope
+
+Rejected.
+
+Global container-level instructions still need a shared default independent of
+any specific repo. Baked-in image config is the cleaner boundary.
+
+### 4. Keep mounted config but make it read-only precedence only
+
+Rejected.
+
+It would still preserve two authoritative sources for shared defaults and would
+keep master-to-agent passdown more complex than necessary.
+
+## Consequences
+
+Positive:
+
+- startup behavior becomes deterministic
+- agent images become the single source of shared default instructions
+- durable session state is no longer injected from master
+- repo refresh is safer for durable workspaces
+- troubleshooting becomes simpler because path precedence shrinks
+
+Tradeoffs:
+
+- updating shared defaults now requires an updated agent image
+- operators lose the ability to hot-swap shared config through master-only mount
+  changes
+- some existing deployments may depend on the old transitional behavior and need
+  migration
+
+## Migration Guidance
+
+Implementation should land in a coordinated slice:
+
+1. remove `/workspace/.codex` selection from `docker/entrypoint.sh`
+2. remove master-side mounted global config passdown
+3. remove session-seed mount and startup copy
+4. replace destructive repo refresh with a safe clean-tree-only update path
+5. update docs and startup diagnostics to reflect the simplified contract
+
+During rollout, operator guidance should explicitly note:
+
+- shared global instruction changes now require a newer agent image
+- `/master-agent-start` must refresh the image source before recreating agents
+- dirty repo worktrees will now fail startup instead of being silently reset
+
+## Implementation Guidance
+
+Engineer and tester should treat this ADR as the boundary for issues `#53`
+through `#56`:
+
+- remove `/workspace/.codex` support from master-managed startup
+- remove mounted global Codex and Claude config support
+- remove Codex session passthrough support
+- replace destructive repo reset with a non-destructive update policy
+- update tests and docs together because this changes the published runtime
+  contract

--- a/docs/design/agent-container-runtime-design.md
+++ b/docs/design/agent-container-runtime-design.md
@@ -73,8 +73,6 @@ Optional shared auth and config inputs may also be provided:
 - `OPENAI_API_KEY`
 - `CLAUDE_CODE_OAUTH_TOKEN`
 - `ANTHROPIC_API_KEY`
-- `AGENT_GLOBAL_CODEX_CONFIG_DIR=/run/secrets/master_codex_config`
-- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR=/run/secrets/master_claude_config`
 
 Per-request dispatch may also inject:
 
@@ -112,10 +110,9 @@ This matches the headless container model used by the repository.
 
 ### Codex
 
-Shared Codex defaults are provided from a host directory:
+Shared Codex defaults are provided from baked-in image content:
 
-- source env: `MASTER_CODEX_CONFIG_DIR_PATH`
-- mounted in agent: `/run/secrets/master_codex_config:ro`
+- image path: `/opt/codex-slack/config/codex-global`
 - copied into user scope: `/workspace/home/.codex/`
 
 This directory may include files such as:
@@ -127,10 +124,9 @@ These are user-scope defaults for every agent.
 
 ### Claude Code
 
-Shared Claude defaults are provided from a host directory:
+Shared Claude defaults are provided from baked-in image content:
 
-- source env: `MASTER_CLAUDE_CONFIG_DIR_PATH`
-- mounted in agent: `/run/secrets/master_claude_config:ro`
+- image path: `/opt/codex-slack/config/claude-global`
 - copied into user scope: `/workspace/home/.claude/`
 
 These defaults typically include:

--- a/docs/design/agent-runtime-cleanup-detailed-design.md
+++ b/docs/design/agent-runtime-cleanup-detailed-design.md
@@ -14,7 +14,7 @@ This design covers:
 - fixed `CODEX_HOME` behavior
 - removal of mounted global config support
 - removal of Codex session passthrough
-- non-destructive repo refresh rules
+- clone-only repo startup rules
 - required code, test, and documentation updates
 
 ## Current Behavior
@@ -61,7 +61,8 @@ Master-managed agent startup should behave as follows:
 3. entrypoint copies baked-in Codex config into `CODEX_HOME`
 4. entrypoint copies baked-in Claude config into `~/.claude`
 5. worker does not re-import shared config from master-mounted paths
-6. worker syncs the repo safely without destructive reset
+6. worker clones the repo only when absent and otherwise leaves an existing
+   valid repo unchanged
 
 ## Component Changes
 
@@ -130,7 +131,7 @@ The remaining workspace prepare responsibilities should be:
 - log repo-local project-scope config state
 - apply repo-local git identity
 
-### Replace destructive update path
+### Replace destructive update path with clone-only startup
 
 Current update path:
 
@@ -140,32 +141,29 @@ git checkout <ref>
 git reset --hard origin/<ref>
 ```
 
-Target update policy:
+Target startup policy:
 
 1. if `/workspace/repo/.git` is missing:
    - `git clone --branch <ref> <url> /workspace/repo`
 2. if repo exists:
-   - verify the checkout is clean before changing it
-   - fetch the target ref
-   - switch to the requested ref only when safe
-   - align to the fetched target only when there are no local modifications to
-     overwrite
-3. if the repo is dirty or otherwise unsafe to update:
+   - validate that `/workspace/repo` is a git repo
+   - do not fetch
+   - do not checkout
+   - do not reset
+   - leave the existing repo unchanged
+3. if the path exists but is not a valid git repo:
    - fail startup with an explicit `AgentInitError("repo_sync", ...)`
 
-### Safe-update checks
+### Repo validation rule
 
-The worker should inspect:
+The worker should treat repo startup as a presence/validity check:
 
-- `git status --porcelain`
-- current branch / detached state as needed
+- absent repo: clone
+- valid git repo: keep as-is
+- invalid repo path: fail
 
-If any local modifications are present, the worker should fail instead of
-discarding them.
-
-The v1 cleanup does not need automatic stash, merge, or branch-repair logic.
-
-Failure is the intended safe behavior.
+The v1 cleanup intentionally removes startup-time branch alignment and remote
+refresh from the worker lifecycle.
 
 ### 3. `src/master/service.py`
 
@@ -235,7 +233,7 @@ Keep:
 
 - `agent.worker_settings`
 - repo-local scope logs
-- safe repo-sync status and failure reason
+- clone-vs-existing-repo status and failure reason
 
 Remove references to:
 
@@ -250,10 +248,10 @@ stateDiagram-v2
     Starting --> SeedHome
     SeedHome --> Preflight
     Preflight --> RepoClone: repo absent
-    Preflight --> RepoRefresh: repo present
+    Preflight --> RepoValidate: repo present
     RepoClone --> WorkspacePrepare
-    RepoRefresh --> WorkspacePrepare: clean and updated
-    RepoRefresh --> Failed: dirty or unsafe to update
+    RepoValidate --> WorkspacePrepare: valid git repo
+    RepoValidate --> Failed: invalid repo path
     WorkspacePrepare --> Ready
     Ready --> Dispatching
     Dispatching --> Ready
@@ -270,9 +268,9 @@ flowchart TD
     D --> E[preflight auth check]
     E --> F{repo exists?}
     F -->|no| G[git clone]
-    F -->|yes| H[check clean worktree]
-    H -->|dirty| I[fail repo_sync]
-    H -->|clean| J[fetch and safe checkout/update]
+    F -->|yes| H[validate .git]
+    H -->|invalid| I[fail repo_sync]
+    H -->|valid| J[leave repo unchanged]
     G --> K[workspace prepare]
     J --> K
     K --> L[ready]
@@ -287,7 +285,7 @@ This cleanup intentionally breaks these transitional behaviors:
 - `/workspace/.codex` no longer acts as an implicit user-scope home
 - master-side mounted global config no longer overrides image defaults
 - Codex sessions are no longer seeded from master-managed mounts
-- dirty repo worktrees no longer survive by being reset; startup fails instead
+- existing valid repo worktrees are no longer refreshed or aligned on startup
 
 ### Operational impact
 
@@ -303,9 +301,9 @@ Update or add coverage for:
 - entrypoint fixed `CODEX_HOME` selection
 - entrypoint baked-in config seeding without mounted-config branches
 - absence of session seed handling
-- worker safe repo clone path
-- worker safe repo refresh path on clean repo
-- worker failure on dirty repo
+- worker repo clone path
+- worker no-op path for an existing valid git repo
+- worker failure on an existing invalid repo path
 - master env/mount generation without global config passthrough
 
 ### Regression tests
@@ -315,7 +313,8 @@ Add explicit tests that:
 - `/workspace/.codex` is ignored by the startup contract
 - mounted global config env vars are not passed into agents
 - startup no longer references `codex_sessions`
-- dirty repo startup returns a repo-sync failure instead of discarding changes
+- startup leaves an existing valid repo unchanged
+- existing non-git repo paths fail with a repo-sync error
 
 ### Manual validation
 
@@ -323,9 +322,8 @@ UAT should verify:
 
 1. a fresh agent starts and receives baked-in Codex/Claude config
 2. updating the agent image and restarting refreshes shared defaults
-3. a dirty `/workspace/repo` causes startup to fail with an explicit repo-sync
-   error
-4. an existing clean repo updates safely without destructive reset
+3. an existing valid `/workspace/repo` is left unchanged on startup
+4. an invalid `/workspace/repo` path causes an explicit repo-sync error
 
 ## Documentation Updates
 
@@ -347,7 +345,7 @@ Recommended implementation order:
 1. remove master-side global config and session passdown
 2. simplify entrypoint startup sources
 3. simplify worker workspace-prepare logic
-4. replace repo reset with safe update/fail behavior
+4. replace repo reset with clone-only/no-op repo behavior
 5. update docs and UAT guidance
 
 This order keeps the contract moving from many sources to one source instead of

--- a/docs/design/agent-runtime-cleanup-detailed-design.md
+++ b/docs/design/agent-runtime-cleanup-detailed-design.md
@@ -1,0 +1,354 @@
+# Agent Runtime Cleanup Detailed Design
+
+**Status:** proposed  
+**Issues:** [#53](https://github.com/pandazxx/codex-slack/issues/53), [#54](https://github.com/pandazxx/codex-slack/issues/54), [#55](https://github.com/pandazxx/codex-slack/issues/55), [#56](https://github.com/pandazxx/codex-slack/issues/56)  
+**ADR:** [`docs/decisions/0004-agent-runtime-cleanup.md`](../decisions/0004-agent-runtime-cleanup.md)
+
+## Goal
+
+Implement the later-phase runtime cleanup that removes transitional startup
+behaviors from agent containers.
+
+This design covers:
+
+- fixed `CODEX_HOME` behavior
+- removal of mounted global config support
+- removal of Codex session passthrough
+- non-destructive repo refresh rules
+- required code, test, and documentation updates
+
+## Current Behavior
+
+### Entrypoint
+
+`docker/entrypoint.sh` currently:
+
+- chooses `CODEX_HOME` from explicit env, `/workspace/.codex`, or
+  `/home/appuser/.codex`
+- prefers mounted global config under `/run/secrets/...`
+- seeds Codex sessions from `/run/secrets/codex_sessions`
+- falls back to baked-in config only when the mounts are absent
+
+### Worker
+
+`src/agent/worker.py` currently:
+
+- copies mounted global config again during `workspace_prepare`
+- clones the repo when absent
+- forcibly resets an existing repo to `origin/<ref>`
+
+### Master
+
+`src/master/service.py` currently:
+
+- passes `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- passes `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+- mounts `MASTER_CODEX_CONFIG_DIR_PATH`
+- mounts `MASTER_CLAUDE_CONFIG_DIR_PATH`
+- may mount Codex session seed paths through the runtime adapter
+
+## Target Behavior
+
+### Canonical startup contract
+
+Master-managed agent startup should behave as follows:
+
+1. master sets:
+   - `HOME=/workspace/home`
+   - `XDG_CONFIG_HOME=/workspace/home/.config`
+   - `CODEX_HOME=/workspace/home/.codex`
+2. entrypoint uses that fixed path and does not inspect `/workspace/.codex`
+3. entrypoint copies baked-in Codex config into `CODEX_HOME`
+4. entrypoint copies baked-in Claude config into `~/.claude`
+5. worker does not re-import shared config from master-mounted paths
+6. worker syncs the repo safely without destructive reset
+
+## Component Changes
+
+### 1. `docker/entrypoint.sh`
+
+### Remove dynamic home fallback
+
+Replace:
+
+- explicit `CODEX_HOME`
+- else `/workspace/.codex`
+- else `/home/appuser/.codex`
+
+With:
+
+- explicit `CODEX_HOME` if already provided
+- otherwise `/workspace/home/.codex`
+
+For master-managed startup, `CODEX_HOME` is already provided by master, so the
+entrypoint should simply normalize and create the target directory.
+
+### Remove mounted global config inputs
+
+Delete support for:
+
+- `/run/secrets/master_codex_config`
+- `/run/secrets/master_claude_config`
+
+Startup should seed from baked-in image paths only:
+
+- `/opt/codex-slack/config/codex-global`
+- `/opt/codex-slack/config/claude-global`
+
+### Remove session passthrough
+
+Delete support for:
+
+- `/run/secrets/codex_sessions`
+
+and stop copying that directory into:
+
+- `CODEX_HOME/sessions`
+
+### Keep true secret/auth seeding
+
+Retain:
+
+- Codex auth seeding from `/run/secrets/codex_auth.json`
+- Git user config setup
+- existing runtime mode selection
+
+### 2. `src/agent/worker.py`
+
+### Remove mounted global config copy
+
+Delete `workspace_prepare` support for:
+
+- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+
+The worker should no longer treat mounted config directories as an input source.
+
+The remaining workspace prepare responsibilities should be:
+
+- ensure writable home directories exist
+- log repo-local project-scope config state
+- apply repo-local git identity
+
+### Replace destructive update path
+
+Current update path:
+
+```text
+git fetch origin <ref>
+git checkout <ref>
+git reset --hard origin/<ref>
+```
+
+Target update policy:
+
+1. if `/workspace/repo/.git` is missing:
+   - `git clone --branch <ref> <url> /workspace/repo`
+2. if repo exists:
+   - verify the checkout is clean before changing it
+   - fetch the target ref
+   - switch to the requested ref only when safe
+   - align to the fetched target only when there are no local modifications to
+     overwrite
+3. if the repo is dirty or otherwise unsafe to update:
+   - fail startup with an explicit `AgentInitError("repo_sync", ...)`
+
+### Safe-update checks
+
+The worker should inspect:
+
+- `git status --porcelain`
+- current branch / detached state as needed
+
+If any local modifications are present, the worker should fail instead of
+discarding them.
+
+The v1 cleanup does not need automatic stash, merge, or branch-repair logic.
+
+Failure is the intended safe behavior.
+
+### 3. `src/master/service.py`
+
+### Remove mounted config env passdown
+
+Stop injecting:
+
+- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+
+into the agent env.
+
+### Remove mounted config bind mounts
+
+Stop mounting:
+
+- `MASTER_CODEX_CONFIG_DIR_PATH` -> `/run/secrets/master_codex_config`
+- `MASTER_CLAUDE_CONFIG_DIR_PATH` -> `/run/secrets/master_claude_config`
+
+This makes agent startup independent of master-side config-directory mounts.
+
+### Keep image refresh behavior
+
+The current image refresh behavior remains required:
+
+- default image: pull on every `/master-agent-start`
+- project-specific image: rebuild on every `/master-agent-start`
+
+That is now the mechanism for delivering newer baked-in shared config.
+
+### 4. `src/master/runtime_adapter.py`
+
+Remove runtime mount wiring for:
+
+- global Codex config directory mounts
+- global Claude config directory mounts
+- Codex session seed mounts, if still present in the runtime adapter path
+
+The runtime adapter should continue supporting:
+
+- workspace volume
+- Codex auth seed
+- SSH agent socket / known hosts
+- transient request staging
+
+## Logging Changes
+
+Startup diagnostics should be simplified to match the new contract.
+
+### Entrypoint logs
+
+Keep:
+
+- selected `CODEX_HOME`
+- baked-in config source/result
+- auth seed result
+- final launch mode
+
+Remove references to:
+
+- mounted global config source selection
+- mounted session seed copy
+
+### Worker logs
+
+Keep:
+
+- `agent.worker_settings`
+- repo-local scope logs
+- safe repo-sync status and failure reason
+
+Remove references to:
+
+- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
+- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Starting
+    Starting --> SeedHome
+    SeedHome --> Preflight
+    Preflight --> RepoClone: repo absent
+    Preflight --> RepoRefresh: repo present
+    RepoClone --> WorkspacePrepare
+    RepoRefresh --> WorkspacePrepare: clean and updated
+    RepoRefresh --> Failed: dirty or unsafe to update
+    WorkspacePrepare --> Ready
+    Ready --> Dispatching
+    Dispatching --> Ready
+    Failed --> [*]
+```
+
+## Flow Chart
+
+```mermaid
+flowchart TD
+    A[container start] --> B[fixed CODEX_HOME]
+    B --> C[copy baked-in Codex config]
+    C --> D[copy baked-in Claude config]
+    D --> E[preflight auth check]
+    E --> F{repo exists?}
+    F -->|no| G[git clone]
+    F -->|yes| H[check clean worktree]
+    H -->|dirty| I[fail repo_sync]
+    H -->|clean| J[fetch and safe checkout/update]
+    G --> K[workspace prepare]
+    J --> K
+    K --> L[ready]
+```
+
+## Compatibility Impact
+
+### Breaking changes
+
+This cleanup intentionally breaks these transitional behaviors:
+
+- `/workspace/.codex` no longer acts as an implicit user-scope home
+- master-side mounted global config no longer overrides image defaults
+- Codex sessions are no longer seeded from master-managed mounts
+- dirty repo worktrees no longer survive by being reset; startup fails instead
+
+### Operational impact
+
+Operators must treat shared instruction/config updates as an image rollout
+concern, not a master env-only change.
+
+## Test Plan
+
+### Unit tests
+
+Update or add coverage for:
+
+- entrypoint fixed `CODEX_HOME` selection
+- entrypoint baked-in config seeding without mounted-config branches
+- absence of session seed handling
+- worker safe repo clone path
+- worker safe repo refresh path on clean repo
+- worker failure on dirty repo
+- master env/mount generation without global config passthrough
+
+### Regression tests
+
+Add explicit tests that:
+
+- `/workspace/.codex` is ignored by the startup contract
+- mounted global config env vars are not passed into agents
+- startup no longer references `codex_sessions`
+- dirty repo startup returns a repo-sync failure instead of discarding changes
+
+### Manual validation
+
+UAT should verify:
+
+1. a fresh agent starts and receives baked-in Codex/Claude config
+2. updating the agent image and restarting refreshes shared defaults
+3. a dirty `/workspace/repo` causes startup to fail with an explicit repo-sync
+   error
+4. an existing clean repo updates safely without destructive reset
+
+## Documentation Updates
+
+Update these docs together with implementation:
+
+- [`docs/design/containers/agent-container-design.md`](containers/agent-container-design.md)
+- [`docs/design/agent-container-runtime-design.md`](agent-container-runtime-design.md)
+- [`docs/design/containers/environment-variable-passdown-design.md`](containers/environment-variable-passdown-design.md)
+- [`docs/guides/container-runtime.md`](../guides/container-runtime.md)
+- [`docs/references/config.md`](../references/config.md)
+
+The later-phase cleanup notes in the container design should be converted into
+current-state wording once the implementation lands.
+
+## Rollout Order
+
+Recommended implementation order:
+
+1. remove master-side global config and session passdown
+2. simplify entrypoint startup sources
+3. simplify worker workspace-prepare logic
+4. replace repo reset with safe update/fail behavior
+5. update docs and UAT guidance
+
+This order keeps the contract moving from many sources to one source instead of
+mixing old and new behavior across layers.

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -106,8 +106,6 @@ Optional but common inputs:
 - `GH_TOKEN` / `GITHUB_TOKEN`
 - `OPENAI_API_KEY`
 - `CLAUDE_CODE_OAUTH_TOKEN`
-- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
-- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
 - `SSH_AUTH_SOCK`
 - `GIT_SSH_COMMAND`
 - `AGENT_REQUEST_MANIFEST`
@@ -117,17 +115,9 @@ Optional but common inputs:
 The master typically mounts:
 
 - workspace volume at `/workspace`
-- global Codex config at `/run/secrets/master_codex_config`
-- global Claude config at `/run/secrets/master_claude_config`
 - Codex auth seed at `/run/secrets/codex_auth.json`
-- Codex sessions seed at `/run/secrets/codex_sessions` when applicable
 - SSH agent socket at `/run/secrets/ssh-auth.sock`
 - transient request data under `/workspace/message/...`
-
-Later-phase cleanup target:
-
-- remove the mounted Codex session-seed passthrough and simplify startup so
-  session state is no longer seeded from `/run/secrets/codex_sessions`
 
 ## Storage Layout
 
@@ -191,13 +181,7 @@ stateDiagram-v2
 The entrypoint chooses `CODEX_HOME` in this order:
 
 1. explicit `CODEX_HOME`
-2. project-level `/workspace/.codex` if it already exists in the mounted
-   workspace volume before the entrypoint runs
-3. default `/home/appuser/.codex`
-
-In normal master-managed agent startup, `/workspace` is a named volume and
-usually starts empty, so the second case normally does not apply unless
-something created `/workspace/.codex` in that volume earlier.
+2. default `/workspace/home/.codex`
 
 It then ensures the selected directory exists and refreshes global config into
 it.
@@ -206,25 +190,13 @@ it.
 
 Codex:
 
-- prefers `/run/secrets/master_codex_config`
-- falls back to baked-in `/opt/codex-slack/config/codex-global`
+- uses baked-in `/opt/codex-slack/config/codex-global`
 - copies into writable `CODEX_HOME`
-
-Later-phase cleanup target:
-
-- remove the mounted global Codex config passthrough and rely on baked-in global
-  Codex config as the single shared-default source
 
 Claude:
 
-- prefers `/run/secrets/master_claude_config`
-- falls back to baked-in `/opt/codex-slack/config/claude-global`
+- uses baked-in `/opt/codex-slack/config/claude-global`
 - copies into writable `~/.claude`
-
-Later-phase cleanup target:
-
-- remove the mounted global Claude config passthrough and rely on baked-in
-  global Claude config as the single shared-default source
 
 ### 3. Auth/session seeding
 
@@ -235,13 +207,8 @@ Codex auth:
 
 Codex sessions:
 
-- copies `/run/secrets/codex_sessions` into `CODEX_HOME/sessions` only when the
-  target session directory is absent or empty
-
-Later-phase cleanup target:
-
-- remove the mounted Codex session seed and stop treating session data as a
-  startup passthrough concern
+- are local runtime state in `CODEX_HOME/sessions`
+- are not seeded from master-mounted startup inputs
 
 Claude auth:
 
@@ -263,22 +230,11 @@ Claude auth:
   - clone path:
     - used when `/workspace/repo/.git` does not exist
     - command: `git clone --branch <AGENT_REPO_REF> <AGENT_REPO_URL> /workspace/repo`
-  - update path:
-    - used when `/workspace/repo/.git` already exists
-    - commands:
-      - `git fetch origin <AGENT_REPO_REF>`
-      - `git checkout <AGENT_REPO_REF>`
-      - `git reset --hard origin/<AGENT_REPO_REF>`
-    - this is not a merge-style `git pull`; it forcibly aligns the local repo to
-      the requested remote ref
-    - later-phase cleanup target:
-      - remove this destructive hard-reset update behavior and replace it with a
-        less destructive repo refresh strategy
+  - existing repo path:
+    - used when `/workspace/repo` already exists as a valid git repo
+    - startup leaves the repo unchanged
+    - if the path exists but is not a valid git repo, startup fails
 - prepare workspace/home directories
-- copy shared global config into writable user scope again from the mounted env
-  path when configured
-  - `AGENT_GLOBAL_CODEX_CONFIG_DIR` for Codex
-  - `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` for Claude
 - record status for master-side inspection
 
 ## Request Handling Contract
@@ -310,8 +266,7 @@ Important logs include:
 - `agent.worker_settings`
 - `agent.stage ...`
 - `agent.workspace_prepare_state`
-- `agent.workspace_prepare_copied`
-- `agent.workspace_prepare_copy_skipped`
+- `agent.repo_sync_existing_repo`
 
 The entrypoint also runs with shell tracing enabled to make copy and launch
 behavior diagnosable.

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -16,6 +16,7 @@ Define the agent container as a runtime unit:
 This is the container-focused companion to:
 
 - [`docs/design/agent-container-runtime-design.md`](../agent-container-runtime-design.md)
+- [`docs/design/agent-runtime-cleanup-detailed-design.md`](../agent-runtime-cleanup-detailed-design.md)
 - [`docs/design/master-agent-interface-design.md`](../master-agent-interface-design.md)
 - [`docs/references/config.md`](../../references/config.md)
 - [`docs/references/logging.md`](../../references/logging.md)

--- a/docs/design/containers/environment-variable-passdown-design.md
+++ b/docs/design/containers/environment-variable-passdown-design.md
@@ -126,8 +126,8 @@ vars or mount points.
 |---|---|---|---|---|
 | `MASTER_AGENT_BASE_IMAGE` | `agent_base_image` | not a path | none | image reference used at container create/start time |
 | `MASTER_CODEX_AUTH_JSON_PATH` | `agent_codex_auth_json_path` | host path | none | mount at `/run/secrets/codex_auth.json` |
-| `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | host path | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | env value `/run/secrets/master_codex_config` plus matching mount |
-| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `agent_claude_config_dir_path` | host path | `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | env value `/run/secrets/master_claude_config` plus matching mount |
+| `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | host path | none | deprecated legacy setting; no longer passed into agents |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `agent_claude_config_dir_path` | host path | none | deprecated legacy setting; no longer passed into agents |
 | `MASTER_SSH_AUTH_SOCK_PATH` | `agent_ssh_auth_sock_path` | host path | `SSH_AUTH_SOCK` | env value `/run/secrets/ssh-auth.sock` plus matching mount |
 | `MASTER_SSH_KNOWN_HOSTS_PATH` | `agent_ssh_known_hosts_path` | host path | `GIT_SSH_COMMAND` | env embeds mounted in-container path `/run/secrets/ssh_known_hosts` if configured |
 | `MASTER_GIT_USER_NAME` | `git_user_name` | not a path | `AGENT_GIT_USER_NAME` | string passed through |
@@ -142,9 +142,7 @@ vars or mount points.
 `MASTER_PROJECT_DIR` is special:
 
 - it is loaded by `load_master_settings()`
-- it may be used to auto-detect:
-  - `MASTER_CODEX_CONFIG_DIR_PATH`
-  - `MASTER_CLAUDE_CONFIG_DIR_PATH`
+- it may still be used to auto-detect historical config-dir env vars
 - it is not passed to the agent directly
 
 ## 3. Master-to-Agent Env Construction
@@ -175,8 +173,6 @@ The important agent env keys built by master are:
 | `AGENT_REPO_URL` | agent record `repo_source`; not a path | worker |
 | `AGENT_REPO_REF` | agent record `repo_ref`; not a path | worker |
 | `AGENT_ADAPTER` | agent record or master default; not a path | dispatch-time semantics and logs |
-| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | master mount contract; mounted in-container path | worker |
-| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | master mount contract; mounted in-container path | worker |
 | `AGENT_GIT_USER_NAME` | `MASTER_GIT_USER_NAME`; not a path | worker |
 | `AGENT_GIT_USER_EMAIL` | `MASTER_GIT_USER_EMAIL`; not a path | worker |
 | `SSH_AUTH_SOCK` | SSH mount contract; mounted in-container path | worker / git |
@@ -216,7 +212,7 @@ The agent consumes env in two stages:
 It uses those values to:
 
 - choose the writable Codex home
-- seed global config and auth from mounted sources
+- seed baked-in global config and auth into writable homes
 - configure global Git identity
 - decide whether to launch `src.agent.main`
 
@@ -237,8 +233,6 @@ It uses those values to:
 The worker also reads some env directly instead of storing them in
 `WorkerSettings`:
 
-- `AGENT_GLOBAL_CODEX_CONFIG_DIR`
-- `AGENT_GLOBAL_CLAUDE_CONFIG_DIR`
 - `SSH_AUTH_SOCK`
 - `GH_TOKEN`
 - `GITHUB_TOKEN`
@@ -252,8 +246,6 @@ The main env-name translation patterns are:
 
 | Host-side name | Agent-side name | Reason |
 |---|---|---|
-| `MASTER_CODEX_CONFIG_DIR_PATH` | `AGENT_GLOBAL_CODEX_CONFIG_DIR` | host path becomes in-container mounted source path |
-| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | same pattern for Claude |
 | `MASTER_GIT_USER_NAME` | `AGENT_GIT_USER_NAME` | explicit agent-scoped identity input |
 | `MASTER_GIT_USER_EMAIL` | `AGENT_GIT_USER_EMAIL` | explicit agent-scoped identity input |
 | `CD_*` | none | CD settings stay local to the daemon |
@@ -263,8 +255,6 @@ Mount-path translation is just as important as env translation:
 | Host path env | In-container mounted path |
 |---|---|
 | `MASTER_CODEX_AUTH_JSON_PATH` | `/run/secrets/codex_auth.json` |
-| `MASTER_CODEX_CONFIG_DIR_PATH` | `/run/secrets/master_codex_config` |
-| `MASTER_CLAUDE_CONFIG_DIR_PATH` | `/run/secrets/master_claude_config` |
 | `MASTER_SSH_AUTH_SOCK_PATH` | `/run/secrets/ssh-auth.sock` |
 
 ## 6. Observability

--- a/docs/guides/container-runtime.md
+++ b/docs/guides/container-runtime.md
@@ -35,26 +35,23 @@ The provided `docker-compose.yml` mounts:
 - Workspace: `./:/workspace`
 - Bot logs: `./logs:/workspace/logs`
 - Codex auth cache file (as secret input): `${HOME}/.codex/auth.json:/run/secrets/codex_auth.json:ro`
-- Codex sessions directory (as secret input): `${HOME}/.codex/sessions:/run/secrets/codex_sessions:ro`
 
-Only the Codex auth + sessions paths are mounted read-only; the rest of your host auth/config files are not required.
+Only the Codex auth path is mounted read-only; the rest of your host auth/config files are not required.
 - Slack secrets are provided via environment variables.
 - Codex authentication is provided by copying mounted auth cache into writable `CODEX_HOME` at startup.
+- Shared Codex and Claude defaults are provided from baked-in image content, not host-mounted config directories.
 - Claude authentication is provided either by `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`.
 - GitHub authentication is provided via `GH_TOKEN`.
 - `CODEX_HOME` selection on startup:
   1. Use explicit `CODEX_HOME` env var if set.
   2. Else use `/workspace/home/.codex` for the master-managed agent runtime.
-  3. Else fallback to `/home/appuser/.codex`.
 
 ## Safe Forwarding of `auth.json`
 Configured in compose (default):
 - bind mount `~/.codex/auth.json` to `/run/secrets/codex_auth.json:ro`
-- bind mount `~/.codex/sessions` to `/run/secrets/codex_sessions:ro`
-- entrypoint copies auth/sessions into `${CODEX_HOME}` only when missing
+- entrypoint copies auth into `${CODEX_HOME}` when missing
 - avoids permission errors for Codex caches/skills writes under `CODEX_HOME`
 - prevents direct writes back to host auth file
-- prevents direct writes back to host session files
 - token refresh updates still will not persist to host from container
 - refresh token manually on host (`codex login`) and restart container when needed
 
@@ -113,29 +110,7 @@ Prepare Codex auth on host (once):
 ```bash
 codex login
 test -f ~/.codex/auth.json
-test -d ~/.codex/sessions
 ```
-
-## Project-Specific `CODEX_HOME` (Recommended)
-If `./.codex` exists in your repository root, container startup uses it automatically as `CODEX_HOME`.
-
-Bootstrap project-local Codex state from global host state:
-```bash
-mkdir -p .codex
-cp ~/.codex/auth.json .codex/auth.json
-cp -a ~/.codex/sessions .codex/sessions
-cp ~/.codex/config.toml .codex/config.toml 2>/dev/null || true
-chmod 700 .codex
-chmod 600 .codex/auth.json
-```
-
-Use project-local Codex on host too:
-```bash
-export CODEX_HOME="$PWD/.codex"
-codex resume
-```
-
-Do not commit project-local Codex state. Keep `.codex/` in `.gitignore`.
 
 ## Run Example
 ```bash

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -31,9 +31,9 @@ This page summarizes the main configuration keys loaded directly from the curren
 | `MASTER_DRY_RUN` | No | `false` | Disable side-effecting runtime actions |
 | `MASTER_AGENT_BASE_IMAGE` | No | `codex-slack-bot:latest` | Default image for new agents |
 | `MASTER_CODEX_AUTH_JSON_PATH` | No | unset | Host path to the shared Codex auth file mounted into agents |
-| `MASTER_CODEX_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/codex-global`, fallback `config/codex`) | Host path to the shared Codex config directory mounted into agents |
-| `MASTER_CLAUDE_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/claude-global`) | Host path to the shared Claude config directory mounted into agents |
-| `MASTER_PROJECT_DIR` | No | unset | Host project root used for global config auto-detection |
+| `MASTER_CODEX_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/codex-global`, fallback `config/codex`) | Deprecated legacy host path for historical Codex config passthrough; agent startup now uses baked-in image config |
+| `MASTER_CLAUDE_CONFIG_DIR_PATH` | No | unset or auto-detected from `MASTER_PROJECT_DIR` (`config/claude-global`) | Deprecated legacy host path for historical Claude config passthrough; agent startup now uses baked-in image config |
+| `MASTER_PROJECT_DIR` | No | unset | Host project root used for related path detection |
 | `MASTER_SSH_AUTH_SOCK_PATH` | No | unset | Host path to the SSH agent socket mounted into master/agents |
 | `MASTER_SSH_KNOWN_HOSTS_PATH` | No | unset | Host path to the SSH known-hosts file mounted into agents |
 | `MASTER_GIT_USER_NAME` | No | unset | Git author name for agent workspaces |
@@ -55,10 +55,8 @@ This page summarizes the main configuration keys loaded directly from the curren
 | `AGENT_REPO_REF` | No | `main` | Ref to check out |
 | `AGENT_REPO_DIR` | No | `repo` | Checkout directory name |
 | `AGENT_STATUS_FILE` | No | `/tmp/master-agent/status.json` | Container path inside the agent for the readiness status file |
-| `CODEX_HOME` | No | `/home/appuser/.codex` | Container path inside the agent for the writable Codex home |
+| `CODEX_HOME` | No | `/workspace/home/.codex` | Container path inside the agent for the writable Codex home |
 | `AGENT_READY_POLL_SECONDS` | No | `5` | Readiness polling interval |
-| `AGENT_GLOBAL_CODEX_CONFIG_DIR` | No | empty | Container path inside the agent pointing at the mounted shared Codex config source |
-| `AGENT_GLOBAL_CLAUDE_CONFIG_DIR` | No | empty | Container path inside the agent pointing at the mounted shared Claude config source |
 | `AGENT_GIT_USER_NAME` | No | empty | Per-agent Git author name |
 | `AGENT_GIT_USER_EMAIL` | No | empty | Per-agent Git author email |
 | `SSH_AUTH_SOCK` | No | empty | Container path inside the agent to the passed-through SSH agent socket |

--- a/src/agent/worker.py
+++ b/src/agent/worker.py
@@ -72,21 +72,6 @@ def _run_git(args: list[str], cwd: str | None = None) -> subprocess.CompletedPro
     return completed
 
 
-def _copy_tree(src: Path, dst: Path, *, overwrite: bool) -> None:
-    if not src.exists() or not src.is_dir():
-        return
-    dst.mkdir(parents=True, exist_ok=True)
-    for entry in src.iterdir():
-        target = dst / entry.name
-        if entry.is_dir():
-            _copy_tree(entry, target, overwrite=overwrite)
-            continue
-        if target.exists() and not overwrite:
-            continue
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(entry.read_bytes())
-
-
 def stage_preflight(settings: WorkerSettings) -> None:
     workspace = Path(settings.workspace_path)
     workspace.mkdir(parents=True, exist_ok=True)
@@ -120,16 +105,20 @@ def stage_repo_sync(settings: WorkerSettings) -> Path:
         raise AgentInitError("repo_sync", "AGENT_REPO_URL is required")
 
     repo_dir = Path(settings.workspace_path) / settings.repo_dir_name
-    git_dir = repo_dir / ".git"
-
-    if not git_dir.exists():
+    if not repo_dir.exists():
         repo_dir.parent.mkdir(parents=True, exist_ok=True)
         _run_git(["git", "clone", "--branch", settings.repo_ref, settings.repo_url, str(repo_dir)])
         return repo_dir
 
-    _run_git(["git", "fetch", "origin", settings.repo_ref], cwd=str(repo_dir))
-    _run_git(["git", "checkout", settings.repo_ref], cwd=str(repo_dir))
-    _run_git(["git", "reset", "--hard", f"origin/{settings.repo_ref}"], cwd=str(repo_dir))
+    try:
+        completed = _run_git(["git", "rev-parse", "--is-inside-work-tree"], cwd=str(repo_dir))
+    except RuntimeError as exc:
+        raise AgentInitError("repo_sync", f"existing repo path is not a valid git repo: {repo_dir} ({exc})") from exc
+
+    if completed.stdout.strip() != "true":
+        raise AgentInitError("repo_sync", f"existing repo path is not a valid git repo: {repo_dir}")
+
+    LOGGER.info("agent.repo_sync_existing_repo repo_dir=%s action=noop", repo_dir)
     return repo_dir
 
 
@@ -141,23 +130,14 @@ def stage_workspace_prepare(settings: WorkerSettings) -> None:
     codex_home = Path(settings.codex_home)
     codex_home.mkdir(parents=True, exist_ok=True)
     repo_dir = Path(settings.workspace_path) / settings.repo_dir_name
-    global_codex_config_raw = os.getenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", "").strip()
-    global_claude_config_raw = os.getenv("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", "").strip()
     repo_codex_dir = repo_dir / ".codex"
     home_claude_dir = home_dir / ".claude"
-    global_codex_config_path = Path(global_codex_config_raw) if global_codex_config_raw else None
-    global_claude_config_path = Path(global_claude_config_raw) if global_claude_config_raw else None
 
     LOGGER.info(
-        "agent.workspace_prepare_paths codex_home=%s repo_codex_dir=%s global_codex_config_dir=%s global_codex_config_exists=%s global_codex_config_is_dir=%s global_claude_config_dir=%s global_claude_config_exists=%s global_claude_config_is_dir=%s",
+        "agent.workspace_prepare_paths codex_home=%s repo_codex_dir=%s home_claude_dir=%s",
         codex_home,
         repo_codex_dir,
-        global_codex_config_raw or "-",
-        global_codex_config_path.exists() if global_codex_config_path else False,
-        global_codex_config_path.is_dir() if global_codex_config_path else False,
-        global_claude_config_raw or "-",
-        global_claude_config_path.exists() if global_claude_config_path else False,
-        global_claude_config_path.is_dir() if global_claude_config_path else False,
+        home_claude_dir,
     )
     LOGGER.info(
         "agent.workspace_prepare_state codex_home_exists=%s codex_home_entries=%d codex_home_agents_md=%s codex_home_config_toml=%s home_claude_dir=%s home_claude_exists=%s home_claude_entries=%d home_claude_md=%s home_claude_settings_json=%s",
@@ -172,25 +152,6 @@ def stage_workspace_prepare(settings: WorkerSettings) -> None:
         (home_claude_dir / "settings.json").exists(),
     )
 
-    if global_codex_config_raw:
-        _copy_tree(global_codex_config_path, codex_home, overwrite=True)
-        LOGGER.info(
-            "agent.workspace_prepare_copied target=%s source=%s source_entries=%d target_entries=%d target_agents_md=%s target_config_toml=%s",
-            codex_home,
-            global_codex_config_raw,
-            sum(1 for _ in global_codex_config_path.rglob("*")) if global_codex_config_path and global_codex_config_path.exists() else 0,
-            sum(1 for _ in codex_home.rglob("*")),
-            (codex_home / "AGENTS.md").exists(),
-            (codex_home / "config.toml").exists(),
-        )
-    else:
-        LOGGER.info(
-            "agent.workspace_prepare_copy_skipped target=%s source=- reason=missing_global_codex_config target_entries=%d target_agents_md=%s target_config_toml=%s",
-            codex_home,
-            sum(1 for _ in codex_home.rglob("*")),
-            (codex_home / "AGENTS.md").exists(),
-            (codex_home / "config.toml").exists(),
-        )
     # repo_codex_dir (.codex/ in the cloned repo) is intentionally left in place.
     # Codex reads it as project-scope config from the working directory, which takes
     # precedence over user-scope settings in CODEX_HOME per the Codex scope hierarchy.
@@ -202,26 +163,6 @@ def stage_workspace_prepare(settings: WorkerSettings) -> None:
         (repo_codex_dir / "AGENTS.md").exists(),
         (repo_codex_dir / "config.toml").exists(),
     )
-    if global_claude_config_raw:
-        _copy_tree(global_claude_config_path, home_claude_dir, overwrite=True)
-        LOGGER.info(
-            "agent.workspace_prepare_copied target=%s source=%s source_entries=%d target_entries=%d target_claude_md=%s target_settings_json=%s",
-            home_claude_dir,
-            global_claude_config_raw,
-            sum(1 for _ in global_claude_config_path.rglob("*")) if global_claude_config_path and global_claude_config_path.exists() else 0,
-            sum(1 for _ in home_claude_dir.rglob("*")),
-            (home_claude_dir / "CLAUDE.md").exists(),
-            (home_claude_dir / "settings.json").exists(),
-        )
-    else:
-        LOGGER.info(
-            "agent.workspace_prepare_copy_skipped target=%s source=- reason=missing_global_claude_config target_entries=%d target_claude_md=%s target_settings_json=%s",
-            home_claude_dir,
-            sum(1 for _ in home_claude_dir.rglob("*")) if home_claude_dir.exists() else 0,
-            (home_claude_dir / "CLAUDE.md").exists(),
-            (home_claude_dir / "settings.json").exists(),
-        )
-
     git_user_name = os.getenv("AGENT_GIT_USER_NAME", "").strip()
     git_user_email = os.getenv("AGENT_GIT_USER_EMAIL", "").strip()
 

--- a/src/master/runtime_adapter.py
+++ b/src/master/runtime_adapter.py
@@ -121,13 +121,11 @@ class PodmanRuntimeAdapter:
         env = env or {}
         mounts = mounts or []
         LOGGER.info(
-            "runtime.create_or_update_agent container=%s image=%s repo_volume=%s env_keys=%s global_codex_config_env=%s global_claude_config_env=%s mounts=%s",
+            "runtime.create_or_update_agent container=%s image=%s repo_volume=%s env_keys=%s mounts=%s",
             container_name,
             image,
             repo_volume,
             ",".join(sorted(env)) or "-",
-            env.get("AGENT_GLOBAL_CODEX_CONFIG_DIR", "-"),
-            env.get("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", "-"),
             json.dumps(mounts),
         )
         cmd = [

--- a/src/master/service.py
+++ b/src/master/service.py
@@ -15,8 +15,6 @@ DEFAULT_IMAGE = "codex-slack-bot:latest"
 DEFAULT_RUNTIME = "podman"
 DEFAULT_AGENT_ADAPTER = "codex"
 SUPPORTED_AGENT_ADAPTERS = {"codex", "claude-code"}
-GLOBAL_CODEX_CONFIG_MOUNT = "/run/secrets/master_codex_config"
-GLOBAL_CLAUDE_CONFIG_MOUNT = "/run/secrets/master_claude_config"
 LOGGER = logging.getLogger(__name__)
 
 
@@ -192,7 +190,7 @@ class MasterService:
             env = self._build_agent_env(record)
             mounts = self._build_agent_mounts()
             LOGGER.info(
-                "master.start_agent_config agent=%s container=%s repo_ref=%s adapter=%s image_plan=%s resolved_image=%s codex_home=%s global_codex_config_env=%s global_codex_config_mount=%s global_claude_config_env=%s global_claude_config_mount=%s",
+                "master.start_agent_config agent=%s container=%s repo_ref=%s adapter=%s image_plan=%s resolved_image=%s codex_home=%s",
                 record.name,
                 record.container_name,
                 record.repo_ref,
@@ -200,10 +198,6 @@ class MasterService:
                 record.image_plan.get("type", "-"),
                 image,
                 env.get("CODEX_HOME", "-"),
-                env.get("AGENT_GLOBAL_CODEX_CONFIG_DIR", "-"),
-                GLOBAL_CODEX_CONFIG_MOUNT if self._agent_codex_config_dir_path else "-",
-                env.get("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", "-"),
-                GLOBAL_CLAUDE_CONFIG_MOUNT if self._agent_claude_config_dir_path else "-",
             )
             self._runtime.create_or_update_agent(
                 container_name=record.container_name,
@@ -363,40 +357,11 @@ class MasterService:
             self._audit(command="refresh-config", agent=name, result=result)
             return result
 
-        if not self._agent_claude_config_dir_path:
-            result = CommandResult(
-                ok=False,
-                code="ERR_RUNTIME_FAILED",
-                message="agent claude config source is not configured",
-                data={},
-            )
-            self._audit(command="refresh-config", agent=name, result=result)
-            return result
-
-        try:
-            self._runtime.refresh_agent_config(
-                volume_name=f"agent-workspace-{record.name}",
-                host_config_dir=self._agent_claude_config_dir_path,
-            )
-        except Exception as exc:  # noqa: BLE001
-            result = CommandResult(
-                ok=False,
-                code="ERR_RUNTIME_FAILED",
-                message=f"failed to refresh config for {name}: {exc}",
-                data={},
-            )
-            self._audit(command="refresh-config", agent=name, result=result)
-            return result
-
         result = CommandResult(
-            ok=True,
-            code="OK",
-            message=f"refreshed config for {name}",
-            data={
-                "refreshed": True,
-                "volume_name": f"agent-workspace-{record.name}",
-                "config_source": self._agent_claude_config_dir_path,
-            },
+            ok=False,
+            code="ERR_RUNTIME_FAILED",
+            message="agent config passthrough is no longer supported; update the agent image and restart the agent",
+            data={"name": name},
         )
         self._audit(command="refresh-config", agent=name, result=result)
         return result
@@ -488,10 +453,6 @@ class MasterService:
             env["CLAUDE_CODE_OAUTH_TOKEN"] = claude_code_oauth_token
         elif anthropic_api_key:
             env["ANTHROPIC_API_KEY"] = anthropic_api_key
-        if self._agent_codex_config_dir_path:
-            env["AGENT_GLOBAL_CODEX_CONFIG_DIR"] = GLOBAL_CODEX_CONFIG_MOUNT
-        if self._agent_claude_config_dir_path:
-            env["AGENT_GLOBAL_CLAUDE_CONFIG_DIR"] = GLOBAL_CLAUDE_CONFIG_MOUNT
         if self._git_user_name:
             env["AGENT_GIT_USER_NAME"] = self._git_user_name
         if self._git_user_email:
@@ -499,10 +460,9 @@ class MasterService:
         if self._agent_ssh_auth_sock_path:
             env["SSH_AUTH_SOCK"] = "/run/secrets/ssh-auth.sock"
             env["GIT_SSH_COMMAND"] = self._agent_git_ssh_command()
-        # CLAUDE_CONFIG_DIR is intentionally NOT set here. The entrypoint copies
-        # /run/secrets/master_claude_config into ~/.claude/ so claude can write
-        # session data there. Pointing CLAUDE_CONFIG_DIR at the read-only mount
-        # causes claude to hang on its first write attempt.
+        # CLAUDE_CONFIG_DIR is intentionally NOT set here. The entrypoint seeds
+        # baked-in Claude config into a writable ~/.claude/ inside the workspace
+        # volume, and Claude must not be pointed at a read-only path.
 
         return env
 
@@ -510,10 +470,6 @@ class MasterService:
         mounts: list[str] = []
         if self._agent_codex_auth_json_path:
             mounts.append(f"{self._agent_codex_auth_json_path}:/run/secrets/codex_auth.json:ro")
-        if self._agent_codex_config_dir_path:
-            mounts.append(f"{self._agent_codex_config_dir_path}:{GLOBAL_CODEX_CONFIG_MOUNT}:ro")
-        if self._agent_claude_config_dir_path:
-            mounts.append(f"{self._agent_claude_config_dir_path}:{GLOBAL_CLAUDE_CONFIG_MOUNT}:ro")
         if self._agent_ssh_auth_sock_path:
             mounts.append(f"{self._agent_ssh_auth_sock_path}:/run/secrets/ssh-auth.sock")
         if self._agent_ssh_known_hosts_path:

--- a/tests/agent/test_worker.py
+++ b/tests/agent/test_worker.py
@@ -10,18 +10,19 @@ from src.agent import worker
 from src.agent.worker import AgentInitError, WorkerSettings, run_worker, stage_preflight, stage_repo_sync, stage_workspace_prepare
 
 
-def _git(args: list[str], cwd: str | None = None) -> None:
+def _git(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=False)
     if completed.returncode != 0:
         raise RuntimeError(completed.stderr)
+    return completed
 
 
-def _create_local_repo(path) -> str:  # type: ignore[no-untyped-def]
+def _create_local_repo(path: Path, *, readme_text: str = "hello\n") -> str:
     path.mkdir(parents=True)
     _git(["init", "-b", "main"], cwd=str(path))
     _git(["config", "user.name", "tester"], cwd=str(path))
     _git(["config", "user.email", "tester@example.com"], cwd=str(path))
-    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    (path / "README.md").write_text(readme_text, encoding="utf-8")
     _git(["add", "README.md"], cwd=str(path))
     _git(["commit", "-m", "init"], cwd=str(path))
     return str(path)
@@ -104,7 +105,51 @@ def test_stage_repo_sync_clones_repo(tmp_path, monkeypatch) -> None:  # type: ig
 
     repo_dir = stage_repo_sync(settings)
     assert (repo_dir / ".git").exists()
-    assert (repo_dir / "README.md").exists()
+    assert (repo_dir / "README.md").read_text(encoding="utf-8") == "hello\n"
+
+
+def test_stage_repo_sync_leaves_existing_valid_repo_unchanged(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    remote_repo = _create_local_repo(tmp_path / "remote", readme_text="remote\n")
+    workspace = tmp_path / "workspace"
+    existing_repo = Path(_create_local_repo(workspace / "repo", readme_text="existing\n"))
+    monkeypatch.setenv("GH_TOKEN", "token")
+
+    settings = WorkerSettings(
+        workspace_path=str(workspace),
+        repo_url=remote_repo,
+        repo_ref="main",
+        repo_dir_name="repo",
+        status_file=str(tmp_path / "status.json"),
+        codex_home=str(tmp_path / "codex"),
+        ready_poll_seconds=0.1,
+    )
+
+    repo_dir = stage_repo_sync(settings)
+
+    assert repo_dir == existing_repo
+    assert (repo_dir / "README.md").read_text(encoding="utf-8") == "existing\n"
+
+
+def test_stage_repo_sync_rejects_existing_non_git_repo_path(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    src_repo = _create_local_repo(tmp_path / "src")
+    workspace = tmp_path / "workspace"
+    bad_repo = workspace / "repo"
+    bad_repo.mkdir(parents=True)
+    (bad_repo / "README.md").write_text("not a git repo\n", encoding="utf-8")
+    monkeypatch.setenv("GH_TOKEN", "token")
+
+    settings = WorkerSettings(
+        workspace_path=str(workspace),
+        repo_url=src_repo,
+        repo_ref="main",
+        repo_dir_name="repo",
+        status_file=str(tmp_path / "status.json"),
+        codex_home=str(tmp_path / "codex"),
+        ready_poll_seconds=0.1,
+    )
+
+    with pytest.raises(AgentInitError, match="not a valid git repo"):
+        stage_repo_sync(settings)
 
 
 def test_run_worker_writes_error_status_when_repo_missing(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -188,99 +233,13 @@ def test_stage_workspace_prepare_sets_repo_local_git_identity(tmp_path, monkeypa
     assert email_result.stdout.strip() == "agent@example.com"
 
 
-def test_stage_workspace_prepare_applies_global_codex_config_as_user_scope(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """Global (master) Codex config is installed into CODEX_HOME as user-scope."""
+def test_stage_workspace_prepare_leaves_repo_codex_as_project_scope(tmp_path) -> None:  # type: ignore[no-untyped-def]
     repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_codex = tmp_path / "global-codex"
-    global_codex.mkdir()
-    (global_codex / "config.toml").write_text("source = 'global'\n", encoding="utf-8")
-    (global_codex / "AGENTS.md").write_text("global instructions\n", encoding="utf-8")
-    (global_codex / "global-only.txt").write_text("global\n", encoding="utf-8")
-
-    monkeypatch.setenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", str(global_codex))
-
-    codex_home = tmp_path / "codex-home"
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(codex_home),
-        ready_poll_seconds=0.1,
-    )
-
-    stage_workspace_prepare(settings)
-
-    # Global config lands in CODEX_HOME (user scope).
-    assert (codex_home / "config.toml").read_text(encoding="utf-8") == "source = 'global'\n"
-    assert (codex_home / "AGENTS.md").read_text(encoding="utf-8") == "global instructions\n"
-    assert (codex_home / "global-only.txt").read_text(encoding="utf-8") == "global\n"
-
-
-def test_stage_workspace_prepare_logs_codex_copy_result(tmp_path, monkeypatch, caplog) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_codex = tmp_path / "global-codex"
-    global_codex.mkdir()
-    (global_codex / "AGENTS.md").write_text("global instructions\n", encoding="utf-8")
-    (global_codex / "config.toml").write_text("source = 'global'\n", encoding="utf-8")
-    monkeypatch.setenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", str(global_codex))
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(tmp_path / "codex-home"),
-        ready_poll_seconds=0.1,
-    )
-
-    caplog.set_level("INFO")
-    stage_workspace_prepare(settings)
-
-    assert "agent.workspace_prepare_copied" in caplog.text
-    assert "target_agents_md=True" in caplog.text
-    assert "target_config_toml=True" in caplog.text
-
-
-def test_stage_workspace_prepare_logs_codex_copy_skip_state(tmp_path, monkeypatch, caplog) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    monkeypatch.delenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", raising=False)
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(tmp_path / "codex-home"),
-        ready_poll_seconds=0.1,
-    )
-
-    caplog.set_level("INFO")
-    stage_workspace_prepare(settings)
-
-    assert "agent.workspace_prepare_copy_skipped" in caplog.text
-    assert "reason=missing_global_codex_config" in caplog.text
-
-
-def test_stage_workspace_prepare_leaves_repo_codex_as_project_scope(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """Repo .codex/ is NOT copied into CODEX_HOME; it stays in the repo dir as project-scope
-    config, which Codex reads naturally from the working directory and which takes precedence
-    over user-scope settings in CODEX_HOME."""
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_codex = tmp_path / "global-codex"
-    global_codex.mkdir()
-    (global_codex / "config.toml").write_text("source = 'global'\n", encoding="utf-8")
-
     repo_codex = repo_path / ".codex"
     repo_codex.mkdir()
     (repo_codex / "config.toml").write_text("source = 'repo'\n", encoding="utf-8")
     (repo_codex / "repo-only.txt").write_text("repo\n", encoding="utf-8")
 
-    monkeypatch.setenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", str(global_codex))
-
     codex_home = tmp_path / "codex-home"
     settings = WorkerSettings(
         workspace_path=str(tmp_path),
@@ -294,47 +253,11 @@ def test_stage_workspace_prepare_leaves_repo_codex_as_project_scope(tmp_path, mo
 
     stage_workspace_prepare(settings)
 
-    # Global config stays at user scope; repo config is NOT promoted into CODEX_HOME.
-    assert (codex_home / "config.toml").read_text(encoding="utf-8") == "source = 'global'\n"
     assert not (codex_home / "repo-only.txt").exists()
-    # Repo's .codex/ is untouched in place (Codex reads it as project scope from CWD).
     assert (repo_path / ".codex" / "config.toml").read_text(encoding="utf-8") == "source = 'repo'\n"
 
 
-def test_stage_workspace_prepare_overwrites_stale_global_codex_files(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_codex = tmp_path / "global-codex"
-    global_codex.mkdir()
-    (global_codex / "AGENTS.md").write_text("new instructions\n", encoding="utf-8")
-    (global_codex / "config.toml").write_text("source = 'new'\n", encoding="utf-8")
-    monkeypatch.setenv("AGENT_GLOBAL_CODEX_CONFIG_DIR", str(global_codex))
-
-    codex_home = tmp_path / "codex-home"
-    codex_home.mkdir()
-    (codex_home / "AGENTS.md").write_text("old instructions\n", encoding="utf-8")
-    (codex_home / "config.toml").write_text("source = 'old'\n", encoding="utf-8")
-    (codex_home / "auth.json").write_text('{"token":"keep"}\n', encoding="utf-8")
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(codex_home),
-        ready_poll_seconds=0.1,
-    )
-
-    stage_workspace_prepare(settings)
-
-    assert (codex_home / "AGENTS.md").read_text(encoding="utf-8") == "new instructions\n"
-    assert (codex_home / "config.toml").read_text(encoding="utf-8") == "source = 'new'\n"
-    assert (codex_home / "auth.json").read_text(encoding="utf-8") == '{"token":"keep"}\n'
-
-
 def test_stage_workspace_prepare_leaves_repo_claude_as_project_scope(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """Repo .claude/ is NOT copied to ~/.claude/; Claude Code reads it as project-scope config
-    from the working directory, which takes precedence over user-scope settings in ~/.claude/."""
     repo_path = Path(_create_local_repo(tmp_path / "src"))
     repo_claude = repo_path / ".claude"
     repo_claude.mkdir()
@@ -343,7 +266,6 @@ def test_stage_workspace_prepare_leaves_repo_claude_as_project_scope(tmp_path, m
 
     home_dir = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.delenv("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", raising=False)
 
     settings = WorkerSettings(
         workspace_path=str(tmp_path),
@@ -357,70 +279,9 @@ def test_stage_workspace_prepare_leaves_repo_claude_as_project_scope(tmp_path, m
 
     stage_workspace_prepare(settings)
 
-    # Repo .claude/ stays in the repo (project scope); nothing is copied into ~/.claude/.
     assert not (home_dir / ".claude" / "settings.json").exists()
     assert not (home_dir / ".claude" / "CLAUDE.md").exists()
-    # Repo files are untouched.
     assert (repo_path / ".claude" / "settings.json").read_text(encoding="utf-8") == '{"source":"repo"}\n'
-
-
-def test_stage_workspace_prepare_applies_global_claude_config_to_home(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_claude = tmp_path / "global-claude"
-    global_claude.mkdir()
-    (global_claude / "settings.json").write_text('{"theme":"global"}\n', encoding="utf-8")
-
-    home_dir = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.setenv("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", str(global_claude))
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(tmp_path / "codex"),
-        ready_poll_seconds=0.1,
-    )
-
-    stage_workspace_prepare(settings)
-
-    assert (home_dir / ".claude" / "settings.json").read_text(encoding="utf-8") == '{"theme":"global"}\n'
-
-
-def test_stage_workspace_prepare_overwrites_stale_global_claude_files(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    repo_path = Path(_create_local_repo(tmp_path / "src"))
-    global_claude = tmp_path / "global-claude"
-    global_claude.mkdir()
-    (global_claude / "settings.json").write_text('{"theme":"new"}\n', encoding="utf-8")
-    (global_claude / "CLAUDE.md").write_text("# New global instructions\n", encoding="utf-8")
-
-    home_dir = tmp_path / "home"
-    home_claude = home_dir / ".claude"
-    home_claude.mkdir(parents=True)
-    (home_claude / "settings.json").write_text('{"theme":"old"}\n', encoding="utf-8")
-    (home_claude / "CLAUDE.md").write_text("# Old global instructions\n", encoding="utf-8")
-    (home_claude / "sessions.json").write_text('{"keep":true}\n', encoding="utf-8")
-
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.setenv("AGENT_GLOBAL_CLAUDE_CONFIG_DIR", str(global_claude))
-
-    settings = WorkerSettings(
-        workspace_path=str(tmp_path),
-        repo_url=str(repo_path),
-        repo_ref="main",
-        repo_dir_name="src",
-        status_file=str(tmp_path / "status.json"),
-        codex_home=str(tmp_path / "codex"),
-        ready_poll_seconds=0.1,
-    )
-
-    stage_workspace_prepare(settings)
-
-    assert (home_claude / "settings.json").read_text(encoding="utf-8") == '{"theme":"new"}\n'
-    assert (home_claude / "CLAUDE.md").read_text(encoding="utf-8") == "# New global instructions\n"
-    assert (home_claude / "sessions.json").read_text(encoding="utf-8") == '{"keep":true}\n'
 
 
 def test_load_worker_settings_uses_writable_default_status_path(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/master/test_master_service.py
+++ b/tests/master/test_master_service.py
@@ -289,7 +289,7 @@ def test_start_agent_mounts_codex_auth_json_only(tmp_path) -> None:
     assert mounts == ["/host/secrets/codex-auth.json:/run/secrets/codex_auth.json:ro"]
 
 
-def test_start_agent_mounts_global_codex_and_claude_config_dirs(tmp_path) -> None:
+def test_start_agent_ignores_legacy_global_config_mount_settings(tmp_path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
 
@@ -310,12 +310,9 @@ def test_start_agent_mounts_global_codex_and_claude_config_dirs(tmp_path) -> Non
     assert runtime.calls[0][0] == "pull_image"
     env = runtime.calls[1][1]["env"]
     mounts = runtime.calls[1][1]["mounts"]
-    assert env["AGENT_GLOBAL_CODEX_CONFIG_DIR"] == "/run/secrets/master_codex_config"
-    assert env["AGENT_GLOBAL_CLAUDE_CONFIG_DIR"] == "/run/secrets/master_claude_config"
-    assert mounts == [
-        "/host/config/codex:/run/secrets/master_codex_config:ro",
-        "/host/config/claude:/run/secrets/master_claude_config:ro",
-    ]
+    assert "AGENT_GLOBAL_CODEX_CONFIG_DIR" not in env
+    assert "AGENT_GLOBAL_CLAUDE_CONFIG_DIR" not in env
+    assert mounts == []
 
 
 def test_start_agent_mounts_ssh_forwarding_and_sets_env(tmp_path) -> None:
@@ -475,6 +472,27 @@ def test_refresh_agent_auth_propagates_runtime_failure(tmp_path) -> None:
     refreshed = service.refresh_agent_auth(name="payments-api")
     assert refreshed.ok is False
     assert refreshed.code == "ERR_RUNTIME_FAILED"
+
+
+def test_refresh_agent_config_is_no_longer_supported(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    service = MasterService(
+        registry=registry,
+        runtime=runtime,
+        agent_claude_config_dir_path="/host/config/claude",
+    )
+
+    loaded = service.load_agent(name="payments-api", repo_path=str(repo), channel_id="C123")
+    assert loaded.ok is True
+
+    refreshed = service.refresh_agent_config(name="payments-api")
+    assert refreshed.ok is False
+    assert refreshed.code == "ERR_RUNTIME_FAILED"
+    assert "no longer supported" in refreshed.message
 
 
 def test_load_agent_invalid_name_returns_invalid_args(tmp_path) -> None:

--- a/tests/test_image_contract.py
+++ b/tests/test_image_contract.py
@@ -16,12 +16,12 @@ def test_agent_minimal_image_installs_github_cli() -> None:
 def test_entrypoint_has_baked_in_codex_and_claude_global_fallbacks() -> None:
     entrypoint = Path("docker/entrypoint.sh").read_text(encoding="utf-8")
     assert "set -x" in entrypoint
-    assert "/run/secrets/master_codex_config" in entrypoint
     assert "/opt/codex-slack/config/codex-global" in entrypoint
-    assert "/run/secrets/master_claude_config" in entrypoint
     assert "/opt/codex-slack/config/claude-global" in entrypoint
-    assert 'cp -af /run/secrets/master_codex_config/. "${CODEX_HOME_PATH}/"' in entrypoint
     assert 'cp -af /opt/codex-slack/config/codex-global/. "${CODEX_HOME_PATH}/"' in entrypoint
+    assert "/run/secrets/master_codex_config" not in entrypoint
+    assert "/run/secrets/master_claude_config" not in entrypoint
+    assert "codex_sessions" not in entrypoint
     assert 'entrypoint_log "startup ' in entrypoint
     assert 'entrypoint_log "codex_config_result ' in entrypoint
     assert 'entrypoint_log "claude_config_result ' in entrypoint


### PR DESCRIPTION
## Summary
- simplify agent startup to use baked-in global Codex/Claude config instead of mounted config passthrough
- remove Codex session passthrough and make existing valid repo checkouts a startup no-op instead of a destructive reset
- update core runtime docs and regression tests to match the new startup contract

## Linked issues
- closes #53
- closes #54
- closes #55
- closes #56

## Test evidence
- `./.venv/bin/python -m pytest -q tests/agent/test_worker.py tests/master/test_master_service.py tests/master/test_runtime_adapter.py tests/master/test_command_runtime.py tests/test_image_contract.py`
  - `57 passed`
- `bash -n docker/entrypoint.sh`
- `./.venv/bin/python -m py_compile src/agent/worker.py src/master/service.py src/master/runtime_adapter.py`

## Notes
- `/master-agent-refresh-config` now returns an unsupported-runtime message because host config passthrough is removed; shared config updates are now delivered through the agent image plus restart flow.
- Existing valid `/workspace/repo` checkouts are intentionally left unchanged on startup.