### PR TITLE
feat: auto-start agent on first message

### DIFF
--- a/docs/design/agent-container-runtime-design.md
+++ b/docs/design/agent-container-runtime-design.md
@@ -202,6 +202,12 @@ Rules:
 
 This is intended to refresh auth without destroying the rest of the Codex home.
 
+For Codex agents, master also runs the same refresh operation during routed
+message preparation when the registry record has no `auth_refreshed_at` value or
+the timestamp is older than `MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS` (default
+`2`). The refresh happens after any required container startup and before the
+prompt is executed inside the agent.
+
 ### Claude config refresh
 
 `/master-agent-refresh-config <name>` copies the current shared Claude config

--- a/docs/design/containers/master-container-design.md
+++ b/docs/design/containers/master-container-design.md
@@ -83,6 +83,8 @@ The master process composes these main subsystems:
   - persists logical agent records and routing metadata
 - `MasterService`
   - owns command-side lifecycle operations
+  - prepares agents for routed messages by starting absent/stopped containers
+    and refreshing stale Codex auth when needed
 - `PodmanRuntimeAdapter`
   - translates lifecycle operations into container runtime commands
 - `ChannelRouter`
@@ -126,6 +128,11 @@ The master is the only control plane for agents. It injects:
 - shared mounts such as workspace volume, auth seed, global config, SSH agent
   socket, and transient request storage
 - prompt dispatch via `podman exec`
+
+Before dispatching a routed prompt, the dispatcher calls back into
+`MasterService.prepare_agent_for_message()`. That prepare step uses the same
+agent startup path as `/master-agent-start` when the container is absent or not
+running, and refreshes Codex auth if the registry timestamp is stale.
 
 Detailed agent-side semantics belong in:
 
@@ -240,6 +247,8 @@ The master container must preserve these invariants:
 
 - it is the only control plane for agent containers
 - registry and thread state are durable across container restart
+- Codex auth refresh timestamps live in the registry and must remain durable
+  across master restart for age-based refresh decisions
 - agent work happens in agent containers, not inside the master process
 - request staging is transient and isolated from durable repo state
 - frontend adapters may differ, but they share the same service and router core

--- a/docs/design/master-agent-architecture.md
+++ b/docs/design/master-agent-architecture.md
@@ -172,14 +172,19 @@ sequenceDiagram
     participant U as User
     participant FE as Frontend Adapter
     participant RT as ChannelRouter
+    participant M as MasterService
     participant DISP as Dispatcher
     participant AG as Agent Container
 
     U->>FE: mention / follow-up message
     FE->>RT: normalized prompt + attachments
     RT->>RT: validate mapping and thread continuity
-    RT->>RT: stage request input if needed
     RT->>DISP: dispatch prompt
+    DISP->>M: prepare_agent_for_message(name)
+    M->>M: start agent if container is absent/stopped
+    M->>M: refresh stale Codex auth if due
+    DISP->>DISP: verify container is running
+    RT->>RT: stage request input if needed
     DISP->>AG: podman exec / adapter command
     AG-->>DISP: response text
     DISP-->>RT: normalized result
@@ -229,8 +234,10 @@ stateDiagram-v2
     [*] --> MasterRunning
     MasterRunning --> AgentLoaded: /master-agent-load
     AgentLoaded --> AgentRunning: /master-agent-start
+    AgentLoaded --> AgentRunning: routed prompt prepare step
     AgentRunning --> AgentStopped: /master-agent-stop
     AgentStopped --> AgentRunning: /master-agent-start
+    AgentStopped --> AgentRunning: routed prompt prepare step
     AgentLoaded --> AgentRemoved: /master-agent-remove
     AgentStopped --> AgentRemoved: /master-agent-remove
     AgentRunning --> AgentError: runtime or dispatch failure

--- a/docs/design/master-agent-interface-design.md
+++ b/docs/design/master-agent-interface-design.md
@@ -219,6 +219,10 @@ The manifest is the canonical descriptor for:
 - primary execution path is `codex exec ...`
 - user-scope config lives under `/workspace/home/.codex`
 - auth refresh writes to `/workspace/home/.codex/auth.json`
+- routed prompts trigger a master-side prepare step before dispatch; if
+  `auth_refreshed_at` is missing or older than
+  `MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS`, master refreshes Codex auth before
+  executing the prompt
 
 ### Claude Code
 

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -112,6 +112,7 @@ Important env notes:
 - If `MASTER_GIT_USER_NAME` and `MASTER_GIT_USER_EMAIL` are set, the master passes them into each agent and the worker writes them into the checked-out repo's local Git config during startup.
 - Default command template is `MASTER_AGENT_COMMAND_TEMPLATE='codex exec --dangerously-bypass-approvals-and-sandbox resume --last -'`.
 - Default adapter is `MASTER_DEFAULT_AGENT_ADAPTER=codex`.
+- `MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS` defaults to `2`. For Codex agents, routed prompts run a master-side prepare step that refreshes workspace auth when the registry timestamp is missing or older than this threshold.
 - If you use the `claude-code` adapter, rebuild the base image from this branch so the agent container includes the `claude` CLI binary.
 - If a project repo contains `.prj_assistant/image/Dockerfile`, master builds that repo-local image on `/master-agent-start` and does not use `MASTER_AGENT_BASE_IMAGE` for that agent.
 
@@ -125,6 +126,7 @@ claude setup-token
 
 Persistence notes:
 - Without the `data/master` volume mount, `agents.json` is lost when the master container exits, so `/master-agent-list` will look empty after restart.
+- The agent registry also stores `auth_refreshed_at` for Codex agents. Keep `data/master` mounted if you want automatic auth refresh age checks to survive master restarts.
 - The repo includes `docker-compose.master-agent.example.yml` as the baseline Compose definition for the master runtime.
 2. Verify startup logs include:
 - loaded admin channels
@@ -171,9 +173,12 @@ Omit the model argument to clear the override:
 
 ## Routing Validation
 1. In mapped non-admin channel, mention bot with prompt.
