### PR TITLE
feat(v3/slice-5): MQTT client — master connects to Mosquitto on startup

### DIFF
--- a/src/master/main.py
+++ b/src/master/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from ..logging_utils import LocalTimeFormatter
 from .config import load_master_settings
 from .db import init_db, schema_info
+from .mqtt_client import build_client as build_mqtt_client
 from .topics import router as topics_router
 from .workspaces import router as workspaces_router
 
@@ -43,9 +44,15 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
     db_path = _db_path(settings.data_dir)
     init_db(db_path)
     LOGGER.info("master.db_init path=%s", db_path)
+    mqtt = build_mqtt_client(settings)
+    mqtt.loop_start()
+    LOGGER.info("master.mqtt_loop_start host=%s port=%s", settings.mqtt_host, settings.mqtt_port)
     app.state.settings = settings
     app.state.db_path = db_path
+    app.state.mqtt = mqtt
     yield
+    mqtt.loop_stop()
+    mqtt.disconnect()
     LOGGER.info("master.shutdown")
 
 

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+
+import paho.mqtt.client as mqtt
+
+from .config import MasterSettings
+
+LOGGER = logging.getLogger(__name__)
+
+_RESPONSE_TOPIC = "codex-slack/workspace/+/topic/+/response"
+_STATUS_TOPIC = "codex-slack/workspace/+/topic/+/status"
+
+
+def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -> None:  # type: ignore[type-arg]
+    if reason_code.is_failure:
+        LOGGER.error("mqtt.connect_failed reason=%s", reason_code)
+        return
+    LOGGER.info("mqtt.connected")
+    client.subscribe(_RESPONSE_TOPIC, qos=1)
+    client.subscribe(_STATUS_TOPIC, qos=0)
+    LOGGER.info("mqtt.subscribed topics=%s,%s", _RESPONSE_TOPIC, _STATUS_TOPIC)
+
+
+def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
+    LOGGER.warning("mqtt.disconnected reason=%s", reason_code)
+
+
+def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
+    LOGGER.info("mqtt.message topic=%s payload_bytes=%d", msg.topic, len(msg.payload))
+
+
+def build_client(settings: MasterSettings) -> mqtt.Client:
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.on_connect = _on_connect
+    client.on_disconnect = _on_disconnect
+    client.on_message = _on_message
+    client.connect_async(settings.mqtt_host, settings.mqtt_port, keepalive=60)
+    return client

--- a/tests/master/test_mqtt_client.py
+++ b/tests/master/test_mqtt_client.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import paho.mqtt.client as mqtt
+import pytest
+from fastapi.testclient import TestClient
+
+from src.master.config import MasterSettings
+from src.master.mqtt_client import (
+    _RESPONSE_TOPIC,
+    _STATUS_TOPIC,
+    _on_connect,
+    _on_disconnect,
+    _on_message,
+    build_client,
+)
+
+
+def _make_settings(**kwargs):
+    defaults = dict(
+        data_dir="/tmp",
+        dry_run=False,
+        agent_base_image="img:latest",
+        agent_codex_auth_json_path=None,
+        agent_ssh_auth_sock_path=None,
+        agent_ssh_known_hosts_path=None,
+        git_user_name=None,
+        git_user_email=None,
+        mqtt_host="localhost",
+        mqtt_port=1883,
+        master_port=8080,
+        container_runtime="docker",
+    )
+    return MasterSettings(**{**defaults, **kwargs})
+
+
+# --- build_client ---
+
+def test_build_client_calls_connect_async():
+    settings = _make_settings(mqtt_host="broker", mqtt_port=1883)
+    with patch("src.master.mqtt_client.mqtt.Client") as MockClient:
+        instance = MockClient.return_value
+        build_client(settings)
+        instance.connect_async.assert_called_once_with("broker", 1883, keepalive=60)
+
+
+def test_build_client_sets_callbacks():
+    settings = _make_settings()
+    with patch("src.master.mqtt_client.mqtt.Client") as MockClient:
+        instance = MockClient.return_value
+        build_client(settings)
+        assert instance.on_connect == _on_connect
+        assert instance.on_disconnect == _on_disconnect
+        assert instance.on_message == _on_message
+
+
+# --- on_connect ---
+
+def test_on_connect_subscribes_on_success():
+    client = MagicMock()
+    reason_code = MagicMock()
+    reason_code.is_failure = False
+    _on_connect(client, None, None, reason_code, None)
+    calls = client.subscribe.call_args_list
+    subscribed_topics = {c.args[0] for c in calls}
+    assert _RESPONSE_TOPIC in subscribed_topics
+    assert _STATUS_TOPIC in subscribed_topics
+
+
+def test_on_connect_does_not_subscribe_on_failure():
+    client = MagicMock()
+    reason_code = MagicMock()
+    reason_code.is_failure = True
+    _on_connect(client, None, None, reason_code, None)
+    client.subscribe.assert_not_called()
+
+
+def test_on_connect_response_topic_qos1():
+    client = MagicMock()
+    reason_code = MagicMock()
+    reason_code.is_failure = False
+    _on_connect(client, None, None, reason_code, None)
+    response_calls = [c for c in client.subscribe.call_args_list if c.args[0] == _RESPONSE_TOPIC]
+    assert response_calls and response_calls[0].kwargs.get("qos", response_calls[0].args[1] if len(response_calls[0].args) > 1 else None) == 1
+
+
+def test_on_connect_status_topic_qos0():
+    client = MagicMock()
+    reason_code = MagicMock()
+    reason_code.is_failure = False
+    _on_connect(client, None, None, reason_code, None)
+    status_calls = [c for c in client.subscribe.call_args_list if c.args[0] == _STATUS_TOPIC]
+    assert status_calls and status_calls[0].kwargs.get("qos", status_calls[0].args[1] if len(status_calls[0].args) > 1 else None) == 0
+
+
+# --- lifespan integration ---
+
+def test_lifespan_starts_and_stops_mqtt_loop(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    with patch("src.master.main.build_mqtt_client") as mock_build:
+        mock_client = MagicMock()
+        mock_build.return_value = mock_client
+        from src.master.main import app
+        with TestClient(app):
+            mock_client.loop_start.assert_called_once()
+        mock_client.loop_stop.assert_called_once()
+        mock_client.disconnect.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `src/master/mqtt_client.py`: `build_client()` creates a paho-mqtt v2 `Client` with `on_connect`/`on_disconnect`/`on_message` callbacks; on successful connect, subscribes to `codex-slack/workspace/+/topic/+/response` (QoS 1) and `codex-slack/workspace/+/topic/+/status` (QoS 0) wildcard topics
- Wire MQTT into the FastAPI lifespan: `loop_start()` before `yield`, `loop_stop()` + `disconnect()` on shutdown; client stored on `app.state.mqtt` for later use by prompt dispatch
- 7 tests (all mocked — no broker needed): `connect_async` called with correct host/port, callbacks wired, subscriptions only on success, correct QoS per topic, lifespan calls `loop_start`/`loop_stop`/`disconnect`

## Test plan

- [ ] `docker compose up` → master logs show `mqtt.connected` and `mqtt.subscribed` lines after startup
- [ ] `docker compose stop master && docker compose start master` → logs show reconnect (`mqtt.disconnected` then `mqtt.connected` again)
- [ ] `python -m pytest tests/master/test_mqtt_client.py -v` → 7 passed (all mocked, no broker required)
- [ ] `python -m pytest tests/master/ -v` → 46 passed total

🤖 Generated with repository automation