### PR TITLE
fix: prefer Discord proxy attachment URLs for staging

### DIFF
--- a/src/master/discord_app.py
+++ b/src/master/discord_app.py
@@ -171,7 +171,8 @@ async def _read_text_attachments(attachments: list[Any]) -> str:
 def _extract_attachment_urls(attachments: list[Any]) -> list[str]:
     urls: list[str] = []
     for item in attachments:
-        url = str(getattr(item, "url", "") or "").strip()
+        proxy_url = str(getattr(item, "proxy_url", "") or "").strip()
+        url = proxy_url or str(getattr(item, "url", "") or "").strip()
         if url:
             urls.append(url)
     return urls

--- a/tests/master/test_discord_app.py
+++ b/tests/master/test_discord_app.py
@@ -68,8 +68,9 @@ def test_build_discord_reply_plan_uses_file_for_very_large_unhinted_response() -
 
 def test_extract_attachment_urls_keeps_non_image_files() -> None:
     class Attachment:
-        def __init__(self, url: str, content_type: str) -> None:
+        def __init__(self, url: str, content_type: str, proxy_url: str = "") -> None:
             self.url = url
+            self.proxy_url = proxy_url
             self.content_type = content_type
 
     urls = _extract_attachment_urls(
@@ -79,6 +80,35 @@ def test_extract_attachment_urls_keeps_non_image_files() -> None:
         ]
     )
     assert urls == ["https://cdn.discordapp.com/a.docx", "https://cdn.discordapp.com/b.png"]
+
+
+def test_extract_attachment_urls_prefers_proxy_url_when_available() -> None:
+    class Attachment:
+        def __init__(self, url: str, proxy_url: str) -> None:
+            self.url = url
+            self.proxy_url = proxy_url
+
+    urls = _extract_attachment_urls(
+        [
+            Attachment(
+                "https://cdn.discordapp.com/attachments/original.png",
+                "https://media.discordapp.net/attachments/proxy.png",
+            )
+        ]
+    )
+
+    assert urls == ["https://media.discordapp.net/attachments/proxy.png"]
+
+
+def test_extract_attachment_urls_falls_back_to_primary_url_without_proxy() -> None:
+    class Attachment:
+        def __init__(self, url: str) -> None:
+            self.url = url
+            self.proxy_url = ""
+
+    urls = _extract_attachment_urls([Attachment("https://cdn.discordapp.com/attachments/original.png")])
+
+    assert urls == ["https://cdn.discordapp.com/attachments/original.png"]
 
 
 def test_sync_registered_commands_copies_global_commands_to_admin_guild() -> None:


### PR DESCRIPTION
## Summary

Prefer Discord `attachment.proxy_url` over `attachment.url` when extracting attachment URLs in master ingress. This avoids the staging path falling back to raw CDN URLs that can return `403 Forbidden` during download.

## Why

Issue #62 showed that Discord attachments were routed into master correctly, but master-side staging could fail when downloading the raw CDN URL. Discord provides a proxied URL that is more suitable for this fetch path.

## Changes

- update Discord attachment URL extraction to prefer `proxy_url`
- keep fallback to the primary `url` when no proxy URL is available
- add regression tests for proxy preference and fallback behavior

## Test Evidence

- `.venv/bin/pytest -q tests/master/test_discord_app.py` -> `14 passed`
- `.venv/bin/pytest -q tests/master/test_router.py` -> `26 passed`
- manual validation after deployment confirmed a `media.discordapp.net` attachment URL was reachable and visible

## Issue

- resolves #62