-2. Confirm master logs routing event for mapped agent.
-3. Reply in the same thread without mention.
-4. Confirm thread follow-up routes to same agent.
+2. Confirm master runs the message prepare step before dispatch.
+3. If the agent container is absent or stopped, confirm master uses the same startup flow as `/master-agent-start` before dispatching.
+4. For Codex agents, if `auth_refreshed_at` is missing or stale, confirm master refreshes auth before dispatching.
+5. Confirm master logs routing event for mapped agent.
+6. Reply in the same thread without mention.
+7. Confirm thread follow-up routes to same agent.
 
 ## Failure Recovery
 ### Build or start failure
@@ -235,6 +240,7 @@ ls -l "$MASTER_SSH_AUTH_SOCK_PATH"
 ```
 - This updates `/workspace/home/.codex/auth.json` in the agent home and preserves existing `.codex` session state files.
 - You do not need to remove the agent container for this recovery path.
+- Routed Codex prompts also refresh auth automatically when `auth_refreshed_at` is missing or older than `MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS`. Manual `/master-agent-refresh-auth` is still useful immediately after rotating the host auth source or when validating auth recovery.
 
 ### Rate-limited commands
 - Master returns `ERR_RATE_LIMITED`.

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -43,6 +43,7 @@ This page summarizes the main configuration keys loaded directly from the curren
 | `MASTER_CLAUDE_COMMAND_TEMPLATE` | No | `claude -p --output-format json --dangerously-skip-permissions` | Claude dispatch command |
 | `MASTER_DEFAULT_AGENT_ADAPTER` | No | `codex` | Default agent adapter |
 | `MASTER_AGENT_TIMEOUT_SECONDS` | No | unset | Dispatch timeout |
+| `MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS` | No | `2` | Maximum age, in days, for persisted Codex auth refresh state before routed Codex prompts refresh auth again |
 | `MASTER_COMMAND_RATE_LIMIT_COUNT` | No | `20` | Per-user command burst limit |
 | `MASTER_COMMAND_RATE_LIMIT_WINDOW_SECONDS` | No | `60` | Rate-limit window size |
 

--- a/docs/test-plans/master-agent-uat.md
+++ b/docs/test-plans/master-agent-uat.md
@@ -411,6 +411,35 @@ Expected:
 - Response includes the target workspace volume name.
 - Existing agent workspace `.codex` is re-seeded from the current host `auth.json` without removing the agent record.
 
+## UAT-005B: Routed Prompt Auto-Starts Agent
+Preconditions:
+- Agent is loaded and mapped to a non-admin channel.
+- Agent container is stopped or absent.
+
+Steps:
+1. Send a routed mention prompt in the mapped channel.
+2. Inspect master logs and `/master-agent-status payments-agent`.
+
+Expected:
+- Master runs the same startup flow as `/master-agent-start payments-agent`.
+- The agent container becomes running before prompt dispatch.
+- The routed prompt receives an agent response.
+
+## UAT-005C: Routed Prompt Refreshes Stale Codex Auth
+Preconditions:
+- Agent uses the `codex` adapter.
+- `MASTER_CODEX_AUTH_JSON_PATH` points to the host auth file.
+- `MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS` is set to a low value for testing, or the registry record has no `auth_refreshed_at`.
+
+Steps:
+1. Send a routed mention prompt in the mapped channel.
+2. Inspect the registry record and master logs.
+
+Expected:
+- Master refreshes agent auth before dispatching the prompt.
+- Registry record includes an updated `auth_refreshed_at` timestamp.
+- Existing Codex session state in the agent workspace is preserved.
+
 ## UAT-006: Admin Channel Enforcement
 Preconditions:
 - Master running.

--- a/src/master/config.py
+++ b/src/master/config.py
@@ -160,9 +160,9 @@ def load_master_settings() -> MasterSettings:
     dispatch_timeout_seconds = int(raw_dispatch_timeout) if raw_dispatch_timeout else None
     if dispatch_timeout_seconds is not None and dispatch_timeout_seconds <= 0:
         dispatch_timeout_seconds = None
-    raw_auth_refresh_days = os.getenv("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS", "7").strip()
+    raw_auth_refresh_days = os.getenv("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS", "2").strip()
     _log_env("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS", os.getenv("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS"))
-    auth_refresh_max_age_days = int(raw_auth_refresh_days) if raw_auth_refresh_days else 7
+    auth_refresh_max_age_days = int(raw_auth_refresh_days) if raw_auth_refresh_days else 2
     if auth_refresh_max_age_days < 0:
         auth_refresh_max_age_days = 0
     raw_rate_limit_count = os.getenv("MASTER_COMMAND_RATE_LIMIT_COUNT", "20").strip()

--- a/src/master/config.py
+++ b/src/master/config.py
@@ -31,6 +31,7 @@ class MasterSettings:
     codex_command_template: str
     claude_command_template: str
     dispatch_timeout_seconds: int | None
+    auth_refresh_max_age_days: int
     command_rate_limit_count: int
     command_rate_limit_window_seconds: int
 
@@ -159,6 +160,11 @@ def load_master_settings() -> MasterSettings:
     dispatch_timeout_seconds = int(raw_dispatch_timeout) if raw_dispatch_timeout else None
     if dispatch_timeout_seconds is not None and dispatch_timeout_seconds <= 0:
         dispatch_timeout_seconds = None
+    raw_auth_refresh_days = os.getenv("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS", "7").strip()
+    _log_env("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS", os.getenv("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS"))
+    auth_refresh_max_age_days = int(raw_auth_refresh_days) if raw_auth_refresh_days else 7
+    if auth_refresh_max_age_days < 0:
+        auth_refresh_max_age_days = 0
     raw_rate_limit_count = os.getenv("MASTER_COMMAND_RATE_LIMIT_COUNT", "20").strip()
     _log_env("MASTER_COMMAND_RATE_LIMIT_COUNT", os.getenv("MASTER_COMMAND_RATE_LIMIT_COUNT"))
     raw_rate_limit_window = os.getenv("MASTER_COMMAND_RATE_LIMIT_WINDOW_SECONDS", "60").strip()
@@ -213,6 +219,7 @@ def load_master_settings() -> MasterSettings:
         codex_command_template=codex_command_template,
         claude_command_template=claude_command_template,
         dispatch_timeout_seconds=dispatch_timeout_seconds,
+        auth_refresh_max_age_days=auth_refresh_max_age_days,
         command_rate_limit_count=command_rate_limit_count,
         command_rate_limit_window_seconds=command_rate_limit_window_seconds,
     )

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -34,13 +34,13 @@ def mask_token(token: str) -> str:
     return f"{value[:4]}...{value[-4:]}"
 
 
-def build_auto_start_callback(service: MasterService):  # type: ignore[no-untyped-def]
-    def auto_start(agent_name: str) -> None:
-        result = service.start_agent(name=agent_name)
+def build_agent_prepare_callback(service: MasterService):  # type: ignore[no-untyped-def]
+    def prepare(agent_name: str) -> None:
+        result = service.prepare_agent_for_message(name=agent_name)
         if not result.ok:
             raise RuntimeError(result.message)
 
-    return auto_start
+    return prepare
 
 
 def main() -> None:
@@ -50,7 +50,7 @@ def main() -> None:
 
     settings = load_master_settings()
     logging.getLogger(__name__).info(
-        "master.startup frontends=%s registry_path=%s thread_state_path=%s admin_channels=%s discord_admin_channels=%s dry_run=%s base_image=%s auth_json_path=%s codex_config_dir_path=%s claude_config_dir_path=%s ssh_auth_sock_path=%s ssh_known_hosts_path=%s git_user=%s git_email=%s default_adapter=%s bot_token=%s app_token=%s discord_token=%s dispatch_timeout=%s rate_limit=%d/%ds",
+        "master.startup frontends=%s registry_path=%s thread_state_path=%s admin_channels=%s discord_admin_channels=%s dry_run=%s base_image=%s auth_json_path=%s codex_config_dir_path=%s claude_config_dir_path=%s ssh_auth_sock_path=%s ssh_known_hosts_path=%s git_user=%s git_email=%s default_adapter=%s bot_token=%s app_token=%s discord_token=%s dispatch_timeout=%s auth_refresh_days=%s rate_limit=%d/%ds",
         ",".join(sorted(settings.frontends)),
         settings.registry_path,
         settings.thread_state_path,
@@ -70,6 +70,7 @@ def main() -> None:
         mask_token(settings.slack_app_token),
         mask_token(settings.discord_bot_token or ""),
         settings.dispatch_timeout_seconds,
+        settings.auth_refresh_max_age_days,
         settings.command_rate_limit_count,
         settings.command_rate_limit_window_seconds,
     )
@@ -90,19 +91,20 @@ def main() -> None:
         git_user_name=settings.git_user_name,
         git_user_email=settings.git_user_email,
         default_agent_adapter=settings.default_agent_adapter,
+        auth_refresh_max_age_days=settings.auth_refresh_max_age_days,
     )
-    auto_start_callback = build_auto_start_callback(service)
+    agent_prepare_callback = build_agent_prepare_callback(service)
     codex_dispatcher = PodmanExecDispatcher(
         command_template=settings.codex_command_template,
         timeout_seconds=settings.dispatch_timeout_seconds,
         slack_bot_token=settings.slack_bot_token,
-        agent_start_callback=auto_start_callback,
+        agent_prepare_callback=agent_prepare_callback,
     )
     claude_dispatcher = ClaudeCodeDispatcher(
         command_template=settings.claude_command_template,
         timeout_seconds=settings.dispatch_timeout_seconds,
         slack_bot_token=settings.slack_bot_token,
-        agent_start_callback=auto_start_callback,
+        agent_prepare_callback=agent_prepare_callback,
     )
     dispatcher = MultiAgentDispatcher(
         dispatchers={"codex": codex_dispatcher, "claude-code": claude_dispatcher},

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -34,6 +34,15 @@ def mask_token(token: str) -> str:
     return f"{value[:4]}...{value[-4:]}"
 
 
+def build_auto_start_callback(service: MasterService):  # type: ignore[no-untyped-def]
+    def auto_start(agent_name: str) -> None:
+        result = service.start_agent(name=agent_name)
+        if not result.ok:
+            raise RuntimeError(result.message)
+
+    return auto_start
+
+
 def main() -> None:
     load_dotenv()
     configure_logging()
@@ -82,15 +91,18 @@ def main() -> None:
         git_user_email=settings.git_user_email,
         default_agent_adapter=settings.default_agent_adapter,
     )
+    auto_start_callback = build_auto_start_callback(service)
     codex_dispatcher = PodmanExecDispatcher(
         command_template=settings.codex_command_template,
         timeout_seconds=settings.dispatch_timeout_seconds,
         slack_bot_token=settings.slack_bot_token,
+        agent_start_callback=auto_start_callback,
     )
     claude_dispatcher = ClaudeCodeDispatcher(
         command_template=settings.claude_command_template,
         timeout_seconds=settings.dispatch_timeout_seconds,
         slack_bot_token=settings.slack_bot_token,
+        agent_start_callback=auto_start_callback,
     )
     dispatcher = MultiAgentDispatcher(
         dispatchers={"codex": codex_dispatcher, "claude-code": claude_dispatcher},

--- a/src/master/registry.py
+++ b/src/master/registry.py
@@ -30,6 +30,7 @@ class AgentRecord:
     resolved_image: str | None = None
     last_error: str | None = None
     claude_model: str | None = None
+    auth_refreshed_at: str | None = None
     created_at: str = ""
     updated_at: str = ""
 
@@ -77,6 +78,7 @@ class AgentRegistry:
         normalized = dict(item)
         normalized.setdefault("platform", "slack")
         normalized.setdefault("agent_adapter", "codex")
+        normalized.setdefault("auth_refreshed_at", None)
         return normalized
 
     def migrate_schema(self) -> bool:

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 from threading import Lock
 import time
-from typing import Protocol
+from typing import Callable, Protocol
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
@@ -58,6 +58,7 @@ class PodmanExecDispatcher:
     workdir: str = "/workspace/repo"
     codex_home: str = "/workspace/home/.codex"
     slack_bot_token: str | None = None
+    agent_start_callback: Callable[[str], None] | None = None
 
     @staticmethod
     def _clip(value: str, limit: int = 240) -> str:
@@ -98,7 +99,7 @@ class PodmanExecDispatcher:
             return stripped
         return f"{stripped} --dangerously-skip-permissions"
 
-    def _ensure_container_running(self, *, container_name: str) -> None:
+    def _ensure_container_running(self, *, agent_name: str, container_name: str) -> None:
         try:
             inspected = subprocess.run(
                 ["podman", "inspect", "--type", "container", container_name],
@@ -117,6 +118,18 @@ class PodmanExecDispatcher:
             raise RouteError("podman CLI is not available in the master runtime") from exc
 
         if inspected.returncode != 0:
+            if self.agent_start_callback is not None:
+                LOGGER.info(
+                    "router.container_autostart_via_master agent=%s container=%s previous_status=%s",
+                    agent_name,
+                    container_name,
+                    "absent",
+                )
+                try:
+                    self.agent_start_callback(agent_name)
+                except Exception as exc:  # noqa: BLE001
+                    raise RouteError(f"failed to auto-start {agent_name}: {exc}") from exc
+                return
             stderr_text = self._clip(inspected.stderr)
             raise RouteError(
                 f"agent container is not available: {container_name}"
@@ -135,6 +148,19 @@ class PodmanExecDispatcher:
         status = str(state.get("Status", "unknown"))
         running = bool(state.get("Running", False))
         if running:
+            return
+
+        if self.agent_start_callback is not None:
+            LOGGER.info(
+                "router.container_autostart_via_master agent=%s container=%s previous_status=%s",
+                agent_name,
+                container_name,
+                status,
+            )
+            try:
+                self.agent_start_callback(agent_name)
+            except Exception as exc:  # noqa: BLE001
+                raise RouteError(f"failed to auto-start {agent_name}: {exc}") from exc
             return
 
         LOGGER.info(
@@ -181,7 +207,7 @@ class PodmanExecDispatcher:
         if claude_model:
             rendered_command = _inject_claude_model(rendered_command, claude_model)
         image_urls = image_urls or []
-        self._ensure_container_running(container_name=container_name)
+        self._ensure_container_running(agent_name=agent_name, container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
             session_id=session_id,
@@ -573,7 +599,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
     ) -> str:
         LOGGER.info("router.claude_command_template template=%r", self.command_template)
         image_urls = image_urls or []
-        self._ensure_container_running(container_name=container_name)
+        self._ensure_container_running(agent_name=agent_name, container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
             session_id=channel_id,

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -58,7 +58,7 @@ class PodmanExecDispatcher:
     workdir: str = "/workspace/repo"
     codex_home: str = "/workspace/home/.codex"
     slack_bot_token: str | None = None
-    agent_start_callback: Callable[[str], None] | None = None
+    agent_prepare_callback: Callable[[str], None] | None = None
 
     @staticmethod
     def _clip(value: str, limit: int = 240) -> str:
@@ -118,18 +118,6 @@ class PodmanExecDispatcher:
             raise RouteError("podman CLI is not available in the master runtime") from exc
 
         if inspected.returncode != 0:
-            if self.agent_start_callback is not None:
-                LOGGER.info(
-                    "router.container_autostart_via_master agent=%s container=%s previous_status=%s",
-                    agent_name,
-                    container_name,
-                    "absent",
-                )
-                try:
-                    self.agent_start_callback(agent_name)
-                except Exception as exc:  # noqa: BLE001
-                    raise RouteError(f"failed to auto-start {agent_name}: {exc}") from exc
-                return
             stderr_text = self._clip(inspected.stderr)
             raise RouteError(f"agent container is not running and auto-start is not configured: {container_name}" + (f" ({stderr_text})" if stderr_text else ""))
 
@@ -147,20 +135,15 @@ class PodmanExecDispatcher:
         if running:
             return
 
-        if self.agent_start_callback is not None:
-            LOGGER.info(
-                "router.container_autostart_via_master agent=%s container=%s previous_status=%s",
-                agent_name,
-                container_name,
-                status,
-            )
-            try:
-                self.agent_start_callback(agent_name)
-            except Exception as exc:  # noqa: BLE001
-                raise RouteError(f"failed to auto-start {agent_name}: {exc}") from exc
-            return
-
         raise RouteError(f"agent container is not running and auto-start is not configured: {container_name} (status={status})")
+
+    def _prepare_agent_for_dispatch(self, *, agent_name: str) -> None:
+        if self.agent_prepare_callback is None:
+            return
+        try:
+            self.agent_prepare_callback(agent_name)
+        except Exception as exc:  # noqa: BLE001
+            raise RouteError(f"failed to prepare {agent_name}: {exc}") from exc
 
     def send_prompt(
         self,
@@ -180,6 +163,7 @@ class PodmanExecDispatcher:
         if claude_model:
             rendered_command = _inject_claude_model(rendered_command, claude_model)
         image_urls = image_urls or []
+        self._prepare_agent_for_dispatch(agent_name=agent_name)
         self._ensure_container_running(agent_name=agent_name, container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
@@ -572,6 +556,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
     ) -> str:
         LOGGER.info("router.claude_command_template template=%r", self.command_template)
         image_urls = image_urls or []
+        self._prepare_agent_for_dispatch(agent_name=agent_name)
         self._ensure_container_running(agent_name=agent_name, container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -98,6 +98,71 @@ class PodmanExecDispatcher:
             return stripped
         return f"{stripped} --dangerously-skip-permissions"
 
+    def _ensure_container_running(self, *, container_name: str) -> None:
+        try:
+            inspected = subprocess.run(
+                ["podman", "inspect", "--type", "container", container_name],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RouteError(f"dispatch timed out after {self.timeout_seconds}s") from exc
+        except FileNotFoundError as exc:
+            LOGGER.warning(
+                "router.dispatch_failed agent_container=%s reason=missing_binary error=%s",
+                container_name,
+                exc,
+            )
+            raise RouteError("podman CLI is not available in the master runtime") from exc
+
+        if inspected.returncode != 0:
+            stderr_text = self._clip(inspected.stderr)
+            raise RouteError(
+                f"agent container is not available: {container_name}"
+                + (f" ({stderr_text})" if stderr_text else "")
+            )
+
+        try:
+            payload = json.loads(inspected.stdout)
+        except json.JSONDecodeError as exc:
+            raise RouteError(f"failed to inspect agent container {container_name}: invalid inspect output") from exc
+
+        if not payload:
+            raise RouteError(f"agent container is not available: {container_name}")
+
+        state = payload[0].get("State", {})
+        status = str(state.get("Status", "unknown"))
+        running = bool(state.get("Running", False))
+        if running:
+            return
+
+        LOGGER.info(
+            "router.container_autostart_begin container=%s previous_status=%s",
+            container_name,
+            status,
+        )
+        try:
+            started = subprocess.run(
+                ["podman", "start", container_name],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RouteError(f"dispatch timed out after {self.timeout_seconds}s") from exc
+        if started.returncode != 0:
+            stderr_text = self._clip(started.stderr)
+            raise RouteError(
+                f"failed to start agent container {container_name}"
+                + (f" ({stderr_text})" if stderr_text else "")
+            )
+        LOGGER.info(
+            "router.container_autostart_done container=%s previous_status=%s",
+            container_name,
+            status,
+        )
+
     def send_prompt(
         self,
         *,
@@ -116,6 +181,7 @@ class PodmanExecDispatcher:
         if claude_model:
             rendered_command = _inject_claude_model(rendered_command, claude_model)
         image_urls = image_urls or []
+        self._ensure_container_running(container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
             session_id=session_id,
@@ -507,6 +573,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
     ) -> str:
         LOGGER.info("router.claude_command_template template=%r", self.command_template)
         image_urls = image_urls or []
+        self._ensure_container_running(container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
             session_id=channel_id,

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -131,10 +131,7 @@ class PodmanExecDispatcher:
                     raise RouteError(f"failed to auto-start {agent_name}: {exc}") from exc
                 return
             stderr_text = self._clip(inspected.stderr)
-            raise RouteError(
-                f"agent container is not available: {container_name}"
-                + (f" ({stderr_text})" if stderr_text else "")
-            )
+            raise RouteError(f"agent container is not running and auto-start is not configured: {container_name}" + (f" ({stderr_text})" if stderr_text else ""))
 
         try:
             payload = json.loads(inspected.stdout)
@@ -163,31 +160,7 @@ class PodmanExecDispatcher:
                 raise RouteError(f"failed to auto-start {agent_name}: {exc}") from exc
             return
 
-        LOGGER.info(
-            "router.container_autostart_begin container=%s previous_status=%s",
-            container_name,
-            status,
-        )
-        try:
-            started = subprocess.run(
-                ["podman", "start", container_name],
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise RouteError(f"dispatch timed out after {self.timeout_seconds}s") from exc
-        if started.returncode != 0:
-            stderr_text = self._clip(started.stderr)
-            raise RouteError(
-                f"failed to start agent container {container_name}"
-                + (f" ({stderr_text})" if stderr_text else "")
-            )
-        LOGGER.info(
-            "router.container_autostart_done container=%s previous_status=%s",
-            container_name,
-            status,
-        )
+        raise RouteError(f"agent container is not running and auto-start is not configured: {container_name} (status={status})")
 
     def send_prompt(
         self,

--- a/src/master/service.py
+++ b/src/master/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 import logging
 import os
 from pathlib import Path
@@ -8,7 +9,7 @@ import re
 import shutil
 import subprocess
 
-from .registry import AgentRecord, AgentRegistry
+from .registry import AgentRecord, AgentRegistry, utc_now_iso
 from .runtime_adapter import RuntimeAdapter
 
 DEFAULT_IMAGE = "codex-slack-bot:latest"
@@ -42,6 +43,7 @@ class MasterService:
         git_user_name: str | None = None,
         git_user_email: str | None = None,
         default_agent_adapter: str = DEFAULT_AGENT_ADAPTER,
+        auth_refresh_max_age_days: int = 7,
     ) -> None:
         self._registry = registry
         self._runtime = runtime
@@ -54,6 +56,7 @@ class MasterService:
         self._git_user_name = git_user_name
         self._git_user_email = git_user_email
         self._default_agent_adapter = default_agent_adapter if default_agent_adapter in SUPPORTED_AGENT_ADAPTERS else DEFAULT_AGENT_ADAPTER
+        self._auth_refresh_max_age_days = max(auth_refresh_max_age_days, 0)
 
     def list_agents(self) -> CommandResult:
         agents = []
@@ -343,6 +346,9 @@ class MasterService:
             self._audit(command="refresh-auth", agent=name, result=result)
             return result
 
+        record.auth_refreshed_at = utc_now_iso()
+        self._registry.upsert(record)
+
         result = CommandResult(
             ok=True,
             code="OK",
@@ -351,9 +357,50 @@ class MasterService:
                 "refreshed": True,
                 "volume_name": f"agent-workspace-{record.name}",
                 "auth_source": self._agent_codex_auth_json_path,
+                "auth_refreshed_at": record.auth_refreshed_at,
             },
         )
         self._audit(command="refresh-auth", agent=name, result=result)
+        return result
+
+    def prepare_agent_for_message(self, *, name: str) -> CommandResult:
+        record = self._registry.get(name)
+        if not record:
+            result = CommandResult(ok=False, code="ERR_AGENT_NOT_FOUND", message=f"unknown agent: {name}", data={})
+            self._audit(command="prepare-message", agent=name, result=result)
+            return result
+
+        inspect = self._runtime.inspect_agent(record.container_name)
+        started = False
+        refreshed_auth = False
+
+        if not self._is_runtime_running(inspect):
+            started_result = self.start_agent(name=name)
+            if not started_result.ok:
+                self._audit(command="prepare-message", agent=name, result=started_result)
+                return started_result
+            started = True
+            record = self._registry.get(name) or record
+
+        if self._should_refresh_agent_auth(record):
+            refresh_result = self.refresh_agent_auth(name=name)
+            if not refresh_result.ok:
+                self._audit(command="prepare-message", agent=name, result=refresh_result)
+                return refresh_result
+            refreshed_auth = True
+            record = self._registry.get(name) or record
+
+        result = CommandResult(
+            ok=True,
+            code="OK",
+            message=f"prepared {name} for message",
+            data={
+                "started": started,
+                "refreshed_auth": refreshed_auth,
+                "auth_refreshed_at": record.auth_refreshed_at,
+            },
+        )
+        self._audit(command="prepare-message", agent=name, result=result)
         return result
 
     def refresh_agent_config(self, *, name: str) -> CommandResult:
@@ -505,6 +552,35 @@ class MasterService:
         # causes claude to hang on its first write attempt.
 
         return env
+
+    @staticmethod
+    def _is_runtime_running(inspect: object) -> bool:
+        if not isinstance(inspect, dict):
+            return False
+        state = inspect.get("State")
+        if isinstance(state, dict):
+            return bool(state.get("Running", False))
+        if isinstance(state, str):
+            return state == "running"
+        return False
+
+    def _should_refresh_agent_auth(self, record: AgentRecord) -> bool:
+        if record.agent_adapter != "codex":
+            return False
+        if not self._agent_codex_auth_json_path:
+            return False
+        if self._auth_refresh_max_age_days <= 0:
+            return False
+        if not record.auth_refreshed_at:
+            return True
+        try:
+            refreshed_at = datetime.fromisoformat(record.auth_refreshed_at)
+        except ValueError:
+            return True
+        if refreshed_at.tzinfo is None:
+            refreshed_at = refreshed_at.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - refreshed_at.astimezone(timezone.utc)
+        return age >= timedelta(days=self._auth_refresh_max_age_days)
 
     def _build_agent_mounts(self) -> list[str]:
         mounts: list[str] = []

--- a/src/master/service.py
+++ b/src/master/service.py
@@ -43,7 +43,7 @@ class MasterService:
         git_user_name: str | None = None,
         git_user_email: str | None = None,
         default_agent_adapter: str = DEFAULT_AGENT_ADAPTER,
-        auth_refresh_max_age_days: int = 7,
+        auth_refresh_max_age_days: int = 2,
     ) -> None:
         self._registry = registry
         self._runtime = runtime

--- a/tests/master/test_master_config.py
+++ b/tests/master/test_master_config.py
@@ -81,7 +81,7 @@ def test_load_master_settings_uses_session_aware_default_template(monkeypatch) -
     assert settings.codex_command_template == "codex exec --dangerously-bypass-approvals-and-sandbox resume --last -"
     assert settings.claude_command_template == "claude -p --output-format json --dangerously-skip-permissions"
     assert settings.default_agent_adapter == "codex"
-    assert settings.auth_refresh_max_age_days == 7
+    assert settings.auth_refresh_max_age_days == 2
 
 
 def test_load_master_settings_rejects_unknown_default_agent_adapter(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/master/test_master_config.py
+++ b/tests/master/test_master_config.py
@@ -27,6 +27,7 @@ def test_load_master_settings(monkeypatch) -> None:  # type: ignore[no-untyped-d
     monkeypatch.setenv("MASTER_CLAUDE_COMMAND_TEMPLATE", "claude --print -")
     monkeypatch.setenv("MASTER_DEFAULT_AGENT_ADAPTER", "claude-code")
     monkeypatch.setenv("MASTER_AGENT_TIMEOUT_SECONDS", "30")
+    monkeypatch.setenv("MASTER_AGENT_AUTH_REFRESH_MAX_AGE_DAYS", "14")
     monkeypatch.setenv("MASTER_COMMAND_RATE_LIMIT_COUNT", "10")
     monkeypatch.setenv("MASTER_COMMAND_RATE_LIMIT_WINDOW_SECONDS", "45")
 
@@ -52,6 +53,7 @@ def test_load_master_settings(monkeypatch) -> None:  # type: ignore[no-untyped-d
     assert settings.claude_command_template == "claude --print -"
     assert settings.default_agent_adapter == "claude-code"
     assert settings.dispatch_timeout_seconds == 30
+    assert settings.auth_refresh_max_age_days == 14
     assert settings.command_rate_limit_count == 10
     assert settings.command_rate_limit_window_seconds == 45
 
@@ -79,6 +81,7 @@ def test_load_master_settings_uses_session_aware_default_template(monkeypatch) -
     assert settings.codex_command_template == "codex exec --dangerously-bypass-approvals-and-sandbox resume --last -"
     assert settings.claude_command_template == "claude -p --output-format json --dangerously-skip-permissions"
     assert settings.default_agent_adapter == "codex"
+    assert settings.auth_refresh_max_age_days == 7
 
 
 def test_load_master_settings_rejects_unknown_default_agent_adapter(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/master/test_master_service.py
+++ b/tests/master/test_master_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 from src.master.registry import AgentRegistry
 from src.master.service import MasterService
 
@@ -7,6 +9,7 @@ from src.master.service import MasterService
 class FakeRuntime:
     def __init__(self) -> None:
         self.calls: list[tuple[str, object]] = []
+        self.inspect_result: dict[str, object] | None = {"Name": "agent", "State": "running"}
 
     def pull_image(self, image: str) -> None:
         self.calls.append(("pull_image", image))
@@ -45,7 +48,11 @@ class FakeRuntime:
 
     def inspect_agent(self, name: str) -> dict[str, str] | None:
         self.calls.append(("inspect_agent", name))
-        return {"Name": name, "State": "running"}
+        if self.inspect_result is None:
+            return None
+        payload = dict(self.inspect_result)
+        payload["Name"] = name
+        return payload
 
     def tail_logs(self, name: str, lines: int) -> str:
         self.calls.append(("tail_logs", {"name": name, "lines": lines}))
@@ -439,6 +446,10 @@ def test_refresh_agent_auth_reseeds_workspace_codex_home(tmp_path) -> None:
             "host_auth_path": "/host/secrets/codex-auth.json",
         },
     )
+    saved = registry.get("payments-api")
+    assert saved is not None
+    assert saved.auth_refreshed_at is not None
+    assert refreshed.data["auth_refreshed_at"] == saved.auth_refreshed_at
 
 
 def test_refresh_agent_auth_requires_configured_auth_source(tmp_path) -> None:
@@ -475,6 +486,113 @@ def test_refresh_agent_auth_propagates_runtime_failure(tmp_path) -> None:
     refreshed = service.refresh_agent_auth(name="payments-api")
     assert refreshed.ok is False
     assert refreshed.code == "ERR_RUNTIME_FAILED"
+
+
+def test_prepare_agent_for_message_starts_stopped_agent_and_refreshes_stale_auth(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    runtime.inspect_result = {"State": {"Running": False, "Status": "exited"}}
+    service = MasterService(
+        registry=registry,
+        runtime=runtime,
+        agent_codex_auth_json_path="/host/secrets/codex-auth.json",
+        auth_refresh_max_age_days=7,
+    )
+
+    loaded = service.load_agent(name="payments-api", repo_path=str(repo), channel_id="C123")
+    assert loaded.ok is True
+    record = registry.get("payments-api")
+    assert record is not None
+    record.auth_refreshed_at = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+    registry.upsert(record)
+
+    prepared = service.prepare_agent_for_message(name="payments-api")
+
+    assert prepared.ok is True
+    assert prepared.data["started"] is True
+    assert prepared.data["refreshed_auth"] is True
+    call_names = [call[0] for call in runtime.calls]
+    assert "inspect_agent" in call_names
+    assert "start_agent" in call_names
+    assert "refresh_agent_auth" in call_names
+
+
+def test_prepare_agent_for_message_refreshes_missing_auth_timestamp_for_running_codex_agent(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    runtime.inspect_result = {"State": {"Running": True, "Status": "running"}}
+    service = MasterService(
+        registry=registry,
+        runtime=runtime,
+        agent_codex_auth_json_path="/host/secrets/codex-auth.json",
+        auth_refresh_max_age_days=7,
+    )
+
+    loaded = service.load_agent(name="payments-api", repo_path=str(repo), channel_id="C123")
+    assert loaded.ok is True
+
+    prepared = service.prepare_agent_for_message(name="payments-api")
+
+    assert prepared.ok is True
+    assert prepared.data["started"] is False
+    assert prepared.data["refreshed_auth"] is True
+
+
+def test_prepare_agent_for_message_skips_refresh_for_fresh_auth_timestamp(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    runtime.inspect_result = {"State": {"Running": True, "Status": "running"}}
+    service = MasterService(
+        registry=registry,
+        runtime=runtime,
+        agent_codex_auth_json_path="/host/secrets/codex-auth.json",
+        auth_refresh_max_age_days=7,
+    )
+
+    loaded = service.load_agent(name="payments-api", repo_path=str(repo), channel_id="C123")
+    assert loaded.ok is True
+    record = registry.get("payments-api")
+    assert record is not None
+    record.auth_refreshed_at = datetime.now(timezone.utc).isoformat()
+    registry.upsert(record)
+
+    prepared = service.prepare_agent_for_message(name="payments-api")
+
+    assert prepared.ok is True
+    assert prepared.data["started"] is False
+    assert prepared.data["refreshed_auth"] is False
+
+
+def test_prepare_agent_for_message_skips_codex_auth_refresh_for_claude_agent(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    runtime.inspect_result = {"State": {"Running": True, "Status": "running"}}
+    service = MasterService(
+        registry=registry,
+        runtime=runtime,
+        agent_codex_auth_json_path="/host/secrets/codex-auth.json",
+        auth_refresh_max_age_days=7,
+    )
+
+    loaded = service.load_agent(name="payments-api", repo_path=str(repo), channel_id="C123", agent_adapter="claude-code")
+    assert loaded.ok is True
+
+    prepared = service.prepare_agent_for_message(name="payments-api")
+
+    assert prepared.ok is True
+    assert prepared.data["refreshed_auth"] is False
 
 
 def test_load_agent_invalid_name_returns_invalid_args(tmp_path) -> None:

--- a/tests/master/test_master_service.py
+++ b/tests/master/test_master_service.py
@@ -518,6 +518,7 @@ def test_prepare_agent_for_message_starts_stopped_agent_and_refreshes_stale_auth
     assert "inspect_agent" in call_names
     assert "start_agent" in call_names
     assert "refresh_agent_auth" in call_names
+    assert call_names.index("start_agent") < call_names.index("refresh_agent_auth")
 
 
 def test_prepare_agent_for_message_refreshes_missing_auth_timestamp_for_running_codex_agent(tmp_path) -> None:

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -511,7 +511,7 @@ def test_multi_agent_dispatcher_selects_adapter_by_name() -> None:
 
 def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_not_running(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     started: list[str] = []
-    dispatcher = PodmanExecDispatcher(agent_start_callback=started.append)
+    dispatcher = PodmanExecDispatcher(agent_prepare_callback=started.append)
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
@@ -520,11 +520,9 @@ def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_not
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=0,
-                stdout='[{"State":{"Running":false,"Status":"exited"}}]',
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
                 stderr="",
             )
-        if cmd[:2] == ["podman", "start"]:
-            raise AssertionError("direct podman start should not be used when callback is provided")
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
@@ -593,13 +591,16 @@ def test_podman_exec_dispatcher_reports_stopped_container_without_callback(monke
 
 def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     started: list[str] = []
-    dispatcher = PodmanExecDispatcher(agent_start_callback=started.append)
+    dispatcher = PodmanExecDispatcher(agent_prepare_callback=started.append)
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
         if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(args=cmd, returncode=125, stdout="", stderr="no such container")
-        if cmd[:2] == ["podman", "start"]:
-            raise AssertionError("direct podman start should not be used when callback is provided")
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -509,40 +509,6 @@ def test_multi_agent_dispatcher_selects_adapter_by_name() -> None:
     assert len(claude.calls) == 1
 
 
-def test_podman_exec_dispatcher_autostarts_stopped_container(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    dispatcher = PodmanExecDispatcher()
-    seen: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        seen.append(cmd)
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":false,"Status":"exited"}}]',
-                stderr="",
-            )
-        if cmd[:2] == ["podman", "start"]:
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="agent-payments\n", stderr="")
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
-
-    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
-
-    response = dispatcher.send_prompt(
-        agent_name="payments-agent",
-        container_name="agent-payments",
-        prompt="hello",
-        channel_id="CAGENT",
-        thread_ts="1730000000.1234",
-        user_id="U123",
-    )
-
-    assert response == "ok"
-    assert seen[0] == ["podman", "inspect", "--type", "container", "agent-payments"]
-    assert seen[1] == ["podman", "start", "agent-payments"]
-    assert seen[2][0:3] == ["podman", "exec", "-i"]
-
-
 def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_not_running(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     started: list[str] = []
     dispatcher = PodmanExecDispatcher(agent_start_callback=started.append)
@@ -588,7 +554,33 @@ def test_podman_exec_dispatcher_reports_missing_container(monkeypatch) -> None: 
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
 
-    with pytest.raises(RouteError, match=r"agent container is not available: agent-payments"):
+    with pytest.raises(RouteError, match=r"agent container is not running and auto-start is not configured: agent-payments"):
+        dispatcher.send_prompt(
+            agent_name="payments-agent",
+            container_name="agent-payments",
+            prompt="hello",
+            channel_id="CAGENT",
+            thread_ts="1730000000.1234",
+            user_id="U123",
+        )
+
+
+def test_podman_exec_dispatcher_reports_stopped_container_without_callback(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    dispatcher = PodmanExecDispatcher()
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":false,"Status":"exited"}}]',
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    with pytest.raises(RouteError, match=r"agent container is not running and auto-start is not configured: agent-payments"):
         dispatcher.send_prompt(
             agent_name="payments-agent",
             container_name="agent-payments",

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -543,6 +543,41 @@ def test_podman_exec_dispatcher_autostarts_stopped_container(monkeypatch) -> Non
     assert seen[2][0:3] == ["podman", "exec", "-i"]
 
 
+def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_not_running(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    started: list[str] = []
+    dispatcher = PodmanExecDispatcher(agent_start_callback=started.append)
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(cmd)
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":false,"Status":"exited"}}]',
+                stderr="",
+            )
+        if cmd[:2] == ["podman", "start"]:
+            raise AssertionError("direct podman start should not be used when callback is provided")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    response = dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        channel_id="CAGENT",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+    )
+
+    assert response == "ok"
+    assert started == ["payments-agent"]
+    assert seen[0] == ["podman", "inspect", "--type", "container", "agent-payments"]
+    assert seen[1][0:3] == ["podman", "exec", "-i"]
+
+
 def test_podman_exec_dispatcher_reports_missing_container(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     dispatcher = PodmanExecDispatcher()
 
@@ -562,6 +597,32 @@ def test_podman_exec_dispatcher_reports_missing_container(monkeypatch) -> None: 
             thread_ts="1730000000.1234",
             user_id="U123",
         )
+
+
+def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    started: list[str] = []
+    dispatcher = PodmanExecDispatcher(agent_start_callback=started.append)
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(args=cmd, returncode=125, stdout="", stderr="no such container")
+        if cmd[:2] == ["podman", "start"]:
+            raise AssertionError("direct podman start should not be used when callback is provided")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    response = dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        channel_id="CAGENT",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+    )
+
+    assert response == "ok"
+    assert started == ["payments-agent"]
 
 
 def test_claude_dispatcher_creates_session_and_injects_permission_bypass(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -326,6 +326,13 @@ def test_podman_exec_dispatcher_includes_exit_and_output_details(monkeypatch) ->
     dispatcher = PodmanExecDispatcher()
 
     def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        if args[0][:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=args[0],
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         return subprocess.CompletedProcess(
             args=args[0],
             returncode=17,
@@ -350,6 +357,13 @@ def test_podman_exec_dispatcher_reports_timeout(monkeypatch) -> None:  # type: i
     dispatcher = PodmanExecDispatcher(timeout_seconds=12)
 
     def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        if args[0][:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=args[0],
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=12)
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
@@ -389,6 +403,13 @@ def test_podman_exec_dispatcher_runs_in_repo_workdir(monkeypatch) -> None:  # ty
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -413,6 +434,13 @@ def test_podman_exec_dispatcher_injects_session_resume_for_legacy_template(monke
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -438,6 +466,13 @@ def test_podman_exec_dispatcher_does_not_inject_resume_for_last_template(monkeyp
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -474,11 +509,73 @@ def test_multi_agent_dispatcher_selects_adapter_by_name() -> None:
     assert len(claude.calls) == 1
 
 
+def test_podman_exec_dispatcher_autostarts_stopped_container(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    dispatcher = PodmanExecDispatcher()
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(cmd)
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":false,"Status":"exited"}}]',
+                stderr="",
+            )
+        if cmd[:2] == ["podman", "start"]:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="agent-payments\n", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    response = dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        channel_id="CAGENT",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+    )
+
+    assert response == "ok"
+    assert seen[0] == ["podman", "inspect", "--type", "container", "agent-payments"]
+    assert seen[1] == ["podman", "start", "agent-payments"]
+    assert seen[2][0:3] == ["podman", "exec", "-i"]
+
+
+def test_podman_exec_dispatcher_reports_missing_container(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    dispatcher = PodmanExecDispatcher()
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(args=cmd, returncode=125, stdout="", stderr="no such container")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    with pytest.raises(RouteError, match=r"agent container is not available: agent-payments"):
+        dispatcher.send_prompt(
+            agent_name="payments-agent",
+            container_name="agent-payments",
+            prompt="hello",
+            channel_id="CAGENT",
+            thread_ts="1730000000.1234",
+            user_id="U123",
+        )
+
+
 def test_claude_dispatcher_creates_session_and_injects_permission_bypass(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     dispatcher = ClaudeCodeDispatcher(command_template="claude -p")
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -506,6 +603,13 @@ def test_claude_dispatcher_resumes_with_same_session_for_same_channel(monkeypatc
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen.append(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -541,6 +645,13 @@ def test_claude_dispatcher_uses_distinct_sessions_for_distinct_channels(monkeypa
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen.append(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -575,6 +686,13 @@ def test_claude_dispatcher_retries_with_create_when_session_missing(monkeypatch)
     calls = {"count": 0}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen.append(cmd)
         calls["count"] += 1
         if calls["count"] == 2:
@@ -619,6 +737,13 @@ def test_podman_exec_dispatcher_injects_claude_permission_bypass(monkeypatch) ->
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -641,6 +766,13 @@ def test_podman_exec_dispatcher_preserves_existing_claude_permission_bypass(monk
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 


### PR DESCRIPTION
## Summary
When a user messages an agent, master now checks whether the target container is already running. If it is, routing proceeds normally. If it is missing or stopped, master runs the same startup flow as  before dispatching the prompt.

## Changes
- add dispatcher container preflight before prompt execution
- wire a master auto-start callback from 
- use the callback for both Codex and Claude dispatchers
- remove the direct  fallback so message routing and  stay aligned
- add router tests for running, stopped, missing, and callback-driven startup cases

## Behavior
- running container: prompt is delivered immediately
- stopped or missing container: same startup flow as 
- no auto-start callback configured: explicit routing error instead of a partial fallback path

## Test Evidence
- ..............................                                           [100%]
30 passed in 0.16s

## Notes
This keeps startup semantics centralized in  instead of duplicating container boot logic inside the router.
