### PR TITLE
feat(v3/slice-3): workspace CRUD API with default agent creation

### DIFF
--- a/src/master/db.py
+++ b/src/master/db.py
@@ -6,7 +6,7 @@ from pathlib import Path
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS workspaces (
     id             TEXT PRIMARY KEY,
-    name           TEXT NOT NULL,
+    name           TEXT NOT NULL UNIQUE,
     repo_url       TEXT NOT NULL,
     container_name TEXT,
     created_at     TEXT NOT NULL

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from ..logging_utils import LocalTimeFormatter
 from .config import load_master_settings
 from .db import init_db, schema_info
+from .workspaces import router as workspaces_router
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
 
 
 app = FastAPI(lifespan=lifespan)
+app.include_router(workspaces_router)
 
 
 @app.get("/health")

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from .db import get_connection
+
+router = APIRouter(prefix="/workspaces", tags=["workspaces"])
+
+_DEFAULT_AGENTS = [
+    ("claude", "claude-code", None),
+    ("codex", "codex", None),
+]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class WorkspaceCreate(BaseModel):
+    name: str
+    repo_url: str
+
+
+class WorkspaceAgentOut(BaseModel):
+    id: str
+    agent_name: str
+    adapter: str
+    subagent: str | None
+    active: bool
+
+
+class WorkspaceOut(BaseModel):
+    id: str
+    name: str
+    repo_url: str
+    container_name: str | None
+    created_at: str
+    agents: list[WorkspaceAgentOut]
+
+
+def _fetch_workspace(conn, workspace_id: str) -> WorkspaceOut | None:
+    row = conn.execute(
+        "SELECT id, name, repo_url, container_name, created_at FROM workspaces WHERE id = ?",
+        (workspace_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    agents = conn.execute(
+        "SELECT id, agent_name, adapter, subagent, active FROM workspace_agents"
+        " WHERE workspace_id = ? AND active = 1",
+        (workspace_id,),
+    ).fetchall()
+    return WorkspaceOut(
+        id=row["id"],
+        name=row["name"],
+        repo_url=row["repo_url"],
+        container_name=row["container_name"],
+        created_at=row["created_at"],
+        agents=[
+            WorkspaceAgentOut(
+                id=a["id"],
+                agent_name=a["agent_name"],
+                adapter=a["adapter"],
+                subagent=a["subagent"],
+                active=bool(a["active"]),
+            )
+            for a in agents
+        ],
+    )
+
+
+@router.post("", status_code=201, response_model=WorkspaceOut)
+def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
+    workspace_id = str(uuid.uuid4())
+    now = _now()
+    conn = get_connection(request.app.state.db_path)
+    try:
+        conn.execute(
+            "INSERT INTO workspaces (id, name, repo_url, container_name, created_at)"
+            " VALUES (?, ?, ?, NULL, ?)",
+            (workspace_id, body.name.strip(), body.repo_url.strip(), now),
+        )
+        for agent_name, adapter, subagent in _DEFAULT_AGENTS:
+            conn.execute(
+                "INSERT INTO workspace_agents"
+                " (id, workspace_id, agent_name, adapter, subagent, active, created_at, deleted_at)"
+                " VALUES (?, ?, ?, ?, ?, 1, ?, NULL)",
+                (str(uuid.uuid4()), workspace_id, agent_name, adapter, subagent, now),
+            )
+        conn.commit()
+        result = _fetch_workspace(conn, workspace_id)
+    finally:
+        conn.close()
+    assert result is not None
+    return result
+
+
+@router.get("", response_model=list[WorkspaceOut])
+def list_workspaces(request: Request) -> list[WorkspaceOut]:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id FROM workspaces ORDER BY created_at"
+        ).fetchall()
+        return [w for row in rows if (w := _fetch_workspace(conn, row["id"])) is not None]
+    finally:
+        conn.close()
+
+
+@router.get("/{workspace_id}", response_model=WorkspaceOut)
+def get_workspace(workspace_id: str, request: Request) -> WorkspaceOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        result = _fetch_workspace(conn, workspace_id)
+    finally:
+        conn.close()
+    if result is None:
+        raise HTTPException(status_code=404, detail="workspace not found")
+    return result
+
+
+@router.delete("/{workspace_id}", status_code=204)
+def delete_workspace(workspace_id: str, request: Request) -> None:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        row = conn.execute(
+            "SELECT id FROM workspaces WHERE id = ?", (workspace_id,)
+        ).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="workspace not found")
+        conn.execute("DELETE FROM workspace_agents WHERE workspace_id = ?", (workspace_id,))
+        conn.execute("DELETE FROM workspaces WHERE id = ?", (workspace_id,))
+        conn.commit()
+    finally:
+        conn.close()

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import uuid
 from datetime import datetime, timezone
 
@@ -79,11 +80,14 @@ def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
     now = _now()
     conn = get_connection(request.app.state.db_path)
     try:
-        conn.execute(
-            "INSERT INTO workspaces (id, name, repo_url, container_name, created_at)"
-            " VALUES (?, ?, ?, NULL, ?)",
-            (workspace_id, body.name.strip(), body.repo_url.strip(), now),
-        )
+        try:
+            conn.execute(
+                "INSERT INTO workspaces (id, name, repo_url, container_name, created_at)"
+                " VALUES (?, ?, ?, NULL, ?)",
+                (workspace_id, body.name.strip(), body.repo_url.strip(), now),
+            )
+        except sqlite3.IntegrityError:
+            raise HTTPException(status_code=409, detail="workspace name already exists")
         for agent_name, adapter, subagent in _DEFAULT_AGENTS:
             conn.execute(
                 "INSERT INTO workspace_agents"

--- a/tests/master/test_workspaces.py
+++ b/tests/master/test_workspaces.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.master.main import app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    with TestClient(app) as c:
+        yield c
+
+
+def create_ws(client, name="myrepo", repo_url="https://github.com/x/y"):
+    return client.post("/workspaces", json={"name": name, "repo_url": repo_url})
+
+
+# --- create ---
+
+def test_create_workspace_returns_201(client):
+    r = create_ws(client)
+    assert r.status_code == 201
+
+
+def test_create_workspace_body(client):
+    r = create_ws(client, name="myrepo", repo_url="https://github.com/x/y")
+    body = r.json()
+    assert body["name"] == "myrepo"
+    assert body["repo_url"] == "https://github.com/x/y"
+    assert body["container_name"] is None
+    assert "id" in body
+    assert "created_at" in body
+
+
+def test_create_workspace_inserts_default_agents(client):
+    r = create_ws(client)
+    agents = {a["agent_name"]: a for a in r.json()["agents"]}
+    assert "claude" in agents
+    assert "codex" in agents
+    assert agents["claude"]["adapter"] == "claude-code"
+    assert agents["codex"]["adapter"] == "codex"
+    assert agents["claude"]["active"] is True
+
+
+def test_create_workspace_strips_whitespace(client):
+    r = client.post("/workspaces", json={"name": "  repo  ", "repo_url": "  https://github.com/x/y  "})
+    body = r.json()
+    assert body["name"] == "repo"
+    assert body["repo_url"] == "https://github.com/x/y"
+
+
+# --- list ---
+
+def test_list_workspaces_empty(client):
+    r = client.get("/workspaces")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_workspaces_returns_all(client):
+    create_ws(client, name="a", repo_url="https://github.com/x/a")
+    create_ws(client, name="b", repo_url="https://github.com/x/b")
+    r = client.get("/workspaces")
+    assert r.status_code == 200
+    names = {w["name"] for w in r.json()}
+    assert names == {"a", "b"}
+
+
+# --- get ---
+
+def test_get_workspace_by_id(client):
+    ws_id = create_ws(client).json()["id"]
+    r = client.get(f"/workspaces/{ws_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == ws_id
+
+
+def test_get_workspace_not_found(client):
+    r = client.get("/workspaces/does-not-exist")
+    assert r.status_code == 404
+
+
+# --- delete ---
+
+def test_delete_workspace_returns_204(client):
+    ws_id = create_ws(client).json()["id"]
+    r = client.delete(f"/workspaces/{ws_id}")
+    assert r.status_code == 204
+
+
+def test_delete_workspace_removes_it(client):
+    ws_id = create_ws(client).json()["id"]
+    client.delete(f"/workspaces/{ws_id}")
+    assert client.get(f"/workspaces/{ws_id}").status_code == 404
+    assert all(w["id"] != ws_id for w in client.get("/workspaces").json())
+
+
+def test_delete_workspace_not_found(client):
+    r = client.delete("/workspaces/does-not-exist")
+    assert r.status_code == 404

--- a/tests/master/test_workspaces.py
+++ b/tests/master/test_workspaces.py
@@ -45,6 +45,12 @@ def test_create_workspace_inserts_default_agents(client):
     assert agents["claude"]["active"] is True
 
 
+def test_create_workspace_duplicate_name_returns_409(client):
+    create_ws(client, name="same")
+    r = client.post("/workspaces", json={"name": "same", "repo_url": "https://github.com/x/z"})
+    assert r.status_code == 409
+
+
 def test_create_workspace_strips_whitespace(client):
     r = client.post("/workspaces", json={"name": "  repo  ", "repo_url": "  https://github.com/x/y  "})
     body = r.json()


### PR DESCRIPTION
## Summary

- Add `src/master/workspaces.py`: `POST /workspaces`, `GET /workspaces`, `GET /workspaces/{id}`, `DELETE /workspaces/{id}` with Pydantic request/response models
- Workspace creation auto-inserts two default agents (`claude`/`claude-code`, `codex`/`codex`); input name and repo_url are whitespace-stripped
- Enforce unique workspace names: `UNIQUE` constraint on `workspaces.name` in the schema + 409 response on duplicate, preventing two workspaces from sharing the same name
- 12 tests covering create (body, defaults, whitespace, duplicate 409), list (empty, multiple), get (by id, 404), and delete (204, removes, 404)

## Test plan

- [ ] `POST /workspaces` with `{"name":"myrepo","repo_url":"..."}` → 201 with `id`, `name`, `repo_url`, `container_name: null`, and `agents` array containing `claude` and `codex`
- [ ] `GET /workspaces` → array listing the created workspace
- [ ] `GET /workspaces/<id>` → same workspace object
- [ ] `GET /workspaces/does-not-exist` → 404
- [ ] Second `POST /workspaces` with the same `name` → 409 `{"detail":"workspace name already exists"}`
- [ ] `DELETE /workspaces/<id>` → 204; subsequent `GET` returns 404 and list is empty
- [ ] `python -m pytest tests/master/test_workspaces.py tests/master/test_db.py tests/master/test_main.py -v` → 23 passed

🤖 Generated with repository automation