### PR TITLE
fix: restore explicit claude session resume

### DIFF
--- a/src/master/router.py
+++ b/src/master/router.py
@@ -13,6 +13,7 @@ import time
 from typing import Protocol
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
+import uuid
 
 from .registry import AgentRegistry
 
@@ -343,11 +344,38 @@ class MultiAgentDispatcher:
 @dataclass(frozen=True)
 class ClaudeCodeDispatcher(PodmanExecDispatcher):
     command_template: str = "claude -p --output-format json"
+    _channel_sessions: dict[str, str] = field(default_factory=dict, init=False, repr=False, compare=False)
+    _session_lock: Lock = field(default_factory=Lock, init=False, repr=False, compare=False)
 
-    def _render_command(self, *, action: str) -> str:
-        rendered = self.command_template.rstrip()
-        if action == "continue":
-            rendered = f"{rendered} --continue"
+    @staticmethod
+    def _conversation_key(*, agent_name: str, platform: str, channel_id: str) -> str:
+        return f"{agent_name}:{platform}:{channel_id}"
+
+    @staticmethod
+    def _strip_session_flags(command: str) -> str:
+        stripped = command.rstrip()
+        patterns = [
+            r"\s+--continue\b",
+            r"\s+-n\b",
+            r"\s+-r\s+\S+",
+            r"\s+--resume\s+\S+",
+            r"\s+--session-id\s+\S+",
+        ]
+        for pattern in patterns:
+            stripped = re.sub(pattern, "", stripped)
+        return stripped.strip()
+
+    @staticmethod
+    def _inject_session_flags(*, command: str, action: str, session_id: str) -> str:
+        if action == "create":
+            return re.sub(r"\bclaude\b", f"claude -n --session-id {session_id}", command, count=1)
+        if action == "resume":
+            return re.sub(r"\bclaude\b", f"claude -r {session_id}", command, count=1)
+        raise ValueError(f"unsupported claude action: {action}")
+
+    def _render_command(self, *, action: str, session_id: str) -> str:
+        rendered = self._strip_session_flags(self.command_template)
+        rendered = self._inject_session_flags(command=rendered, action=action, session_id=session_id)
         return self._ensure_claude_permission_bypass(rendered)
 
     @staticmethod
@@ -489,9 +517,18 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
             prefix = f"{effective_prompt}\n\n" if effective_prompt else ""
             effective_prompt = f"{prefix}Attached files:\n" + "\n".join(lines)
 
-        initial_action = "continue"
+        conversation_key = self._conversation_key(
+            agent_name=agent_name,
+            platform=platform,
+            channel_id=channel_id,
+        )
+        with self._session_lock:
+            known_session_id = self._channel_sessions.get(conversation_key)
+        initial_action = "resume" if known_session_id else "create"
+        initial_session_id = known_session_id or str(uuid.uuid4())
         retry_action: str | None = None
-        rendered_command = self._render_command(action=initial_action)
+        effective_session_id = initial_session_id
+        rendered_command = self._render_command(action=initial_action, session_id=effective_session_id)
         if claude_model:
             rendered_command = _inject_claude_model(rendered_command, claude_model)
         try:
@@ -533,8 +570,11 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
             stderr_text = self._clip(completed.stderr)
             if self._should_retry_with_create(stderr_text):
                 retry_action = "create"
+                with self._session_lock:
+                    self._channel_sessions.pop(conversation_key, None)
+                effective_session_id = str(uuid.uuid4())
                 LOGGER.info(
-                    "router.dispatch_retry agent=%s container=%s platform=%s channel=%s thread_ts=%s user=%s claude_action=%s claude_retry_action=%s retry_reason=%r",
+                    "router.dispatch_retry agent=%s container=%s platform=%s channel=%s thread_ts=%s user=%s claude_action=%s claude_retry_action=%s session_id=%s retry_reason=%r",
                     agent_name,
                     container_name,
                     platform,
@@ -543,9 +583,10 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
                     user_id or "-",
                     initial_action,
                     retry_action,
+                    effective_session_id,
                     stderr_text,
                 )
