### PR TITLE
feat(v3/slice-7): prompt dispatch — POST /messages publishes to MQTT, agent responses saved to DB

### DIFF
--- a/src/master/main.py
+++ b/src/master/main.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from ..logging_utils import LocalTimeFormatter
 from .config import load_master_settings
 from .db import init_db, schema_info
+from .messages import router as messages_router
 from .mqtt_client import build_client as build_mqtt_client
 from .topics import router as topics_router
 from .workspaces import router as workspaces_router
@@ -48,7 +49,7 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
     LOGGER.info("master.db_init path=%s", db_path)
     hub = ConnectionHub()
     loop = asyncio.get_event_loop()
-    mqtt = build_mqtt_client(settings, hub=hub, loop=loop)
+    mqtt = build_mqtt_client(settings, hub=hub, loop=loop, db_path=db_path)
     mqtt.loop_start()
     LOGGER.info("master.mqtt_loop_start host=%s port=%s", settings.mqtt_host, settings.mqtt_port)
     app.state.settings = settings
@@ -64,6 +65,7 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
 app = FastAPI(lifespan=lifespan)
 app.include_router(workspaces_router)
 app.include_router(topics_router)
+app.include_router(messages_router)
 
 
 @app.get("/health")

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from .db import get_connection
+
+router = APIRouter(
+    prefix="/workspaces/{workspace_id}/topics/{topic_id}/messages",
+    tags=["messages"],
+)
+
+_PROMPT_TOPIC = "codex-slack/workspace/{workspace_id}/topic/{topic_id}/prompt"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _get_or_create_session(conn, topic_id: str, agent_name: str, adapter: str) -> tuple[str, str | None]:
+    row = conn.execute(
+        "SELECT id, llm_session_id FROM sessions WHERE topic_id = ? AND agent_name = ?",
+        (topic_id, agent_name),
+    ).fetchone()
+    if row:
+        return row["id"], row["llm_session_id"]
+    session_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO sessions (id, topic_id, agent_name, adapter, llm_session_id, updated_at)"
+        " VALUES (?, ?, ?, ?, NULL, ?)",
+        (session_id, topic_id, agent_name, adapter, _now()),
+    )
+    conn.commit()
+    return session_id, None
+
+
+class MessageSend(BaseModel):
+    text: str
+    agent_name: str = "claude"
+
+
+class MessageOut(BaseModel):
+    id: str
+    sender: str
+    agent_name: str | None
+    text: str
+    created_at: str
+
+
+@router.post("", status_code=202)
+def send_message(workspace_id: str, topic_id: str, body: MessageSend, request: Request) -> dict:  # type: ignore[type-arg]
+    conn = get_connection(request.app.state.db_path)
+    try:
+        if conn.execute("SELECT 1 FROM workspaces WHERE id = ?", (workspace_id,)).fetchone() is None:
+            raise HTTPException(404, "workspace not found")
+        topic = conn.execute(
+            "SELECT id, worktree_path FROM topics WHERE id = ? AND workspace_id = ?",
+            (topic_id, workspace_id),
+        ).fetchone()
+        if topic is None:
+            raise HTTPException(404, "topic not found")
+        agent = conn.execute(
+            "SELECT adapter, subagent FROM workspace_agents"
+            " WHERE workspace_id = ? AND agent_name = ? AND active = 1",
+            (workspace_id, body.agent_name),
+        ).fetchone()
+        if agent is None:
+            raise HTTPException(404, f"agent '{body.agent_name}' not found in workspace")
+        _session_id, llm_session_id = _get_or_create_session(
+            conn, topic_id, body.agent_name, agent["adapter"]
+        )
+        message_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO messages"
+            " (id, topic_id, sender, agent_name, text, transcript, attachments_json, created_at)"
+            " VALUES (?, ?, 'user', NULL, ?, NULL, NULL, ?)",
+            (message_id, topic_id, body.text.strip(), _now()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    payload = json.dumps({
+        "message_id": message_id,
+        "subagent": agent["subagent"],
+        "worktree": topic["worktree_path"],
+        "session_id": llm_session_id,
+        "text": body.text.strip(),
+        "attachments": [],
+    })
+    mqtt_topic = _PROMPT_TOPIC.format(workspace_id=workspace_id, topic_id=topic_id)
+    request.app.state.mqtt.publish(mqtt_topic, payload, qos=1)
+
+    return {"message_id": message_id, "status": "queued"}
+
+
+@router.get("", response_model=list[MessageOut])
+def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[MessageOut]:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        if conn.execute("SELECT 1 FROM workspaces WHERE id = ?", (workspace_id,)).fetchone() is None:
+            raise HTTPException(404, "workspace not found")
+        if conn.execute(
+            "SELECT 1 FROM topics WHERE id = ? AND workspace_id = ?", (topic_id, workspace_id)
+        ).fetchone() is None:
+            raise HTTPException(404, "topic not found")
+        rows = conn.execute(
+            "SELECT id, sender, agent_name, text, created_at FROM messages"
+            " WHERE topic_id = ? ORDER BY created_at",
+            (topic_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        MessageOut(
+            id=r["id"], sender=r["sender"], agent_name=r["agent_name"],
+            text=r["text"], created_at=r["created_at"],
+        )
+        for r in rows
+    ]

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sqlite3
+import uuid
+from datetime import datetime, timezone
 
 import paho.mqtt.client as mqtt
 
@@ -17,12 +20,45 @@ _STATUS_TOPIC = "codex-slack/workspace/+/topic/+/status"
 _TOPIC_PARTS = 6
 
 
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _parse_mqtt_topic(raw: str) -> tuple[str, str] | None:
     """Return (topic_id, msg_type) from an MQTT topic string, or None if malformed."""
     parts = raw.split("/")
     if len(parts) != _TOPIC_PARTS:
         return None
     return parts[4], parts[5]
+
+
+def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  # type: ignore[type-arg]
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        try:
+            text = payload.get("last_response", "")
+            transcript = payload.get("transcript")
+            llm_session_id = payload.get("session_id")
+            message_id = payload.get("message_id") or str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO messages"
+                " (id, topic_id, sender, agent_name, text, transcript, attachments_json, created_at)"
+                " VALUES (?, ?, 'agent', NULL, ?, ?, NULL, ?)",
+                (message_id, topic_id, text, transcript, _now()),
+            )
+            if llm_session_id:
+                conn.execute(
+                    "UPDATE sessions SET llm_session_id = ?, updated_at = ?"
+                    " WHERE topic_id = ?",
+                    (llm_session_id, _now(), topic_id),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        LOGGER.exception("mqtt.save_agent_response_error topic_id=%s", topic_id)
 
 
 def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -> None:  # type: ignore[type-arg]
@@ -57,6 +93,9 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
         message = {"type": "status", "state": payload.get("state")}
     elif msg_type == "response":
         message = {"type": "message", "sender": "agent", **payload}
+        db_path = userdata.get("db_path")
+        if db_path:
+            _save_agent_response(db_path, topic_id, payload)
     else:
         return
 
@@ -66,8 +105,13 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
         hub.broadcast_threadsafe(topic_id, message, loop)
 
 
-def build_client(settings: MasterSettings, hub=None, loop: asyncio.AbstractEventLoop | None = None) -> mqtt.Client:
-    userdata = {"hub": hub, "loop": loop}
+def build_client(
+    settings: MasterSettings,
+    hub=None,
+    loop: asyncio.AbstractEventLoop | None = None,
+    db_path: str | None = None,
+) -> mqtt.Client:
+    userdata = {"hub": hub, "loop": loop, "db_path": db_path}
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, userdata=userdata)
     client.on_connect = _on_connect
     client.on_disconnect = _on_disconnect

--- a/tests/master/test_messages.py
+++ b/tests/master/test_messages.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    with patch("src.master.main.build_mqtt_client") as mock_build:
+        mock_mqtt = MagicMock()
+        mock_build.return_value = mock_mqtt
+        from src.master.main import app
+        with TestClient(app) as c:
+            yield c, mock_mqtt
+
+
+@pytest.fixture()
+def workspace_topic(client):
+    c, _ = client
+    ws = c.post("/workspaces", json={"name": "repo", "repo_url": "https://github.com/x/y"}).json()
+    topic = c.post(f"/workspaces/{ws['id']}/topics", json={"subject": "Fix bug"}).json()
+    return ws["id"], topic["id"]
+
+
+def send(client, ws_id, topic_id, text="Hello", agent="claude"):
+    c, _ = client
+    return c.post(
+        f"/workspaces/{ws_id}/topics/{topic_id}/messages",
+        json={"text": text, "agent_name": agent},
+    )
+
+
+# --- send message ---
+
+def test_send_returns_202(client, workspace_topic):
+    ws_id, topic_id = workspace_topic
+    r = send(client, ws_id, topic_id)
+    assert r.status_code == 202
+
+
+def test_send_returns_message_id_and_queued(client, workspace_topic):
+    ws_id, topic_id = workspace_topic
+    body = send(client, ws_id, topic_id).json()
+    assert "message_id" in body
+    assert body["status"] == "queued"
+
+
+def test_send_publishes_mqtt(client, workspace_topic):
+    ws_id, topic_id = workspace_topic
+    c, mock_mqtt = client
+    send(client, ws_id, topic_id, text="Do it")
+    assert mock_mqtt.publish.called
+    call_args = mock_mqtt.publish.call_args
+    topic = call_args.args[0]
+    assert topic_id in topic
+    assert "prompt" in topic
+    import json
+    payload = json.loads(call_args.args[1])
+    assert payload["text"] == "Do it"
+    assert payload["worktree"].startswith("/workspace/worktrees/")
+
+
+def test_send_saves_user_message(client, workspace_topic):
+    c, _ = client
+    ws_id, topic_id = workspace_topic
+    send(client, ws_id, topic_id, text="Remember this")
+    msgs = c.get(f"/workspaces/{ws_id}/topics/{topic_id}/messages").json()
+    assert any(m["sender"] == "user" and m["text"] == "Remember this" for m in msgs)
+
+
+def test_send_unknown_workspace(client, workspace_topic):
+    _, topic_id = workspace_topic
+    c, _ = client
+    r = c.post(f"/workspaces/no-such/topics/{topic_id}/messages", json={"text": "hi"})
+    assert r.status_code == 404
+
+
+def test_send_unknown_topic(client, workspace_topic):
+    ws_id, _ = workspace_topic
+    c, _ = client
+    r = c.post(f"/workspaces/{ws_id}/topics/no-such/messages", json={"text": "hi"})
+    assert r.status_code == 404
+
+
+def test_send_unknown_agent(client, workspace_topic):
+    ws_id, topic_id = workspace_topic
+    r = send(client, ws_id, topic_id, agent="no-such-agent")
+    assert r.status_code == 404
+
+
+# --- list messages ---
+
+def test_list_messages_empty(client, workspace_topic):
+    c, _ = client
+    ws_id, topic_id = workspace_topic
+    r = c.get(f"/workspaces/{ws_id}/topics/{topic_id}/messages")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_messages_ordered(client, workspace_topic):
+    ws_id, topic_id = workspace_topic
+    send(client, ws_id, topic_id, text="First")
+    send(client, ws_id, topic_id, text="Second")
+    c, _ = client
+    msgs = c.get(f"/workspaces/{ws_id}/topics/{topic_id}/messages").json()
+    assert [m["text"] for m in msgs] == ["First", "Second"]
+
+
+def test_list_messages_unknown_workspace(client):
+    c, _ = client
+    r = c.get("/workspaces/no-such/topics/no-such/messages")
+    assert r.status_code == 404
+
+
+# --- session created on first send ---
+
+def test_send_creates_session(client, workspace_topic):
+    ws_id, topic_id = workspace_topic
+    c, mock_mqtt = client
+    send(client, ws_id, topic_id, text="first turn")
+    import json
+    payload = json.loads(mock_mqtt.publish.call_args.args[1])
+    # first turn: session_id is None (no LLM session yet)
+    assert payload["session_id"] is None


### PR DESCRIPTION
## Summary

- Add `src/master/messages.py`: `POST /workspaces/{wid}/topics/{tid}/messages` validates workspace, topic, and agent; gets-or-creates a `sessions` row (with `null` `llm_session_id` on first turn); saves the user message to `messages` table; publishes MQTT prompt (`message_id`, `subagent`, `worktree`, `session_id`, `text`, `attachments`) to `codex-slack/workspace/{wid}/topic/{tid}/prompt` at QoS 1; returns 202 `{message_id, status:"queued"}`
- Add `GET /workspaces/{wid}/topics/{tid}/messages` to list messages ordered by `created_at`
- Update `mqtt_client.py`: on incoming `response` messages, `_save_agent_response()` inserts the agent message row and updates `sessions.llm_session_id` so subsequent turns resume the same LLM session; `db_path` passed via MQTT client userdata
- 11 tests covering: 202 status, message_id in body, MQTT publish topic/payload shape, user message persisted, 404 for unknown workspace/topic/agent, message list ordering, session created with `null` `llm_session_id` on first send

## Verified on testbed

1. `POST /workspaces/{id}/topics/{id}/messages` → 202 `{"message_id":"…","status":"queued"}`
2. `GET .../messages` → `[{"sender":"user","text":"Can you fix this?",…}]`
3. `mosquitto_sub` inside Docker network captured: `codex-slack/workspace/{wid}/topic/{tid}/prompt {"message_id":"…","subagent":null,"worktree":"/workspace/worktrees/…","session_id":null,"text":"Second message","attachments":[]}`

## Test plan

- [ ] Create workspace + topic, `POST .../messages {"text":"…","agent_name":"claude"}` → 202 with `message_id`
- [ ] `GET .../messages` shows the user message with `sender:"user"`
- [ ] `mosquitto_sub -t 'codex-slack/#'` captures the prompt on the correct topic with correct payload fields
- [ ] `POST` with unknown `agent_name` → 404
- [ ] `python -m pytest tests/master/ -q` → 120 passed

🤖 Generated with repository automation