### PR TITLE
feat(v3/slice-4): topic CRUD API nested under workspaces

### DIFF
--- a/src/master/main.py
+++ b/src/master/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from ..logging_utils import LocalTimeFormatter
 from .config import load_master_settings
 from .db import init_db, schema_info
+from .topics import router as topics_router
 from .workspaces import router as workspaces_router
 
 LOGGER = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(workspaces_router)
+app.include_router(topics_router)
 
 
 @app.get("/health")

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from .db import get_connection
+
+router = APIRouter(prefix="/workspaces/{workspace_id}/topics", tags=["topics"])
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _slugify(text: str) -> str:
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug[:60] or "topic"
+
+
+def _workspace_exists(conn, workspace_id: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM workspaces WHERE id = ?", (workspace_id,)
+    ).fetchone() is not None
+
+
+class TopicCreate(BaseModel):
+    subject: str
+    branch_name: str | None = None
+
+
+class TopicOut(BaseModel):
+    id: str
+    workspace_id: str
+    subject: str
+    branch_name: str
+    worktree_path: str
+    created_at: str
+
+
+def _row_to_topic(row) -> TopicOut:
+    return TopicOut(
+        id=row["id"],
+        workspace_id=row["workspace_id"],
+        subject=row["subject"],
+        branch_name=row["branch_name"],
+        worktree_path=row["worktree_path"],
+        created_at=row["created_at"],
+    )
+
+
+@router.post("", status_code=201, response_model=TopicOut)
+def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> TopicOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        if not _workspace_exists(conn, workspace_id):
+            raise HTTPException(status_code=404, detail="workspace not found")
+        topic_id = str(uuid.uuid4())
+        branch_name = (body.branch_name or _slugify(body.subject)).strip()
+        worktree_path = f"/workspace/worktrees/{topic_id}"
+        now = _now()
+        conn.execute(
+            "INSERT INTO topics (id, workspace_id, subject, branch_name, worktree_path, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (topic_id, workspace_id, body.subject.strip(), branch_name, worktree_path, now),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM topics WHERE id = ?", (topic_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return _row_to_topic(row)
+
+
+@router.get("", response_model=list[TopicOut])
+def list_topics(workspace_id: str, request: Request) -> list[TopicOut]:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        if not _workspace_exists(conn, workspace_id):
+            raise HTTPException(status_code=404, detail="workspace not found")
+        rows = conn.execute(
+            "SELECT * FROM topics WHERE workspace_id = ? ORDER BY created_at",
+            (workspace_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [_row_to_topic(r) for r in rows]
+
+
+@router.get("/{topic_id}", response_model=TopicOut)
+def get_topic(workspace_id: str, topic_id: str, request: Request) -> TopicOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM topics WHERE id = ? AND workspace_id = ?",
+            (topic_id, workspace_id),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        raise HTTPException(status_code=404, detail="topic not found")
+    return _row_to_topic(row)
+
+
+@router.delete("/{topic_id}", status_code=204)
+def delete_topic(workspace_id: str, topic_id: str, request: Request) -> None:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        row = conn.execute(
+            "SELECT id FROM topics WHERE id = ? AND workspace_id = ?",
+            (topic_id, workspace_id),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="topic not found")
+        conn.execute("DELETE FROM topics WHERE id = ?", (topic_id,))
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/master/test_topics.py
+++ b/tests/master/test_topics.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.master.main import app
+from src.master.topics import _slugify
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def workspace_id(client):
+    r = client.post("/workspaces", json={"name": "repo", "repo_url": "https://github.com/x/y"})
+    return r.json()["id"]
+
+
+def create_topic(client, workspace_id, subject="Fix the bug", branch_name=None):
+    body = {"subject": subject}
+    if branch_name:
+        body["branch_name"] = branch_name
+    return client.post(f"/workspaces/{workspace_id}/topics", json=body)
+
+
+# --- slugify ---
+
+def test_slugify_basic():
+    assert _slugify("Fix the bug") == "fix-the-bug"
+
+
+def test_slugify_special_chars():
+    assert _slugify("Add feat: new/thing!") == "add-feat-newthing"
+
+
+def test_slugify_truncates():
+    assert len(_slugify("a" * 100)) <= 60
+
+
+def test_slugify_empty_falls_back():
+    assert _slugify("!!!") == "topic"
+
+
+# --- create ---
+
+def test_create_topic_returns_201(client, workspace_id):
+    r = create_topic(client, workspace_id)
+    assert r.status_code == 201
+
+
+def test_create_topic_body(client, workspace_id):
+    r = create_topic(client, workspace_id, subject="Fix the bug")
+    body = r.json()
+    assert body["subject"] == "Fix the bug"
+    assert body["workspace_id"] == workspace_id
+    assert body["branch_name"] == "fix-the-bug"
+    assert body["worktree_path"].startswith("/workspace/worktrees/")
+    assert "id" in body and "created_at" in body
+
+
+def test_create_topic_custom_branch(client, workspace_id):
+    r = create_topic(client, workspace_id, subject="My topic", branch_name="feat/my-branch")
+    assert r.json()["branch_name"] == "feat/my-branch"
+
+
+def test_create_topic_unknown_workspace(client):
+    r = create_topic(client, "no-such-workspace")
+    assert r.status_code == 404
+
+
+# --- list ---
+
+def test_list_topics_empty(client, workspace_id):
+    r = client.get(f"/workspaces/{workspace_id}/topics")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_topics_returns_all(client, workspace_id):
+    create_topic(client, workspace_id, subject="Topic A")
+    create_topic(client, workspace_id, subject="Topic B")
+    r = client.get(f"/workspaces/{workspace_id}/topics")
+    assert r.status_code == 200
+    subjects = {t["subject"] for t in r.json()}
+    assert subjects == {"Topic A", "Topic B"}
+
+
+def test_list_topics_unknown_workspace(client):
+    r = client.get("/workspaces/no-such/topics")
+    assert r.status_code == 404
+
+
+# --- get ---
+
+def test_get_topic_by_id(client, workspace_id):
+    topic_id = create_topic(client, workspace_id).json()["id"]
+    r = client.get(f"/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == topic_id
+
+
+def test_get_topic_not_found(client, workspace_id):
+    r = client.get(f"/workspaces/{workspace_id}/topics/no-such")
+    assert r.status_code == 404
+
+
+# --- delete ---
+
+def test_delete_topic_returns_204(client, workspace_id):
+    topic_id = create_topic(client, workspace_id).json()["id"]
+    r = client.delete(f"/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.status_code == 204
+
+
+def test_delete_topic_removes_it(client, workspace_id):
+    topic_id = create_topic(client, workspace_id).json()["id"]
+    client.delete(f"/workspaces/{workspace_id}/topics/{topic_id}")
+    assert client.get(f"/workspaces/{workspace_id}/topics/{topic_id}").status_code == 404
+    assert all(t["id"] != topic_id for t in client.get(f"/workspaces/{workspace_id}/topics").json())
+
+
+def test_delete_topic_not_found(client, workspace_id):
+    r = client.delete(f"/workspaces/{workspace_id}/topics/no-such")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

- Add `src/master/topics.py`: `POST /workspaces/{workspace_id}/topics`, `GET /workspaces/{workspace_id}/topics`, `GET /workspaces/{workspace_id}/topics/{topic_id}`, `DELETE /workspaces/{workspace_id}/topics/{topic_id}`
- `branch_name` auto-generated from `subject` via `_slugify()` (lowercase, special chars stripped, spaces→hyphens, truncated to 60 chars) if not supplied by the caller; `worktree_path` set to `/workspace/worktrees/{topic_id}` (no git operations yet — that's a later slice)
- All topic endpoints return 404 when the parent `workspace_id` does not exist
- 16 tests covering slugify edge cases, create (body fields, custom branch, unknown workspace), list (empty, multiple, unknown workspace), get (by id, 404), and delete (204, removes, 404)

## Test plan

- [ ] `POST /workspaces/{id}/topics` with `{"subject":"Fix the bug"}` → 201 with `branch_name: "fix-the-bug"`, `worktree_path: "/workspace/worktrees/<uuid>"`, correct `workspace_id`
- [ ] Same endpoint with `{"subject":"...", "branch_name":"feat/custom"}` → `branch_name` is `"feat/custom"`
- [ ] `POST` to a non-existent workspace → 404
- [ ] `GET /workspaces/{id}/topics` → empty array initially, then lists created topics
- [ ] `GET /workspaces/{id}/topics/{topic_id}` → topic object; unknown id → 404
- [ ] `DELETE /workspaces/{id}/topics/{topic_id}` → 204; subsequent GET → 404
- [ ] `python -m pytest tests/master/test_topics.py tests/master/test_workspaces.py tests/master/test_main.py tests/master/test_db.py -v` → 39 passed

🤖 Generated with repository automation