### PR TITLE
feat(v3/slice-2): SQLite schema init, /schema endpoint, and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN useradd -m -u 1000 -s /bin/bash appuser \
 USER appuser
 WORKDIR /opt/codex-slack
 
+RUN mkdir -p data/master
+
 COPY --chown=appuser:appuser requirements.txt ./requirements.txt
 RUN python -m pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - "${MASTER_PORT:-8080}:8080"
     volumes:
-      - ${MASTER_DATA_DIR:-./data/master}:/opt/codex-slack/data/master
+      - master_data:/opt/codex-slack/data/master
       - ${MASTER_SSH_AUTH_SOCK_PATH:-/dev/null}:/run/ssh-agent.sock
       - ${CONTAINER_SOCKET_PATH:-/var/run/docker.sock}:/run/container.sock
     depends_on:
@@ -52,3 +52,6 @@ services:
 networks:
   internal:
     driver: bridge
+
+volumes:
+  master_data:

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS workspaces (
+    id             TEXT PRIMARY KEY,
+    name           TEXT NOT NULL,
+    repo_url       TEXT NOT NULL,
+    container_name TEXT,
+    created_at     TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspace_agents (
+    id           TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    agent_name   TEXT NOT NULL,
+    adapter      TEXT NOT NULL,
+    subagent     TEXT,
+    active       INTEGER NOT NULL DEFAULT 1,
+    created_at   TEXT NOT NULL,
+    deleted_at   TEXT,
+    UNIQUE (workspace_id, agent_name)
+);
+
+CREATE TABLE IF NOT EXISTS topics (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
+    subject       TEXT NOT NULL,
+    branch_name   TEXT NOT NULL,
+    worktree_path TEXT NOT NULL,
+    created_at    TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id             TEXT PRIMARY KEY,
+    topic_id       TEXT NOT NULL REFERENCES topics(id),
+    agent_name     TEXT NOT NULL,
+    adapter        TEXT NOT NULL,
+    llm_session_id TEXT,
+    updated_at     TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id               TEXT PRIMARY KEY,
+    topic_id         TEXT NOT NULL REFERENCES topics(id),
+    sender           TEXT NOT NULL,
+    agent_name       TEXT,
+    text             TEXT NOT NULL,
+    transcript       TEXT,
+    attachments_json TEXT,
+    created_at       TEXT NOT NULL
+);
+"""
+
+TABLES = ["workspaces", "workspace_agents", "topics", "sessions", "messages"]
+
+
+def init_db(db_path: str) -> None:
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_connection(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def schema_info(db_path: str) -> dict[str, list[str]]:
+    conn = get_connection(db_path)
+    try:
+        result: dict[str, list[str]] = {}
+        for table in TABLES:
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+            result[table] = [row["name"] for row in rows]
+        return result
+    finally:
+        conn.close()

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
 from ..logging_utils import LocalTimeFormatter
 from .config import load_master_settings
+from .db import init_db, schema_info
+
+LOGGER = logging.getLogger(__name__)
 
 
 def configure_logging() -> None:
@@ -16,12 +20,16 @@ def configure_logging() -> None:
     logging.basicConfig(level=logging.INFO, handlers=[handler])
 
 
+def _db_path(data_dir: str) -> str:
+    return str(Path(data_dir) / "master_data.db")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):  # type: ignore[type-arg]
     load_dotenv()
     configure_logging()
     settings = load_master_settings()
-    logging.getLogger(__name__).info(
+    LOGGER.info(
         "master.startup mqtt=%s:%s data_dir=%s dry_run=%s base_image=%s runtime=%s",
         settings.mqtt_host,
         settings.mqtt_port,
@@ -30,8 +38,13 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
         settings.agent_base_image,
         settings.container_runtime,
     )
+    db_path = _db_path(settings.data_dir)
+    init_db(db_path)
+    LOGGER.info("master.db_init path=%s", db_path)
+    app.state.settings = settings
+    app.state.db_path = db_path
     yield
-    logging.getLogger(__name__).info("master.shutdown")
+    LOGGER.info("master.shutdown")
 
 
 app = FastAPI(lifespan=lifespan)
@@ -40,3 +53,8 @@ app = FastAPI(lifespan=lifespan)
 @app.get("/health")
 async def health() -> dict:  # type: ignore[type-arg]
     return {"status": "ok"}
+
+
+@app.get("/schema")
+async def schema() -> dict:  # type: ignore[type-arg]
+    return schema_info(app.state.db_path)

--- a/tests/master/test_db.py
+++ b/tests/master/test_db.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from src.master.db import TABLES, get_connection, init_db, schema_info
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    path = str(tmp_path / "test.db")
+    init_db(path)
+    return path
+
+
+def test_init_db_creates_file(tmp_path):
+    path = str(tmp_path / "sub" / "master_data.db")
+    init_db(path)
+    import os
+    assert os.path.exists(path)
+
+
+def test_init_db_creates_all_tables(db_path):
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    conn.close()
+    names = {r[0] for r in rows}
+    assert set(TABLES) <= names
+
+
+def test_init_db_is_idempotent(db_path):
+    init_db(db_path)
+    init_db(db_path)
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    conn.close()
+    assert len([r for r in rows if r[0] in TABLES]) == len(TABLES)
+
+
+def test_schema_info_returns_columns(db_path):
+    info = schema_info(db_path)
+    assert set(info.keys()) == set(TABLES)
+    assert "id" in info["workspaces"]
+    assert "repo_url" in info["workspaces"]
+    assert "active" in info["workspace_agents"]
+    assert "deleted_at" in info["workspace_agents"]
+    assert "worktree_path" in info["topics"]
+    assert "llm_session_id" in info["sessions"]
+    assert "transcript" in info["messages"]
+
+
+def test_get_connection_enables_foreign_keys(db_path):
+    conn = get_connection(db_path)
+    row = conn.execute("PRAGMA foreign_keys").fetchone()
+    conn.close()
+    assert row[0] == 1
+
+
+def test_workspace_agents_unique_constraint(db_path):
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO workspaces VALUES (?, ?, ?, ?, ?)",
+        ("w1", "test", "https://github.com/x/y", None, "2026-01-01T00:00:00Z"),
+    )
+    conn.execute(
+        "INSERT INTO workspace_agents VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("a1", "w1", "claude", "claude-code", None, 1, "2026-01-01T00:00:00Z", None),
+    )
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO workspace_agents VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("a2", "w1", "claude", "codex", None, 1, "2026-01-01T00:00:00Z", None),
+        )
+        conn.commit()
+    conn.close()

--- a/tests/master/test_main.py
+++ b/tests/master/test_main.py
@@ -1,18 +1,53 @@
 from __future__ import annotations
 
-from src.master.main import mask_token
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.master.main import app, _db_path
 
 
-def test_mask_token_returns_dash_for_empty() -> None:
-    assert mask_token("") == "-"
-    assert mask_token("   ") == "-"
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    with TestClient(app) as c:
+        yield c
 
 
-def test_mask_token_masks_short_tokens_fully() -> None:
-    assert mask_token("abcd") == "****"
-    assert mask_token("12345678") == "********"
+def test_health(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
 
 
-def test_mask_token_keeps_prefix_and_suffix_for_long_tokens() -> None:
-    assert mask_token("xoxb-1234567890") == "xoxb...7890"
-    assert mask_token("xapp-abcdef123456") == "xapp...3456"
+def test_schema_lists_all_tables(client):
+    r = client.get("/schema")
+    assert r.status_code == 200
+    tables = r.json()
+    assert set(tables.keys()) == {"workspaces", "workspace_agents", "topics", "sessions", "messages"}
+
+
+def test_schema_workspaces_columns(client):
+    r = client.get("/schema")
+    cols = r.json()["workspaces"]
+    assert "id" in cols
+    assert "name" in cols
+    assert "repo_url" in cols
+    assert "created_at" in cols
+
+
+def test_schema_workspace_agents_columns(client):
+    r = client.get("/schema")
+    cols = r.json()["workspace_agents"]
+    for expected in ("id", "workspace_id", "agent_name", "adapter", "subagent", "active", "created_at", "deleted_at"):
+        assert expected in cols, f"missing column: {expected}"
+
+
+def test_db_file_created_on_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    with TestClient(app):
+        db = tmp_path / "master_data.db"
+        assert db.exists(), "master_data.db was not created on startup"


### PR DESCRIPTION
## Summary

- Add `src/master/db.py`: defines all 5 tables (`workspaces`, `workspace_agents`, `topics`, `sessions`, `messages`) via `CREATE TABLE IF NOT EXISTS`, with `init_db()`, `get_connection()` (FK pragma on), and `schema_info()` helper
- Wire `init_db()` into the FastAPI lifespan on startup; expose `GET /schema` endpoint returning `{table: [columns]}` for each table
- Fix data directory ownership: switch compose volume to a named Docker volume (`master_data`) and pre-create `data/master` as `appuser` in the Dockerfile — eliminates the root-owned bind-mount problem that crashed startup
- Replace stale `mask_token` tests with `TestClient`-based health + schema tests; add `tests/master/test_db.py` covering file creation, idempotency, column presence, FK pragma, and `UNIQUE` constraint on `workspace_agents(workspace_id, agent_name)`

## Test plan

- [ ] `docker compose up --build -d` starts both containers without errors (no manual `chown` needed)
- [ ] `curl http://<host>:8080/health` → `{"status":"ok"}`
- [ ] `curl http://<host>:8080/schema` returns all 5 tables with correct columns (including `active`/`deleted_at` on `workspace_agents`, `transcript` on `messages`, `worktree_path` on `topics`)
- [ ] Master logs show `master.db_init path=…/master_data.db` after `master.startup`
- [ ] `docker restart codex-slack-master` → `/schema` still returns the same structure (DB persists across restarts)
- [ ] `python -m pytest tests/master/test_db.py tests/master/test_main.py -v` → 11 passed

🤖 Generated with repository automation