### PR TITLE
fix: persist claude session state across master restarts

### DIFF
--- a/src/master/main.py
+++ b/src/master/main.py
@@ -91,6 +91,7 @@ def main() -> None:
         command_template=settings.claude_command_template,
         timeout_seconds=settings.dispatch_timeout_seconds,
         slack_bot_token=settings.slack_bot_token,
+        state_path=settings.thread_state_path,
     )
     dispatcher = MultiAgentDispatcher(
         dispatchers={"codex": codex_dispatcher, "claude-code": claude_dispatcher},

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 import json
 import logging
 import os
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 from threading import Lock
 import time
-from typing import Protocol
+from typing import Callable, Protocol
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
@@ -18,6 +18,63 @@ from .registry import AgentRegistry
 
 LOGGER = logging.getLogger(__name__)
 MENTION_PATTERN = re.compile(r"<@[^>]+>")
+_ROUTER_STATE_FILE_LOCK = Lock()
+
+
+@dataclass(frozen=True)
+class ClaudeChannelSession:
+    session_name: str
+    created: bool
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ClaudeChannelSession | None":
+        if not isinstance(raw, dict):
+            return None
+        session_name = str(raw.get("session_name") or "").strip()
+        created = bool(raw.get("created", False))
+        if not session_name:
+            return None
+        return cls(session_name=session_name, created=created)
+
+
+def _load_router_state(path: str | None) -> dict[str, object]:
+    state_path = Path((path or "").strip())
+    if not str(state_path):
+        return {}
+    if not state_path.exists():
+        return {}
+    with _ROUTER_STATE_FILE_LOCK:
+        try:
+            raw = json.loads(state_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("router.state_load_failed path=%s error=%s", state_path, exc)
+            return {}
+    if not isinstance(raw, dict):
+        LOGGER.warning("router.state_load_failed path=%s error=invalid_root_type", state_path)
+        return {}
+    return raw
+
+
+def _update_router_state(path: str | None, update: Callable[[dict[str, object]], dict[str, object]]) -> None:
+    state_path_raw = (path or "").strip()
+    if not state_path_raw:
+        return
+    state_path = Path(state_path_raw)
+    with _ROUTER_STATE_FILE_LOCK:
+        try:
+            existing: dict[str, object]
+            if state_path.exists():
+                raw = json.loads(state_path.read_text(encoding="utf-8"))
+                existing = raw if isinstance(raw, dict) else {}
+            else:
+                existing = {}
+            payload = update(dict(existing))
+            if not isinstance(payload, dict):
+                raise ValueError("router state updater must return a dict payload")
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+            state_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("router.state_persist_failed path=%s error=%s", state_path, exc)
 
 
 def _inject_claude_model(command: str, model: str) -> str:
@@ -343,8 +400,12 @@ class MultiAgentDispatcher:
 @dataclass(frozen=True)
 class ClaudeCodeDispatcher(PodmanExecDispatcher):
     command_template: str = "claude -p --output-format json"
-    _channel_sessions: dict[str, str] = field(default_factory=dict, init=False, repr=False, compare=False)
+    state_path: str | None = None
+    _channel_sessions: dict[str, ClaudeChannelSession] = field(default_factory=dict, init=False, repr=False, compare=False)
     _session_lock: Lock = field(default_factory=Lock, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "_channel_sessions", self._load_channel_sessions())
 
     @staticmethod
     def _conversation_key(*, agent_name: str, platform: str, channel_id: str) -> str:
@@ -355,6 +416,30 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
         raw = f"claude-{agent_name}-{platform}-{channel_id}"
         normalized = re.sub(r"[^A-Za-z0-9_-]+", "-", raw).strip("-")
         return normalized or "claude-session"
+
+    def _load_channel_sessions(self) -> dict[str, ClaudeChannelSession]:
+        raw = _load_router_state(self.state_path).get("claude_channel_sessions")
+        if not isinstance(raw, dict):
+            return {}
+        result: dict[str, ClaudeChannelSession] = {}
+        for key, value in raw.items():
+            if not isinstance(key, str):
+                continue
+            session = ClaudeChannelSession.from_dict(value)
+            if session is not None:
+                result[key] = session
+        return result
+
+    def _persist_channel_sessions(self) -> None:
+        with self._session_lock:
+            payload = {key: asdict(value) for key, value in sorted(self._channel_sessions.items())}
+
+        def updater(existing: dict[str, object]) -> dict[str, object]:
+            updated = dict(existing)
+            updated["claude_channel_sessions"] = payload
+            return updated
+
+        _update_router_state(self.state_path, updater)
 
     @staticmethod
     def _strip_session_flags(command: str) -> str:
@@ -528,13 +613,13 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
             channel_id=channel_id,
         )
         with self._session_lock:
-            known_session_id = self._channel_sessions.get(conversation_key)
-        initial_action = "resume" if known_session_id else "create"
-        initial_session_id = known_session_id or self._session_name(
+            known_session = self._channel_sessions.get(conversation_key)
+        initial_session_id = (known_session.session_name if known_session else "") or self._session_name(
             agent_name=agent_name,
             platform=platform,
             channel_id=channel_id,
         )
+        initial_action = "resume" if known_session and known_session.created else "create"
         retry_action: str | None = None
         effective_session_id = initial_session_id
         rendered_command = self._render_command(action=initial_action, session_id=effective_session_id)
@@ -580,7 +665,11 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
             if self._should_retry_with_create(stderr_text):
                 retry_action = "create"
                 with self._session_lock:
-                    self._channel_sessions.pop(conversation_key, None)
+                    self._channel_sessions[conversation_key] = ClaudeChannelSession(
+                        session_name=effective_session_id,
+                        created=False,
+                    )
+                self._persist_channel_sessions()
                 effective_session_id = self._session_name(
                     agent_name=agent_name,
                     platform=platform,
@@ -644,7 +733,11 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
 
         response = self._parse_response(completed.stdout.strip())
         with self._session_lock:
-            self._channel_sessions[conversation_key] = effective_session_id
+            self._channel_sessions[conversation_key] = ClaudeChannelSession(
+                session_name=effective_session_id,
+                created=True,
+            )
+        self._persist_channel_sessions()
         LOGGER.info(
             "router.dispatch_done agent=%s container=%s platform=%s channel=%s thread_ts=%s user=%s claude_action=%s session_id=%s response_chars=%d",
             agent_name,
@@ -845,33 +938,20 @@ class ChannelRouter:
         return True
 
     def _load_tracked_threads(self) -> set[str]:
-        path = (self.tracked_threads_path or "").strip()
-        if not path:
-            return set()
-        state_path = Path(path)
-        if not state_path.exists():
-            return set()
-        try:
-            raw = json.loads(state_path.read_text(encoding="utf-8"))
-        except Exception as exc:  # noqa: BLE001
-            LOGGER.warning("router.thread_state_load_failed path=%s error=%s", path, exc)
-            return set()
-        entries = raw.get("tracked_threads")
+        entries = _load_router_state(self.tracked_threads_path).get("tracked_threads")
         if not isinstance(entries, list):
             return set()
         return {str(item) for item in entries if isinstance(item, str)}
 
     def _persist_tracked_threads_unlocked(self) -> None:
-        path = (self.tracked_threads_path or "").strip()
-        if not path:
-            return
-        state_path = Path(path)
-        payload = {"tracked_threads": sorted(self._tracked_threads)}
-        try:
-            state_path.parent.mkdir(parents=True, exist_ok=True)
-            state_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        except Exception as exc:  # noqa: BLE001
-            LOGGER.warning("router.thread_state_persist_failed path=%s error=%s", path, exc)
+        tracked_threads = sorted(self._tracked_threads)
+
+        def updater(existing: dict[str, object]) -> dict[str, object]:
+            updated = dict(existing)
+            updated["tracked_threads"] = tracked_threads
+            return updated
+
+        _update_router_state(self.tracked_threads_path, updater)
 
     def _record_usage(
         self,

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 
 import pytest
@@ -320,6 +321,84 @@ def test_thread_tracking_persists_across_router_restarts(tmp_path) -> None:
         tracked_threads_path=str(state_path),
     )
     assert restarted.is_tracked_thread(channel_id="CAGENT", thread_ts="1730000000.9999") is True
+
+
+def test_claude_dispatcher_persists_created_session_across_restarts(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    state_path = tmp_path / "thread_state.json"
+    first_dispatcher = ClaudeCodeDispatcher(command_template="claude -p", state_path=str(state_path))
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    first_dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="first",
+        platform="discord",
+        channel_id="123456789",
+        thread_ts="55555",
+        user_id="U123",
+    )
+
+    restarted_dispatcher = ClaudeCodeDispatcher(command_template="claude -p", state_path=str(state_path))
+    restarted_dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="second",
+        platform="discord",
+        channel_id="123456789",
+        thread_ts="99999",
+        user_id="U123",
+    )
+
+    assert " claude -n " in f" {' '.join(seen[0])} "
+    assert " claude -r " in f" {' '.join(seen[1])} "
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["claude_channel_sessions"]["payments-agent:discord:123456789"] == {
+        "created": True,
+        "session_name": "claude-payments-agent-discord-123456789",
+    }
+
+
+def test_claude_dispatcher_session_persistence_preserves_tracked_threads(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    registry = AgentRegistry(tmp_path / "agents.json")
+    state_path = tmp_path / "thread_state.json"
+    router = ChannelRouter(
+        registry=registry,
+        dispatcher=FakeDispatcher(),
+        admin_channels={"CADMIN"},
+        tracked_threads_path=str(state_path),
+    )
+    router.track_thread(channel_id="CAGENT", thread_ts="1730000000.9999")
+
+    dispatcher = ClaudeCodeDispatcher(command_template="claude -p", state_path=str(state_path))
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        platform="slack",
+        channel_id="CAGENT",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+    )
+
+    restarted_router = ChannelRouter(
+        registry=registry,
+        dispatcher=FakeDispatcher(),
+        admin_channels={"CADMIN"},
+        tracked_threads_path=str(state_path),
+    )
+    assert restarted_router.is_tracked_thread(channel_id="CAGENT", thread_ts="1730000000.9999") is True
 
 
 def test_podman_exec_dispatcher_includes_exit_and_output_details(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
Persist Claude per-channel session metadata in master state so restart does not lose created-session status and accidentally re-run `-n`.

## Changes
- add persisted `claude_channel_sessions` state keyed by `agent:platform:channel`
- persist `session_name` and `created` flag
- load persisted state when Claude dispatcher starts
- share router state read/write path so tracked threads and Claude session state coexist
- wire Claude dispatcher `state_path` from master `thread_state_path`

## Behavior
- if a channel session is recorded as created, dispatcher uses `-r <session>`
- if no created record exists, dispatcher uses `-n <session>`
- after successful execution, record is updated to `created=true`

## Test Evidence
- .venv/bin/pytest -q tests/master/test_router.py
- .venv/bin/pytest -q tests/master/test_master_config.py tests/master/test_master_service.py

## Regression Coverage
- persists Claude session state across dispatcher restart
- ensures Claude session persistence does not clobber tracked thread state
