### PR TITLE
feat: add claude subagent override command

### DIFF
--- a/docs/design/frontend-master-interface-design.md
+++ b/docs/design/frontend-master-interface-design.md
@@ -179,6 +179,7 @@ The frontend-to-master command contract includes:
 - `/master-agent-refresh-auth`
 - `/master-agent-refresh-config`
 - `/master-agent-set-model`
+- `/master-agent-set-subagent`
 
 Frontend adapters must:
 

--- a/docs/design/master-agent-interface-design.md
+++ b/docs/design/master-agent-interface-design.md
@@ -61,6 +61,7 @@ Master controls agent containers through these operations:
 - refresh-auth
 - refresh-config
 - set-model
+- set-subagent
 
 ### Load
 
@@ -231,6 +232,7 @@ The manifest is the canonical descriptor for:
 - auth comes from env, not a copied auth file
 - shared Claude config refresh writes to `/workspace/home/.claude/`
 - optional model override may be injected per agent
+- optional subagent override may be injected per agent as `--agent <subagent>`
 
 ## Observability Contract
 

--- a/docs/guides/discord-setup.md
+++ b/docs/guides/discord-setup.md
@@ -199,7 +199,9 @@ Discord exposes command parity with Slack:
 - `/master-agent-usage`
 - `/master-agent-remove`
 - `/master-agent-refresh-auth`
+- `/master-agent-refresh-config`
 - `/master-agent-set-model`
+- `/master-agent-set-subagent`
 
 `/master-agent-load` supports:
 - `name`

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -170,6 +170,15 @@ Omit the model argument to clear the override:
 ```text
 /master-agent-set-model <name>
 ```
+8. Override the Claude Code subagent for a specific agent (persisted in registry, no restart needed):
+```text
+/master-agent-set-subagent <name> code-reviewer
+```
+Omit the subagent argument to clear the override:
+```text
+/master-agent-set-subagent <name>
+```
+When set, master injects `--agent <subagent>` into the Claude Code CLI command before dispatch.
 
 ## Routing Validation
 1. In mapped non-admin channel, mention bot with prompt.

--- a/docs/guides/slack-setup.md
+++ b/docs/guides/slack-setup.md
@@ -58,7 +58,9 @@ Create these commands in **Slash Commands**:
 - `/master-agent-usage`
 - `/master-agent-remove`
 - `/master-agent-refresh-auth`
+- `/master-agent-refresh-config`
 - `/master-agent-set-model`
+- `/master-agent-set-subagent`
 
 For each command:
 1. Click **Create New Command**.
