### PR TITLE
feat(v3/slice-8): Vue 3 frontend skeleton served by FastAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,13 @@ RUN mkdir -p data/master
 COPY --chown=appuser:appuser requirements.txt ./requirements.txt
 RUN python -m pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
+COPY --chown=appuser:appuser frontend/package.json frontend/package-lock.json* ./frontend/
+RUN cd frontend && npm ci --prefer-offline 2>/dev/null || npm install
+
 COPY --chown=appuser:appuser src ./src
+COPY --chown=appuser:appuser frontend ./frontend
+RUN cd frontend && npm run build && rm -rf node_modules
+
 COPY --chown=appuser:appuser config ./config
 COPY --chown=appuser:appuser docs ./docs
 COPY --chown=appuser:appuser README.md BUILD.md USAGE.md ./

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex Slack</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: system-ui, sans-serif; background: #f5f5f5; color: #1a1a1a; }
+      a { color: #2563eb; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "codex-slack-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,22 @@
+<template>
+  <div id="root">
+    <nav>
+      <RouterLink to="/">Codex Slack</RouterLink>
+    </nav>
+    <main>
+      <RouterView />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+nav {
+  background: #1e293b;
+  color: #f8fafc;
+  padding: 0.75rem 1.5rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+nav a { color: #93c5fd; }
+main { padding: 1.5rem; max-width: 900px; margin: 0 auto; }
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,17 @@
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import App from './App.vue'
+import WorkspaceList from './views/WorkspaceList.vue'
+import WorkspaceDetail from './views/WorkspaceDetail.vue'
+import TopicChat from './views/TopicChat.vue'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', component: WorkspaceList },
+    { path: '/workspaces/:id', component: WorkspaceDetail },
+    { path: '/workspaces/:wsId/topics/:topicId', component: TopicChat },
+  ],
+})
+
+createApp(App).use(router).mount('#app')

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="chat-layout">
+    <p class="breadcrumb">
+      <RouterLink to="/">Workspaces</RouterLink> /
+      <RouterLink :to="`/workspaces/${wsId}`">{{ wsId }}</RouterLink> /
+      {{ topic?.subject || topicId }}
+    </p>
+
+    <div class="status-bar" v-if="agentStatus">
+      Agent: <em>{{ agentStatus }}</em>
+    </div>
+
+    <div class="messages" ref="msgBox">
+      <p v-if="loading" class="muted center">Loading…</p>
+      <p v-else-if="!messages.length" class="muted center">No messages yet. Send one below.</p>
+      <div
+        v-for="m in messages"
+        :key="m.id"
+        class="message"
+        :class="m.sender === 'user' ? 'user' : 'agent'"
+      >
+        <span class="label">{{ m.sender === 'user' ? 'You' : (m.agent_name || 'Agent') }}</span>
+        <div class="bubble">{{ m.text }}</div>
+        <span class="ts">{{ m.created_at }}</span>
+      </div>
+    </div>
+
+    <form @submit.prevent="sendMessage" class="send-form">
+      <textarea
+        v-model="text"
+        placeholder="Type a message…"
+        rows="3"
+        :disabled="sending"
+        @keydown.enter.exact.prevent="sendMessage"
+      />
+      <button type="submit" :disabled="sending || !text.trim()">
+        {{ sending ? 'Sending…' : 'Send' }}
+      </button>
+    </form>
+    <p class="hint muted">Enter to send · Shift+Enter for new line</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const wsId = route.params.wsId
+const topicId = route.params.topicId
+
+const topic = ref(null)
+const messages = ref([])
+const loading = ref(true)
+const sending = ref(false)
+const text = ref('')
+const agentStatus = ref('')
+const msgBox = ref(null)
+
+let ws = null
+
+function scrollToBottom() {
+  nextTick(() => {
+    if (msgBox.value) msgBox.value.scrollTop = msgBox.value.scrollHeight
+  })
+}
+
+async function load() {
+  loading.value = true
+  try {
+    const [topicRes, msgsRes] = await Promise.all([
+      fetch(`/workspaces/${wsId}/topics/${topicId}`),
+      fetch(`/workspaces/${wsId}/topics/${topicId}/messages`),
+    ])
+    topic.value = await topicRes.json()
+    messages.value = await msgsRes.json()
+    scrollToBottom()
+  } finally {
+    loading.value = false
+  }
+}
+
+function connectWs() {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+  ws = new WebSocket(`${proto}://${location.host}/ws/${topicId}`)
+
+  ws.onmessage = (evt) => {
+    const data = JSON.parse(evt.data)
+    if (data.type === 'status') {
+      agentStatus.value = data.state || ''
+    } else if (data.type === 'message') {
+      messages.value.push({
+        id: data.message_id || Date.now().toString(),
+        sender: data.sender || 'agent',
+        agent_name: data.agent_name || null,
+        text: data.last_response || data.text || '',
+        created_at: new Date().toISOString(),
+      })
+      scrollToBottom()
+    }
+  }
+
+  ws.onclose = () => {
+    setTimeout(connectWs, 3000)
+  }
+}
+
+async function sendMessage() {
+  const msg = text.value.trim()
+  if (!msg || sending.value) return
+  sending.value = true
+  try {
+    const r = await fetch(`/workspaces/${wsId}/topics/${topicId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: msg }),
+    })
+    if (r.ok) {
+      text.value = ''
+      const saved = {
+        id: (await r.json()).message_id,
+        sender: 'user',
+        agent_name: null,
+        text: msg,
+        created_at: new Date().toISOString(),
+      }
+      messages.value.push(saved)
+      scrollToBottom()
+    }
+  } finally {
+    sending.value = false
+  }
+}
+
+onMounted(() => {
+  load()
+  connectWs()
+})
+
+onUnmounted(() => {
+  if (ws) { ws.onclose = null; ws.close() }
+})
+</script>
+
+<style scoped>
+.chat-layout { display: flex; flex-direction: column; height: calc(100vh - 110px); }
+.breadcrumb { font-size: 0.9em; color: #64748b; margin-bottom: 0.5rem; }
+.status-bar { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; }
+.messages { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; padding: 0.5rem 0; }
+.message { display: flex; flex-direction: column; max-width: 72%; }
+.message.user { align-self: flex-end; align-items: flex-end; }
+.message.agent { align-self: flex-start; align-items: flex-start; }
+.label { font-size: 0.75em; color: #64748b; margin-bottom: 2px; }
+.bubble { padding: 0.6rem 0.9rem; border-radius: 12px; white-space: pre-wrap; line-height: 1.45; }
+.message.user .bubble { background: #2563eb; color: #fff; border-bottom-right-radius: 3px; }
+.message.agent .bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 3px; }
+.ts { font-size: 0.7em; color: #94a3b8; margin-top: 2px; }
+.send-form { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+.send-form textarea { flex: 1; padding: 0.5rem 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; resize: none; font-family: inherit; font-size: 0.95rem; }
+.send-form button { padding: 0.5rem 1.25rem; background: #2563eb; color: #fff; border: none; border-radius: 6px; cursor: pointer; align-self: flex-end; }
+.send-form button:disabled { opacity: 0.6; cursor: default; }
+.hint { font-size: 0.8em; text-align: right; margin-top: 0.25rem; }
+.muted { color: #64748b; }
+.center { text-align: center; }
+</style>

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <p class="breadcrumb"><RouterLink to="/">Workspaces</RouterLink> / {{ workspace?.name || id }}</p>
+    <h2>Topics</h2>
+
+    <form @submit.prevent="createTopic" class="create-form">
+      <input v-model="subject" placeholder="Topic subject" required />
+      <button type="submit" :disabled="creating">
+        {{ creating ? 'Creating…' : 'New Topic' }}
+      </button>
+      <span v-if="createError" class="error">{{ createError }}</span>
+    </form>
+
+    <p v-if="loading" class="muted">Loading…</p>
+    <p v-else-if="!topics.length" class="muted">No topics yet.</p>
+    <ul v-else class="list">
+      <li v-for="t in topics" :key="t.id">
+        <RouterLink :to="`/workspaces/${id}/topics/${t.id}`">{{ t.subject }}</RouterLink>
+        <span class="muted small"> — branch: {{ t.branch_name }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const id = route.params.id
+
+const workspace = ref(null)
+const topics = ref([])
+const loading = ref(true)
+const creating = ref(false)
+const createError = ref('')
+const subject = ref('')
+
+async function load() {
+  loading.value = true
+  try {
+    const [wsRes, topicsRes] = await Promise.all([
+      fetch(`/workspaces/${id}`),
+      fetch(`/workspaces/${id}/topics`),
+    ])
+    workspace.value = await wsRes.json()
+    topics.value = await topicsRes.json()
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createTopic() {
+  creating.value = true
+  createError.value = ''
+  try {
+    const r = await fetch(`/workspaces/${id}/topics`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject: subject.value }),
+    })
+    if (!r.ok) {
+      const err = await r.json()
+      createError.value = err.detail || 'Error creating topic'
+      return
+    }
+    subject.value = ''
+    await load()
+  } finally {
+    creating.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.breadcrumb { font-size: 0.9em; color: #64748b; margin-bottom: 1rem; }
+h2 { margin-bottom: 1rem; }
+.create-form { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; }
+.create-form input { padding: 0.4rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 4px; flex: 1; min-width: 200px; }
+.create-form button { padding: 0.4rem 1rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+.create-form button:disabled { opacity: 0.6; cursor: default; }
+.list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
+.list li { background: #fff; padding: 0.75rem 1rem; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+.muted { color: #64748b; }
+.small { font-size: 0.85em; }
+.error { color: #dc2626; font-size: 0.9em; }
+</style>

--- a/frontend/src/views/WorkspaceList.vue
+++ b/frontend/src/views/WorkspaceList.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <h2>Workspaces</h2>
+
+    <form @submit.prevent="createWorkspace" class="create-form">
+      <input v-model="form.name" placeholder="Name" required />
+      <input v-model="form.repo_url" placeholder="Repository URL" required />
+      <button type="submit" :disabled="creating">
+        {{ creating ? 'Creating…' : 'New Workspace' }}
+      </button>
+      <span v-if="createError" class="error">{{ createError }}</span>
+    </form>
+
+    <p v-if="loading" class="muted">Loading…</p>
+    <p v-else-if="!workspaces.length" class="muted">No workspaces yet.</p>
+    <ul v-else class="list">
+      <li v-for="ws in workspaces" :key="ws.id">
+        <RouterLink :to="`/workspaces/${ws.id}`">{{ ws.name }}</RouterLink>
+        <span class="muted small"> — {{ ws.repo_url }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const workspaces = ref([])
+const loading = ref(true)
+const creating = ref(false)
+const createError = ref('')
+const form = ref({ name: '', repo_url: '' })
+
+async function load() {
+  loading.value = true
+  try {
+    const r = await fetch('/workspaces')
+    workspaces.value = await r.json()
+  } finally {
+    loading.value = false
+  }
+}
+
+async function createWorkspace() {
+  creating.value = true
+  createError.value = ''
+  try {
+    const r = await fetch('/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form.value),
+    })
+    if (!r.ok) {
+      const err = await r.json()
+      createError.value = err.detail || 'Error creating workspace'
+      return
+    }
+    form.value = { name: '', repo_url: '' }
+    await load()
+  } finally {
+    creating.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+h2 { margin-bottom: 1rem; }
+.create-form { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1.5rem; flex-wrap: wrap; }
+.create-form input { padding: 0.4rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 4px; flex: 1; min-width: 160px; }
+.create-form button { padding: 0.4rem 1rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+.create-form button:disabled { opacity: 0.6; cursor: default; }
+.list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
+.list li { background: #fff; padding: 0.75rem 1rem; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+.muted { color: #64748b; }
+.small { font-size: 0.85em; }
+.error { color: #dc2626; font-size: 0.9em; }
+</style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    outDir: '../src/master/static',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/workspaces': 'http://localhost:8080',
+      '/ws': { target: 'ws://localhost:8080', ws: true },
+    },
+  },
+})

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -6,7 +6,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from ..logging_utils import LocalTimeFormatter
 from .config import load_master_settings
@@ -18,6 +20,8 @@ from .workspaces import router as workspaces_router
 from .ws_hub import ConnectionHub
 
 LOGGER = logging.getLogger(__name__)
+
+_STATIC_DIR = Path(__file__).parent / "static"
 
 
 def configure_logging() -> None:
@@ -67,6 +71,9 @@ app.include_router(workspaces_router)
 app.include_router(topics_router)
 app.include_router(messages_router)
 
+if (_STATIC_DIR / "assets").exists():
+    app.mount("/assets", StaticFiles(directory=str(_STATIC_DIR / "assets")), name="static-assets")
+
 
 @app.get("/health")
 async def health() -> dict:  # type: ignore[type-arg]
@@ -89,3 +96,11 @@ async def ws_endpoint(topic_id: str, websocket: WebSocket) -> None:
         pass
     finally:
         app.state.hub.disconnect(topic_id, websocket)
+
+
+@app.get("/{full_path:path}", include_in_schema=False)
+async def spa_index(full_path: str) -> FileResponse:
+    index = _STATIC_DIR / "index.html"
+    if not index.exists():
+        raise HTTPException(404, "frontend not built")
+    return FileResponse(str(index))

--- a/tests/master/test_main.py
+++ b/tests/master/test_main.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from src.master.main import app, _db_path
+from src.master.main import app, _db_path, _STATIC_DIR
 
 
 @pytest.fixture()
@@ -51,3 +53,24 @@ def test_db_file_created_on_startup(tmp_path, monkeypatch):
     with TestClient(app):
         db = tmp_path / "master_data.db"
         assert db.exists(), "master_data.db was not created on startup"
+
+
+def test_spa_returns_404_when_not_built(client):
+    r = client.get("/some/spa/route")
+    assert r.status_code == 404
+
+
+def test_spa_serves_index_when_built(tmp_path, monkeypatch):
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    static = _STATIC_DIR
+    index = static / "index.html"
+    index.parent.mkdir(parents=True, exist_ok=True)
+    index.write_text("<!doctype html><html></html>")
+    try:
+        with TestClient(app) as c:
+            r = c.get("/any/spa/path")
+            assert r.status_code == 200
+            assert "html" in r.text
+    finally:
+        index.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Add Vue 3 + Vite SPA with three views: WorkspaceList, WorkspaceDetail, and TopicChat
- TopicChat connects to \`/ws/{topic_id}\` WebSocket for real-time agent status and message updates
- Dockerfile builds the frontend bundle during image build; output lands in \`src/master/static/\`
- FastAPI mounts \`/assets\` for static resources and adds a SPA catch-all route serving \`index.html\`

## Test plan
- [ ] `docker compose up --build -d` builds without errors; Vite bundle appears in logs
- [ ] `GET http://localhost:8080/` returns the Vue SPA index.html (200)
- [ ] `GET http://localhost:8080/assets/index-*.js` returns the JS bundle (200)
- [ ] `GET http://localhost:8080/some/deep/spa/route` returns index.html (SPA catch-all, 200)
- [ ] Open browser → `http://<testbed>:8080/` → WorkspaceList renders, create a workspace
- [ ] Click workspace → WorkspaceDetail renders topics list, create a topic
- [ ] Click topic → TopicChat renders, message history loads, send form visible
- [ ] WebSocket connects automatically; agent status bar appears on activity
- [ ] API routes (`/workspaces`, `/health`, `/schema`) still respond correctly alongside the SPA
- [ ] All 122 unit tests pass: `python -m pytest tests/master/ -q`

🤖 Generated with repository automation