### PR TITLE
fix: wait for agent repo workdir before dispatch

### DIFF
--- a/src/master/router.py
+++ b/src/master/router.py
@@ -123,6 +123,7 @@ class PodmanExecDispatcher:
     codex_home: str = "/workspace/home/.codex"
     slack_bot_token: str | None = None
     agent_prepare_callback: Callable[[str], None] | None = None
+    workdir_ready_timeout_seconds: float = 60.0
 
     @staticmethod
     def _clip(value: str, limit: int = 240) -> str:
@@ -209,6 +210,55 @@ class PodmanExecDispatcher:
         except Exception as exc:  # noqa: BLE001
             raise RouteError(f"failed to prepare {agent_name}: {exc}") from exc
 
+    def _ensure_workdir_ready(self, *, agent_name: str, container_name: str) -> None:
+        if not self.workdir:
+            return
+
+        deadline = time.monotonic() + max(self.workdir_ready_timeout_seconds, 0)
+        attempt = 0
+        last_stderr = ""
+        quoted_workdir = shlex.quote(self.workdir)
+        while True:
+            attempt += 1
+            try:
+                completed = subprocess.run(
+                    ["podman", "exec", container_name, "sh", "-lc", f"test -d {quoted_workdir}"],
+                    text=True,
+                    capture_output=True,
+                    timeout=self.timeout_seconds,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise RouteError(f"timed out while waiting for agent workdir {self.workdir}") from exc
+            except FileNotFoundError as exc:
+                raise RouteError("podman CLI is not available in the master runtime") from exc
+
+            if completed.returncode == 0:
+                if attempt > 1:
+                    LOGGER.info(
+                        "router.workdir_ready agent=%s container=%s workdir=%s attempts=%d",
+                        agent_name,
+                        container_name,
+                        self.workdir,
+                        attempt,
+                    )
+                return
+
+            last_stderr = self._clip(completed.stderr)
+            if time.monotonic() >= deadline:
+                LOGGER.warning(
+                    "router.workdir_not_ready agent=%s container=%s workdir=%s attempts=%d stderr=%r",
+                    agent_name,
+                    container_name,
+                    self.workdir,
+                    attempt,
+                    last_stderr,
+                )
+                details = f" ({last_stderr})" if last_stderr else ""
+                raise RouteError(f"agent workdir is not ready: {self.workdir}{details}")
+
+            time.sleep(0.5)
+
     def send_prompt(
         self,
         *,
@@ -230,6 +280,7 @@ class PodmanExecDispatcher:
         image_urls = image_urls or []
         self._prepare_agent_for_dispatch(agent_name=agent_name)
         self._ensure_container_running(agent_name=agent_name, container_name=container_name)
+        self._ensure_workdir_ready(agent_name=agent_name, container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
             session_id=session_id,
@@ -654,6 +705,7 @@ class ClaudeCodeDispatcher(PodmanExecDispatcher):
         image_urls = image_urls or []
         self._prepare_agent_for_dispatch(agent_name=agent_name)
         self._ensure_container_running(agent_name=agent_name, container_name=container_name)
+        self._ensure_workdir_ready(agent_name=agent_name, container_name=container_name)
         staged_paths, passthrough_urls = self._stage_attachments(
             container_name=container_name,
             session_id=channel_id,

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -67,6 +67,27 @@ def _seed_registry(registry: AgentRegistry) -> None:
     )
 
 
+def _is_podman_inspect(cmd: list[str]) -> bool:
+    return cmd[:4] == ["podman", "inspect", "--type", "container"]
+
+
+def _is_workdir_probe(cmd: list[str]) -> bool:
+    return cmd[:3] == ["podman", "exec", "agent-payments"] and cmd[-1].startswith("test -d ")
+
+
+def _running_container_result(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=cmd,
+        returncode=0,
+        stdout='[{"State":{"Running":true,"Status":"running"}}]',
+        stderr="",
+    )
+
+
+def _ready_workdir_result(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+
 def test_route_prompt_for_mapped_channel(tmp_path) -> None:
     registry = AgentRegistry(tmp_path / "agents.json")
     _seed_registry(registry)
@@ -443,13 +464,10 @@ def test_podman_exec_dispatcher_includes_exit_and_output_details(monkeypatch) ->
     dispatcher = PodmanExecDispatcher()
 
     def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
-        if args[0][:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=args[0],
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(args[0]):
+            return _running_container_result(args[0])
+        if _is_workdir_probe(args[0]):
+            return _ready_workdir_result(args[0])
         return subprocess.CompletedProcess(
             args=args[0],
             returncode=17,
@@ -474,13 +492,10 @@ def test_podman_exec_dispatcher_reports_timeout(monkeypatch) -> None:  # type: i
     dispatcher = PodmanExecDispatcher(timeout_seconds=12)
 
     def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
-        if args[0][:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=args[0],
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(args[0]):
+            return _running_container_result(args[0])
+        if _is_workdir_probe(args[0]):
+            return _ready_workdir_result(args[0])
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=12)
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
@@ -520,13 +535,10 @@ def test_podman_exec_dispatcher_runs_in_repo_workdir(monkeypatch) -> None:  # ty
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -546,18 +558,38 @@ def test_podman_exec_dispatcher_runs_in_repo_workdir(monkeypatch) -> None:  # ty
     assert seen["cmd"][-1] == "codex exec --dangerously-bypass-approvals-and-sandbox resume --last -"
 
 
+def test_podman_exec_dispatcher_waits_for_repo_workdir_before_dispatch(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    dispatcher = PodmanExecDispatcher(workdir_ready_timeout_seconds=0)
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="missing repo")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
+
+    with pytest.raises(RouteError, match=r"agent workdir is not ready: /workspace/repo"):
+        dispatcher.send_prompt(
+            agent_name="payments-agent",
+            container_name="agent-payments",
+            prompt="hello",
+            channel_id="CAGENT",
+            thread_ts="1730000000.1234",
+            user_id="U123",
+        )
+
+
 def test_podman_exec_dispatcher_injects_session_resume_for_legacy_template(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     dispatcher = PodmanExecDispatcher(command_template="codex exec --dangerously-bypass-approvals-and-sandbox -")
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -583,13 +615,10 @@ def test_podman_exec_dispatcher_does_not_inject_resume_for_last_template(monkeyp
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -632,14 +661,12 @@ def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_not
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if _is_podman_inspect(cmd):
+            seen.append(cmd)
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen.append(cmd)
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
@@ -663,7 +690,7 @@ def test_podman_exec_dispatcher_reports_missing_container(monkeypatch) -> None: 
     dispatcher = PodmanExecDispatcher()
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+        if _is_podman_inspect(cmd):
             return subprocess.CompletedProcess(args=cmd, returncode=125, stdout="", stderr="no such container")
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -684,7 +711,7 @@ def test_podman_exec_dispatcher_reports_stopped_container_without_callback(monke
     dispatcher = PodmanExecDispatcher()
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+        if _is_podman_inspect(cmd):
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=0,
@@ -711,13 +738,10 @@ def test_podman_exec_dispatcher_uses_master_start_callback_when_container_is_mis
     dispatcher = PodmanExecDispatcher(agent_prepare_callback=started.append)
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)
@@ -740,13 +764,10 @@ def test_claude_dispatcher_creates_session_and_injects_permission_bypass(monkeyp
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -806,13 +827,10 @@ def test_claude_dispatcher_resumes_with_same_session_for_same_channel(monkeypatc
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen.append(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -848,13 +866,10 @@ def test_claude_dispatcher_uses_distinct_sessions_for_distinct_channels(monkeypa
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen.append(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -889,13 +904,10 @@ def test_claude_dispatcher_retries_with_create_when_session_missing(monkeypatch)
     calls = {"count": 0}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen.append(cmd)
         calls["count"] += 1
         if calls["count"] == 2:
@@ -940,13 +952,10 @@ def test_podman_exec_dispatcher_injects_claude_permission_bypass(monkeypatch) ->
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -969,13 +978,10 @@ def test_podman_exec_dispatcher_preserves_existing_claude_permission_bypass(monk
     seen: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=0,
-                stdout='[{"State":{"Running":true,"Status":"running"}}]',
-                stderr="",
-            )
+        if _is_podman_inspect(cmd):
+            return _running_container_result(cmd)
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen["cmd"] = cmd
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 

--- a/tests/master/test_router.py
+++ b/tests/master/test_router.py
@@ -374,13 +374,15 @@ def test_claude_dispatcher_persists_created_session_across_restarts(tmp_path, mo
     seen: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+        if _is_podman_inspect(cmd):
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=0,
                 stdout=json.dumps([{"State": {"Running": True, "Status": "running"}}]),
                 stderr="",
             )
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         seen.append(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
@@ -430,13 +432,15 @@ def test_claude_dispatcher_session_persistence_preserves_tracked_threads(tmp_pat
     dispatcher = ClaudeCodeDispatcher(command_template="claude -p", state_path=str(state_path))
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        if cmd[:4] == ["podman", "inspect", "--type", "container"]:
+        if _is_podman_inspect(cmd):
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=0,
                 stdout=json.dumps([{"State": {"Running": True, "Status": "running"}}]),
                 stderr="",
             )
+        if _is_workdir_probe(cmd):
+            return _ready_workdir_result(cmd)
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
 
     monkeypatch.setattr("src.master.router.subprocess.run", fake_run)


### PR DESCRIPTION
## Summary
- Wait for the agent container workdir (`/workspace/repo`) to exist before dispatching prompts with `podman exec --workdir`.
- Fail with a clear `agent workdir is not ready` error if the worker never finishes preparing the repo.
- Add router regression coverage for the missing-workdir startup race.

## Why
A Discord Claude Code dispatch failed immediately after startup with:

```text
crun: chdir to `/workspace/repo`: No such file or directory
```

The container was running, but the agent worker had not finished cloning/preparing the repo yet. The router now gates dispatch on the repo workdir readiness instead of sending the prompt too early.

## Test Evidence
- `.venv/bin/pytest -q tests/master/test_router.py` -> `35 passed in 0.16s`
- `.venv/bin/pytest -q` -> `232 passed in 1.96s`