-                rendered_command = self._render_command(action=retry_action)
+                rendered_command = self._render_command(action=retry_action, session_id=effective_session_id)
                 if claude_model:
                     rendered_command = _inject_claude_model(rendered_command, claude_model)
                 try:
@@ -589,8 +630,10 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
             raise RouteError(f"dispatch failed ({', '.join(details)})")
 
         response = self._parse_response(completed.stdout.strip())
+        with self._session_lock:
+            self._channel_sessions[conversation_key] = effective_session_id
         LOGGER.info(
-            "router.dispatch_done agent=%s container=%s platform=%s channel=%s thread_ts=%s user=%s claude_action=%s response_chars=%d",
+            "router.dispatch_done agent=%s container=%s platform=%s channel=%s thread_ts=%s user=%s claude_action=%s session_id=%s response_chars=%d",
             agent_name,
             container_name,
             platform,
@@ -598,6 +641,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
             thread_ts or "-",
             user_id or "-",
             retry_action or initial_action,
+            effective_session_id,
             len(response),
         )
         return response

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -13,7 +13,6 @@ import time
 from typing import Protocol
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
-import uuid
 
 from .registry import AgentRegistry
 
@@ -352,6 +351,12 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
         return f"{agent_name}:{platform}:{channel_id}"
 
     @staticmethod