@@ -146,8 +148,13 @@ python -m src.master.main
 /master-agent-set-model <name> claude-opus-4-5
 ```
 Omit the model to clear the override and revert to the default.
-8. In the mapped agent channel, mention the bot with a prompt.
-9. Reply in the same thread without mentioning the bot again.
+8. To override the Claude Code subagent for a specific agent:
+```text
+/master-agent-set-subagent <name> code-reviewer
+```
+Omit the subagent to clear the override.
+9. In the mapped agent channel, mention the bot with a prompt.
+10. Reply in the same thread without mentioning the bot again.
 10. Confirm master routes both messages to the mapped agent.
 
 ## 11. Channel Usage Rules

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -24,6 +24,7 @@ Implemented command set:
 - `/master-agent-refresh-auth <name>`
 - `/master-agent-refresh-config <name>`
 - `/master-agent-set-model <name> [model]`
+- `/master-agent-set-subagent <name> [subagent]`
 
 ## Interaction Contracts
 

--- a/docs/test-plans/master-agent-uat.md
+++ b/docs/test-plans/master-agent-uat.md
@@ -440,6 +440,28 @@ Expected:
 - Registry record includes an updated `auth_refreshed_at` timestamp.
 - Existing Codex session state in the agent workspace is preserved.
 
+## UAT-005D: Claude Subagent Override
+Preconditions:
+- Agent is loaded with `--adapter claude-code`.
+
+Steps:
+1. In `CADMIN`, run:
+```text
+/master-agent-set-subagent payments-agent code-reviewer
+```
+2. Send a routed prompt to the mapped agent channel.
+3. Inspect master dispatch logs or the full status payload.
+4. Clear the override:
+```text
+/master-agent-set-subagent payments-agent
+```
+
+Expected:
+- Set command returns `ok=true`.
+- Registry record includes `claude_subagent=code-reviewer`.
+- Claude Code dispatch includes `--agent code-reviewer`.
+- Clear command removes the registry value.
+
 ## UAT-006: Admin Channel Enforcement
 Preconditions:
 - Master running.

--- a/src/master/command_dispatch.py
+++ b/src/master/command_dispatch.py
@@ -195,6 +195,15 @@ def parse_set_model_text(text: str, command_name: str = "/master-agent-set-model
     return parts[0], parts[1] or None
 
 
+def parse_set_subagent_text(text: str, command_name: str = "/master-agent-set-subagent") -> tuple[str, str | None]:
+    parts = [part.strip() for part in text.split(maxsplit=1) if part.strip()]
+    if not parts:
+        raise ValueError(f"usage: {command_name} <name> [subagent]")
+    if len(parts) == 1:
+        return parts[0], None
+    return parts[0], parts[1] or None
+
+
 def dispatch_command(
     service: MasterService,
     request: MasterCommandRequest,
@@ -274,5 +283,9 @@ def dispatch_command(
     if request.command_name == "/master-agent-set-model":
         name, model = parse_set_model_text(request.text, request.command_name)
         return service.set_agent_model(name=name, model=model)
+
+    if request.command_name == "/master-agent-set-subagent":
+        name, subagent = parse_set_subagent_text(request.text, request.command_name)
+        return service.set_agent_subagent(name=name, subagent=subagent)
 
     return CommandResult(ok=False, code="ERR_INVALID_ARGS", message=f"unsupported command: {request.command_name}", data={})

--- a/src/master/command_format.py
+++ b/src/master/command_format.py
@@ -30,6 +30,7 @@ def _format_agent_list_table(result: CommandResult) -> str | None:
                 f"• *{_clip(item.get('name', '-'), 24)}*"
                 f" | state=`{_clip(item.get('status', '-'), 12)}`"
                 f" | adapter=`{_clip(item.get('agent_adapter', '-'), 14)}`"
+                f" | subagent=`{_clip(item.get('claude_subagent') or '-', 18)}`"
                 f" | channel=`{_clip(item.get('channel_id', '-'), 14)}`"
                 f" | ref=`{_clip(item.get('repo_ref', '-'), 12)}`"
                 f" | runtime=`{_clip(item.get('runtime', '-'), 10)}`"
@@ -132,6 +133,7 @@ def _format_status_summary(result: CommandResult) -> str | None:
             f"*State:* registry=`{record.get('status', '-')}` runtime=`{runtime_state}`",
             f"*Channel:* `{record.get('channel_id', '-')}`",
             f"*Branch:* `{record.get('repo_ref', '-')}`",
+            f"*Claude subagent:* `{record.get('claude_subagent') or '-'}`",
             f"*Container:* `{record.get('container_name', '-')}`",
             f"*Image:* `{record.get('resolved_image') or '-'}`",
             f"*Last error:* `{record.get('last_error') or '-'}`",

--- a/src/master/discord_app.py
+++ b/src/master/discord_app.py
@@ -623,4 +623,9 @@ def run_discord_frontend(
         text = name if not model else f"{name} {model}"
         await _execute_and_send(interaction, command_name="/master-agent-set-model", text=text)
 
+    @tree.command(name="master-agent-set-subagent", description="Set or clear an agent Claude subagent override")
+    async def cmd_set_subagent(interaction, name: str, subagent: str | None = None) -> None:  # type: ignore[no-untyped-def]
+        text = name if not subagent else f"{name} {subagent}"
+        await _execute_and_send(interaction, command_name="/master-agent-set-subagent", text=text)
+
     client.run(bot_token)

--- a/src/master/registry.py
+++ b/src/master/registry.py
@@ -30,6 +30,7 @@ class AgentRecord:
     resolved_image: str | None = None
     last_error: str | None = None
     claude_model: str | None = None
+    claude_subagent: str | None = None
     auth_refreshed_at: str | None = None
     created_at: str = ""
     updated_at: str = ""
@@ -78,6 +79,7 @@ class AgentRegistry:
         normalized = dict(item)
         normalized.setdefault("platform", "slack")
         normalized.setdefault("agent_adapter", "codex")
+        normalized.setdefault("claude_subagent", None)
         normalized.setdefault("auth_refreshed_at", None)
         return normalized
 

--- a/src/master/router.py
+++ b/src/master/router.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 import re
+import shlex
 import subprocess
 import tempfile
 from threading import Lock
@@ -22,7 +23,12 @@ MENTION_PATTERN = re.compile(r"<@[^>]+>")
 
 def _inject_claude_model(command: str, model: str) -> str:
     """Insert --model <model> right after 'claude' in the command string."""
-    return re.sub(r"\bclaude\b", f"claude --model {model}", command, count=1)
+    return re.sub(r"\bclaude\b", f"claude --model {shlex.quote(model)}", command, count=1)
+
+
+def _inject_claude_subagent(command: str, subagent: str) -> str:
+    """Insert --agent <subagent> right after 'claude' in the command string."""
+    return re.sub(r"\bclaude\b", f"claude --agent {shlex.quote(subagent)}", command, count=1)
 
 
 class RouteError(RuntimeError):
@@ -47,6 +53,7 @@ class AgentDispatcher(Protocol):
         user_id: str | None,
         image_urls: list[str] | None = None,
         claude_model: str | None = None,
+        claude_subagent: str | None = None,
     ) -> str:
         ...
 
@@ -158,6 +165,7 @@ class PodmanExecDispatcher:
         user_id: str | None,
         image_urls: list[str] | None = None,
         claude_model: str | None = None,
+        claude_subagent: str | None = None,
     ) -> str:
         rendered_command, session_id = self._render_command(channel_id=channel_id, thread_ts=thread_ts)
         if claude_model:
@@ -370,6 +378,7 @@ class MultiAgentDispatcher:
         user_id: str | None,
         image_urls: list[str] | None = None,
         claude_model: str | None = None,
+        claude_subagent: str | None = None,
     ) -> str:
         selected = (agent_adapter or self.default_adapter).strip().lower()
         dispatcher = self.dispatchers.get(selected) or self.dispatchers.get(self.default_adapter)
@@ -386,6 +395,7 @@ class MultiAgentDispatcher:
             user_id=user_id,
             image_urls=image_urls,
             claude_model=claude_model,
+            claude_subagent=claude_subagent,
         )
 
 
@@ -553,6 +563,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
         user_id: str | None,
         image_urls: list[str] | None = None,
         claude_model: str | None = None,
+        claude_subagent: str | None = None,
     ) -> str:
         LOGGER.info("router.claude_command_template template=%r", self.command_template)
         image_urls = image_urls or []
@@ -591,6 +602,8 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
         rendered_command = self._render_command(action=initial_action, session_id=effective_session_id)
         if claude_model:
             rendered_command = _inject_claude_model(rendered_command, claude_model)
+        if claude_subagent:
+            rendered_command = _inject_claude_subagent(rendered_command, claude_subagent)
         try:
             completed = self._execute_prompt(
                 rendered_command=rendered_command,
@@ -653,6 +666,8 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
                 rendered_command = self._render_command(action=retry_action, session_id=effective_session_id)
                 if claude_model:
                     rendered_command = _inject_claude_model(rendered_command, claude_model)
+                if claude_subagent:
+                    rendered_command = _inject_claude_subagent(rendered_command, claude_subagent)
                 try:
                     completed = self._execute_prompt(
                         rendered_command=rendered_command,
@@ -812,6 +827,7 @@ class ChannelRouter:
             user_id=user_id,
             image_urls=image_urls,
             claude_model=record.claude_model,
+            claude_subagent=record.claude_subagent,
         )
         elapsed_ms = (time.perf_counter() - started_at) * 1000
         self._record_usage(

--- a/src/master/service.py
+++ b/src/master/service.py
@@ -466,6 +466,24 @@ class MasterService:
         self._audit(command="set-model", agent=name, result=result)
         return result
 
+    def set_agent_subagent(self, *, name: str, subagent: str | None) -> CommandResult:
+        record = self._registry.get(name)
+        if not record:
+            result = CommandResult(ok=False, code="ERR_AGENT_NOT_FOUND", message=f"unknown agent: {name}", data={})
+            self._audit(command="set-subagent", agent=name, result=result)
+            return result
+
+        record.claude_subagent = subagent
+        self._registry.upsert(record)
+        result = CommandResult(
+            ok=True,
+            code="OK",
+            message=f"subagent set to {subagent!r} for {name}" if subagent else f"subagent cleared for {name}",
+            data={"name": name, "claude_subagent": subagent},
+        )
+        self._audit(command="set-subagent", agent=name, result=result)
+        return result
+
     def _validate_load_inputs(self, *, name: str, channel_id: str, platform: str) -> CommandResult | None:
         if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,30}", name):
             return CommandResult(

--- a/src/master/slack_app.py
+++ b/src/master/slack_app.py
@@ -342,6 +342,7 @@ def create_master_app(
         "/master-agent-refresh-auth",
         "/master-agent-refresh-config",
         "/master-agent-set-model",
+        "/master-agent-set-subagent",
     ):
         _register_command(
             app,

--- a/tests/master/test_master_service.py
+++ b/tests/master/test_master_service.py
@@ -488,6 +488,51 @@ def test_refresh_agent_auth_propagates_runtime_failure(tmp_path) -> None:
     assert refreshed.code == "ERR_RUNTIME_FAILED"
 
 
+def test_set_agent_subagent_persists_registry_value(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    service = MasterService(registry=registry, runtime=runtime)
+
+    loaded = service.load_agent(
+        name="payments-api",
+        repo_path=str(repo),
+        channel_id="C123",
+        agent_adapter="claude-code",
+    )
+    assert loaded.ok is True
+
+    result = service.set_agent_subagent(name="payments-api", subagent="code-reviewer")
+
+    assert result.ok is True
+    assert result.data["claude_subagent"] == "code-reviewer"
+    saved = registry.get("payments-api")
+    assert saved is not None
+    assert saved.claude_subagent == "code-reviewer"
+
+
+def test_set_agent_subagent_can_clear_registry_value(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = AgentRegistry(tmp_path / "agents.json")
+    runtime = FakeRuntime()
+    service = MasterService(registry=registry, runtime=runtime)
+
+    loaded = service.load_agent(name="payments-api", repo_path=str(repo), channel_id="C123")
+    assert loaded.ok is True
+    service.set_agent_subagent(name="payments-api", subagent="code-reviewer")
+
+    result = service.set_agent_subagent(name="payments-api", subagent=None)
+
+    assert result.ok is True
+    saved = registry.get("payments-api")
+    assert saved is not None
+    assert saved.claude_subagent is None
+
+
 def test_prepare_agent_for_message_starts_stopped_agent_and_refreshes_stale_auth(tmp_path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -32,6 +32,7 @@ class FakeDispatcher:
         user_id: str | None,
         image_urls: list[str] | None = None,
         claude_model: str | None = None,
+        claude_subagent: str | None = None,
     ) -> str:
         self.calls.append(
             {
@@ -45,6 +46,7 @@ class FakeDispatcher:
                 "user_id": user_id,
                 "image_urls": image_urls or [],
                 "claude_model": claude_model,
+                "claude_subagent": claude_subagent,
             }
         )
         return f"{agent_name}:{prompt}"
@@ -123,6 +125,27 @@ def test_route_prompt_uses_recorded_claude_adapter(tmp_path) -> None:
     assert dispatcher.calls[0]["agent_adapter"] == "claude-code"
 
 
+def test_route_prompt_passes_recorded_claude_subagent(tmp_path) -> None:
+    registry = AgentRegistry(tmp_path / "agents.json")
+    _seed_registry(registry)
+    record = registry.get("payments-agent")
+    assert record is not None
+    record.agent_adapter = "claude-code"
+    record.claude_subagent = "code-reviewer"
+    registry.upsert(record)
+    dispatcher = FakeDispatcher()
+    router = ChannelRouter(registry=registry, dispatcher=dispatcher, admin_channels={"CADMIN"})
+
+    router.route_prompt(
+        channel_id="CAGENT",
+        text="<@U123> review this",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+    )
+
+    assert dispatcher.calls[0]["claude_subagent"] == "code-reviewer"
+
+
 def test_route_prompt_allows_image_only_message(tmp_path) -> None:
     registry = AgentRegistry(tmp_path / "agents.json")
     _seed_registry(registry)
@@ -174,6 +197,7 @@ class FailingDispatcher(FakeDispatcher):
         user_id: str | None,
         image_urls: list[str] | None = None,
         claude_model: str | None = None,
+        claude_subagent: str | None = None,
     ) -> str:
         raise RouteError("codex exec failed")
 
@@ -650,6 +674,38 @@ def test_claude_dispatcher_creates_session_and_injects_permission_bypass(monkeyp
     assert " --session-id " not in seen["cmd"][-1]
     assert " --continue" not in seen["cmd"][-1]
     assert " --dangerously-skip-permissions" in seen["cmd"][-1]
+
+
+def test_claude_dispatcher_injects_subagent_flag(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    dispatcher = ClaudeCodeDispatcher(command_template="claude -p")
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='[{"State":{"Running":true,"Status":"running"}}]',
+                stderr="",
+            )
+        seen["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    dispatcher.send_prompt(
+        agent_name="payments-agent",
+        container_name="agent-payments",
+        prompt="hello",
+        platform="slack",
+        channel_id="CAGENT",
+        thread_ts="1730000000.1234",
+        user_id="U123",
+        claude_subagent="code-reviewer",
+    )
+
+    assert " --agent code-reviewer " in f" {seen['cmd'][-1]} "
+    assert " -n " in seen["cmd"][-1]
 
 
 def test_claude_dispatcher_resumes_with_same_session_for_same_channel(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/master/test_slack_app.py
+++ b/tests/master/test_slack_app.py
@@ -6,6 +6,7 @@ from src.master.command_dispatch import (
     dispatch_command as dispatch_slash_command,
     parse_load_text,
     parse_set_model_text,
+    parse_set_subagent_text,
     parse_status_text,
 )
 from src.master.command_format import (
@@ -73,6 +74,14 @@ class FakeMasterService:
     def set_agent_model(self, *, name: str, model: str | None) -> CommandResult:
         return CommandResult(ok=True, code="OK", message="model updated", data={"name": name, "claude_model": model})
 
+    def set_agent_subagent(self, *, name: str, subagent: str | None) -> CommandResult:
+        return CommandResult(
+            ok=True,
+            code="OK",
+            message="subagent updated",
+            data={"name": name, "claude_subagent": subagent},
+        )
+
 
 def test_is_admin_channel() -> None:
     assert is_admin_channel("C1", {"C1", "C2"}) is True
@@ -127,6 +136,16 @@ def test_parse_set_model_text_accepts_optional_model() -> None:
 def test_parse_set_model_text_allows_model_clear() -> None:
     name, model = parse_set_model_text("payments")
     assert (name, model) == ("payments", None)
+
+
+def test_parse_set_subagent_text_accepts_optional_subagent() -> None:
+    name, subagent = parse_set_subagent_text("payments code-reviewer")
+    assert (name, subagent) == ("payments", "code-reviewer")
+
+
+def test_parse_set_subagent_text_allows_subagent_clear() -> None:
+    name, subagent = parse_set_subagent_text("payments")
+    assert (name, subagent) == ("payments", None)
 
 
 def test_dispatch_load_command() -> None:
@@ -227,6 +246,34 @@ def test_dispatch_set_model_command_can_clear_model() -> None:
     result = dispatch_slash_command(service, request)
     assert result.ok is True
     assert result.data["claude_model"] is None
+
+
+def test_dispatch_set_subagent_command_accepts_optional_subagent() -> None:
+    service = FakeMasterService()
+    request = SlackCommandRequest(
+        command_name="/master-agent-set-subagent",
+        text="payments code-reviewer",
+        channel_id="CADMIN",
+        user_id="U1",
+    )
+
+    result = dispatch_slash_command(service, request)
+    assert result.ok is True
+    assert result.data["claude_subagent"] == "code-reviewer"
+
+
+def test_dispatch_set_subagent_command_can_clear_subagent() -> None:
+    service = FakeMasterService()
+    request = SlackCommandRequest(
+        command_name="/master-agent-set-subagent",
+        text="payments",
+        channel_id="CADMIN",
+        user_id="U1",
+    )
+
+    result = dispatch_slash_command(service, request)
+    assert result.ok is True
+    assert result.data["claude_subagent"] is None
 
 
 def test_format_command_result_json_payload() -> None:


### PR DESCRIPTION
## Summary
- Add `/master-agent-set-subagent <name> [subagent]` to store a Claude Code subagent override in the master agent registry.
- Inject the stored override into Claude Code dispatch commands via `--agent <subagent>`.
- Show the configured subagent in agent list/status output and register the command for Slack and Discord.
- Update API/runbook/setup/design/UAT docs and add service, command dispatch, and router tests.

## Test Evidence
- `.venv/bin/pytest -q` -> `232 passed in 1.95s`

## Notes
- Omitting the `subagent` argument clears the override.
- The command follows the existing model override behavior and stores the value on the agent record.
