### PR TITLE
fix: create writable workspace in agent images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN pip install --no-cache-dir podman-compose
 
 RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
 
-RUN useradd -m -u 1000 -s /bin/bash appuser
+RUN useradd -m -u 1000 -s /bin/bash appuser \
+    && mkdir -p /workspace/home \
+    && chown -R appuser:appuser /workspace
 USER appuser
 WORKDIR /opt/codex-slack
 

--- a/Dockerfile.agent-minimal
+++ b/Dockerfile.agent-minimal
@@ -22,7 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
 
-RUN useradd -m -u 1000 -s /bin/bash appuser
+RUN useradd -m -u 1000 -s /bin/bash appuser \
+    && mkdir -p /workspace/home \
+    && chown -R appuser:appuser /workspace
 USER appuser
 WORKDIR /opt/codex-slack
 


### PR DESCRIPTION
## Summary
- Create `/workspace/home` during both full and minimal image builds before switching to `appuser`.
- Chown `/workspace` to `appuser` so `docker/entrypoint.sh` can initialize the default `CODEX_HOME=/workspace/home/.codex` without a mounted workspace volume.

## Why
The `Publish Minimal Agent Image` workflow failed in run https://github.com/pandazxx/codex-slack/actions/runs/25240010307 because the smoke test runs the minimal image without a `/workspace` mount. The entrypoint runs as `appuser` and failed with:

```text
mkdir: cannot create directory ‘/workspace’: Permission denied
```

## Test Evidence
- `.venv/bin/pytest -q` -> `221 passed in 1.78s`

## Not Run
- Container smoke test was not run locally because this environment has neither `docker` nor `podman` installed.