+    def _session_name(*, agent_name: str, platform: str, channel_id: str) -> str:
+        raw = f"claude-{agent_name}-{platform}-{channel_id}"
+        normalized = re.sub(r"[^A-Za-z0-9_-]+", "-", raw).strip("-")
+        return normalized or "claude-session"
+
+    @staticmethod
     def _strip_session_flags(command: str) -> str:
         stripped = command.rstrip()
         patterns = [
@@ -368,7 +373,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
     @staticmethod
     def _inject_session_flags(*, command: str, action: str, session_id: str) -> str:
         if action == "create":
-            return re.sub(r"\bclaude\b", f"claude -n --session-id {session_id}", command, count=1)
+            return re.sub(r"\bclaude\b", f"claude -n {session_id}", command, count=1)
         if action == "resume":
             return re.sub(r"\bclaude\b", f"claude -r {session_id}", command, count=1)
         raise ValueError(f"unsupported claude action: {action}")
@@ -525,7 +530,11 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
         with self._session_lock:
             known_session_id = self._channel_sessions.get(conversation_key)
         initial_action = "resume" if known_session_id else "create"
-        initial_session_id = known_session_id or str(uuid.uuid4())
+        initial_session_id = known_session_id or self._session_name(
+            agent_name=agent_name,
+            platform=platform,
+            channel_id=channel_id,
+        )
         retry_action: str | None = None
         effective_session_id = initial_session_id
         rendered_command = self._render_command(action=initial_action, session_id=effective_session_id)
@@ -572,7 +581,11 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
                 retry_action = "create"
                 with self._session_lock:
                     self._channel_sessions.pop(conversation_key, None)
-                effective_session_id = str(uuid.uuid4())
+                effective_session_id = self._session_name(
+                    agent_name=agent_name,
+                    platform=platform,
+                    channel_id=channel_id,
+                )
                 LOGGER.info(
                     "router.dispatch_retry agent=%s container=%s platform=%s channel=%s thread_ts=%s user=%s claude_action=%s claude_retry_action=%s session_id=%s retry_reason=%r",
                     agent_name,

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import subprocess
 
 import pytest
@@ -496,7 +495,8 @@ def test_claude_dispatcher_creates_session_and_injects_permission_bypass(monkeyp
     )
 
     assert seen["cmd"][-1].startswith("claude ")
-    assert " -n --session-id " in seen["cmd"][-1]
+    assert " -n " in seen["cmd"][-1]
+    assert " --session-id " not in seen["cmd"][-1]
     assert " --continue" not in seen["cmd"][-1]
     assert " --dangerously-skip-permissions" in seen["cmd"][-1]
 
@@ -530,11 +530,10 @@ def test_claude_dispatcher_resumes_with_same_session_for_same_channel(monkeypatc
         user_id="U123",
     )
 
-    assert " -n --session-id " in seen[0][-1]
+    assert " -n " in seen[0][-1]
     assert " -r " in seen[1][-1]
-    first_session_id = re.search(r"--session-id ([^ ]+)", seen[0][-1]).group(1)  # type: ignore[union-attr]
-    second_session_id = re.search(r"-r ([^ ]+)", seen[1][-1]).group(1)  # type: ignore[union-attr]
-    assert first_session_id == second_session_id
+    assert "claude-payments-agent-discord-123456789" in seen[0][-1]
+    assert "claude-payments-agent-discord-123456789" in seen[1][-1]
 
 
 def test_claude_dispatcher_uses_distinct_sessions_for_distinct_channels(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -566,9 +565,8 @@ def test_claude_dispatcher_uses_distinct_sessions_for_distinct_channels(monkeypa
         user_id="U123",
     )
 
-    first_session_id = re.search(r"--session-id ([^ ]+)", seen[0][-1]).group(1)  # type: ignore[union-attr]
-    second_session_id = re.search(r"--session-id ([^ ]+)", seen[1][-1]).group(1)  # type: ignore[union-attr]
-    assert first_session_id != second_session_id
+    assert "claude-payments-agent-slack-CAGENT" in seen[0][-1]
+    assert "claude-payments-agent-slack-COTHER" in seen[1][-1]
 
 
 def test_claude_dispatcher_retries_with_create_when_session_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -611,9 +609,9 @@ def test_claude_dispatcher_retries_with_create_when_session_missing(monkeypatch)
 
     assert first == "ok"
     assert response == "ok"
-    assert " -n --session-id " in seen[0][-1]
+    assert " -n " in seen[0][-1]
     assert " -r " in seen[1][-1]
-    assert " -n --session-id " in seen[2][-1]
+    assert " -n " in seen[2][-1]
 
 
 def test_podman_exec_dispatcher_injects_claude_permission_bypass(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 
 import pytest
@@ -474,7 +475,7 @@ def test_multi_agent_dispatcher_selects_adapter_by_name() -> None:
     assert len(claude.calls) == 1
 
 
-def test_claude_dispatcher_uses_continue_and_permission_bypass(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_claude_dispatcher_creates_session_and_injects_permission_bypass(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     dispatcher = ClaudeCodeDispatcher(command_template="claude -p")
     seen: dict[str, object] = {}
 
@@ -494,12 +495,13 @@ def test_claude_dispatcher_uses_continue_and_permission_bypass(monkeypatch) -> N
         user_id="U123",
     )
 
-    assert seen["cmd"][-1].startswith("claude -p ")
-    assert " --continue" in seen["cmd"][-1]
+    assert seen["cmd"][-1].startswith("claude ")
+    assert " -n --session-id " in seen["cmd"][-1]
+    assert " --continue" not in seen["cmd"][-1]
     assert " --dangerously-skip-permissions" in seen["cmd"][-1]
 
 
-def test_claude_dispatcher_uses_continue_for_same_channel(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_claude_dispatcher_resumes_with_same_session_for_same_channel(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     dispatcher = ClaudeCodeDispatcher(command_template="claude -p")
     seen: list[list[str]] = []
 
@@ -528,8 +530,46 @@ def test_claude_dispatcher_uses_continue_for_same_channel(monkeypatch) -> None: 
         user_id="U123",
     )
 
-    assert " --continue" in seen[0][-1]
-    assert " --continue" in seen[1][-1]
+    assert " -n --session-id " in seen[0][-1]
+    assert " -r " in seen[1][-1]
+    first_session_id = re.search(r"--session-id ([^ ]+)", seen[0][-1]).group(1)  # type: ignore[union-attr]
+    second_session_id = re.search(r"-r ([^ ]+)", seen[1][-1]).group(1)  # type: ignore[union-attr]
+    assert first_session_id == second_session_id
+
+
+def test_claude_dispatcher_uses_distinct_sessions_for_distinct_channels(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    dispatcher = ClaudeCodeDispatcher(command_template="claude -p")
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        platform="slack",
+        channel_id="CAGENT",
+        thread_ts="1730000000.0001",
+        user_id="U123",
+    )
+    dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello again",
+        platform="slack",
+        channel_id="COTHER",
+        thread_ts="1730000000.0002",
+        user_id="U123",
+    )
+
+    first_session_id = re.search(r"--session-id ([^ ]+)", seen[0][-1]).group(1)  # type: ignore[union-attr]
+    second_session_id = re.search(r"--session-id ([^ ]+)", seen[1][-1]).group(1)  # type: ignore[union-attr]
+    assert first_session_id != second_session_id
+
 
 def test_claude_dispatcher_retries_with_create_when_session_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     dispatcher = ClaudeCodeDispatcher(command_template="claude -p")
@@ -539,64 +579,41 @@ def test_claude_dispatcher_retries_with_create_when_session_missing(monkeypatch)
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
         seen.append(cmd)
         calls["count"] += 1
-        if calls["count"] == 1:
+        if calls["count"] == 2:
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=1,
                 stdout="",
-                stderr="Error: no session found for continue.",
+                stderr="Error: no session found for resume.",
             )
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
 
+    first = dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        platform="slack",
+        channel_id="CAGENT",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+    )
     response = dispatcher.send_prompt(
         agent_name="payments-agent",
         container_name="agent-payments",
-        prompt="hello",
+        prompt="again",
         platform="slack",
         channel_id="CAGENT",
-        thread_ts="1730000000.1234",
+        thread_ts="1730000000.5678",
         user_id="U123",
     )
 
+    assert first == "ok"
     assert response == "ok"
-    assert " --continue" in seen[0][-1]
-    assert seen[1][-1] == "claude -p --dangerously-skip-permissions"
-
-
-def test_claude_dispatcher_preserves_explicit_session_placeholder_text(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    dispatcher = ClaudeCodeDispatcher(command_template="claude -p --session-id {session_id}")
-    seen: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        seen.append(cmd)
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
-
-    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
-
-    dispatcher.send_prompt(
-        agent_name="payments-agent",
-        container_name="agent-payments",
-        prompt="hello",
-        platform="slack",
-        channel_id="CAGENT",
-        thread_ts="1730000000.1234",
-        user_id="U123",
-    )
-    dispatcher.send_prompt(
-        agent_name="payments-agent",
-        container_name="agent-payments",
-        prompt="second",
-        platform="slack",
-        channel_id="CAGENT",
-        thread_ts="1730000001.1234",
-        user_id="U123",
-    )
-
-    assert seen[0][-1].count("--session-id") == 1
-    assert "{session_id}" in seen[0][-1]
-    assert " --continue " in f" {seen[1][-1]} "
+    assert " -n --session-id " in seen[0][-1]
+    assert " -r " in seen[1][-1]
+    assert " -n --session-id " in seen[2][-1]
 
 
 def test_podman_exec_dispatcher_injects_claude_permission_bypass(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
- replace Claude `--continue` prompt-mode dispatch with explicit create/resume session handling in `ClaudeCodeDispatcher`
- let master decide first vs subsequent prompt using tracked conversation state keyed by agent/platform/channel
- retry once with a fresh create path when Claude reports the tracked session is missing

## Linked issues
- fixes #59
- follow-up enhancement: #60

## Test evidence
- `./.venv/bin/python -m pytest -q tests/master/test_router.py tests/master/test_command_runtime.py`
  - `32 passed`
- `./.venv/bin/python -m py_compile src/master/router.py`

## Notes
- this fix intentionally keeps session tracking in-memory on the dispatcher for now
- the longer-term persistent session design is tracked separately in #60