### PR TITLE
feat(v3/slice-9): agent MQTT loop with LLM invocation

### DIFF
--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -1,0 +1,179 @@
+"""MQTT-driven prompt processor for the v3 agent worker."""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+
+import paho.mqtt.client as mqtt
+
+LOGGER = logging.getLogger(__name__)
+
+_TOPIC_PARTS = 6  # codex-slack/workspace/{wid}/topic/{tid}/prompt
+_LLM_TIMEOUT = 300
+
+_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="agent-llm")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_prompt_topic(raw: str) -> tuple[str, str] | None:
+    parts = raw.split("/")
+    if len(parts) != _TOPIC_PARTS or parts[5] != "prompt":
+        return None
+    return parts[2], parts[4]  # workspace_id, topic_id
+
+
+def _status_topic(workspace_id: str, topic_id: str) -> str:
+    return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/status"
+
+
+def _response_topic(workspace_id: str, topic_id: str) -> str:
+    return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/response"
+
+
+def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str) -> None:
+    if Path(worktree_path).exists():
+        return
+    Path(worktree_path).parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["git", "-C", repo_dir, "worktree", "add", worktree_path, "-b", branch],
+            capture_output=True, text=True, check=True,
+        )
+        LOGGER.info("agent.worktree_created path=%s branch=%s", worktree_path, branch)
+    except subprocess.CalledProcessError:
+        # Branch already exists — check out without -b
+        subprocess.run(
+            ["git", "-C", repo_dir, "worktree", "add", worktree_path, branch],
+            capture_output=True, text=True, check=True,
+        )
+        LOGGER.info("agent.worktree_reused path=%s branch=%s", worktree_path, branch)
+
+
+def _run_claude(worktree: str, text: str, session_id: str | None, subagent: str | None) -> tuple[str, str | None]:
+    cmd = ["claude", "--print", "--no-permissions"]
+    if session_id:
+        cmd += ["--resume", session_id]
+    cmd.append(text)
+    try:
+        result = subprocess.run(cmd, cwd=worktree, capture_output=True, text=True, timeout=_LLM_TIMEOUT)
+        output = result.stdout.strip() or result.stderr.strip() or "(no output)"
+        return output, None
+    except subprocess.TimeoutExpired:
+        return f"(claude timed out after {_LLM_TIMEOUT}s)", None
+    except FileNotFoundError:
+        return "(claude CLI not found in agent container)", None
+    except Exception as exc:
+        return f"(claude error: {exc})", None
+
+
+def _run_codex(worktree: str, text: str) -> tuple[str, str | None]:
+    cmd = ["codex", "--full-auto", "-q", text]
+    try:
+        result = subprocess.run(cmd, cwd=worktree, capture_output=True, text=True, timeout=_LLM_TIMEOUT)
+        output = result.stdout.strip() or result.stderr.strip() or "(no output)"
+        return output, None
+    except subprocess.TimeoutExpired:
+        return f"(codex timed out after {_LLM_TIMEOUT}s)", None
+    except FileNotFoundError:
+        return "(codex CLI not found in agent container)", None
+    except Exception as exc:
+        return f"(codex error: {exc})", None
+
+
+def _process_prompt(
+    client: mqtt.Client,
+    workspace_id: str,
+    topic_id: str,
+    payload: dict,  # type: ignore[type-arg]
+    repo_dir: str,
+) -> None:
+    message_id = payload.get("message_id") or str(uuid.uuid4())
+    worktree = payload.get("worktree", "")
+    branch = payload.get("branch", "")
+    text = payload.get("text", "")
+    session_id = payload.get("session_id")
+    adapter = payload.get("adapter", "claude-code")
+    subagent = payload.get("subagent")
+
+    if not text:
+        LOGGER.warning("agent.empty_prompt topic_id=%s", topic_id)
+        return
+
+    client.publish(_status_topic(workspace_id, topic_id), json.dumps({"state": "thinking"}), qos=0)
+    LOGGER.info("agent.llm_start topic_id=%s adapter=%s worktree=%s", topic_id, adapter, worktree)
+
+    try:
+        if worktree and branch and repo_dir:
+            _ensure_worktree(repo_dir, worktree, branch)
+    except Exception:
+        LOGGER.exception("agent.worktree_create_failed worktree=%s branch=%s", worktree, branch)
+
+    cwd = worktree if (worktree and Path(worktree).exists()) else repo_dir or "/"
+
+    if adapter == "codex":
+        response_text, new_session_id = _run_codex(cwd, text)
+    else:
+        response_text, new_session_id = _run_claude(cwd, text, session_id, subagent)
+
+    LOGGER.info("agent.llm_done topic_id=%s chars=%d", topic_id, len(response_text))
+
+    client.publish(
+        _response_topic(workspace_id, topic_id),
+        json.dumps({
+            "message_id": str(uuid.uuid4()),
+            "reply_to": message_id,
+            "last_response": response_text,
+            "transcript": None,
+            "session_id": new_session_id,
+        }),
+        qos=1,
+    )
+    client.publish(_status_topic(workspace_id, topic_id), json.dumps({"state": "idle"}), qos=0)
+
+
+def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -> None:  # type: ignore[type-arg]
+    if reason_code.is_failure:
+        LOGGER.error("agent.mqtt_connect_failed reason=%s", reason_code)
+        return
+    workspace_id = userdata["workspace_id"]
+    prompt_sub = f"codex-slack/workspace/{workspace_id}/topic/+/prompt"
+    client.subscribe(prompt_sub, qos=1)
+    LOGGER.info("agent.mqtt_connected subscribed=%s", prompt_sub)
+
+
+def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
+    LOGGER.warning("agent.mqtt_disconnected reason=%s", reason_code)
+
+
+def _on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
+    LOGGER.info("agent.mqtt_message topic=%s bytes=%d", msg.topic, len(msg.payload))
+    parsed = _parse_prompt_topic(msg.topic)
+    if parsed is None:
+        return
+    workspace_id, topic_id = parsed
+    try:
+        payload = json.loads(msg.payload)
+    except (json.JSONDecodeError, ValueError):
+        LOGGER.warning("agent.mqtt_parse_error topic=%s", msg.topic)
+        return
+    repo_dir = userdata.get("repo_dir", "")
+    _executor.submit(_process_prompt, client, workspace_id, topic_id, payload, repo_dir)
+
+
+def run_mqtt_loop(workspace_id: str, mqtt_host: str, mqtt_port: int, repo_dir: str = "") -> None:
+    userdata = {"workspace_id": workspace_id, "repo_dir": repo_dir}
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, userdata=userdata)
+    client.on_connect = _on_connect
+    client.on_disconnect = _on_disconnect
+    client.on_message = _on_message
+    client.connect(mqtt_host, mqtt_port, keepalive=60)
+    LOGGER.info("agent.mqtt_loop_start workspace_id=%s host=%s port=%s", workspace_id, mqtt_host, mqtt_port)
+    client.loop_forever()

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -58,7 +58,7 @@ def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str) -> None:
 
 
 def _run_claude(worktree: str, text: str, session_id: str | None, subagent: str | None) -> tuple[str, str | None]:
-    cmd = ["claude", "--print", "--no-permissions"]
+    cmd = ["claude", "--print", "--dangerously-skip-permissions"]
     if session_id:
         cmd += ["--resume", session_id]
     cmd.append(text)

--- a/src/agent/worker.py
+++ b/src/agent/worker.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import subprocess
 import time
+
+from .mqtt_loop import run_mqtt_loop
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +28,9 @@ class WorkerSettings:
     status_file: str
     codex_home: str
     ready_poll_seconds: float
+    workspace_id: str = ""
+    mqtt_host: str = "localhost"
+    mqtt_port: int = 1883
 
 
 def load_worker_settings() -> WorkerSettings:
@@ -37,6 +42,9 @@ def load_worker_settings() -> WorkerSettings:
         status_file=os.getenv("AGENT_STATUS_FILE", "/tmp/master-agent/status.json").strip(),
         codex_home=os.getenv("CODEX_HOME", "/home/appuser/.codex").strip(),
         ready_poll_seconds=float(os.getenv("AGENT_READY_POLL_SECONDS", "5")),
+        workspace_id=os.getenv("WORKSPACE_ID", "").strip(),
+        mqtt_host=os.getenv("MQTT_HOST", "localhost").strip(),
+        mqtt_port=int(os.getenv("MQTT_PORT", "1883")),
     )
 
 
@@ -174,9 +182,18 @@ def stage_workspace_prepare(settings: WorkerSettings) -> None:
 
 
 
-def stage_ready(settings: WorkerSettings) -> None:
-    while True:
-        time.sleep(settings.ready_poll_seconds)
+def stage_mqtt_loop(settings: WorkerSettings, repo_dir: str) -> None:
+    if not settings.workspace_id:
+        LOGGER.warning("agent.no_workspace_id — falling back to idle poll loop")
+        while True:
+            time.sleep(settings.ready_poll_seconds)
+        return
+    run_mqtt_loop(
+        workspace_id=settings.workspace_id,
+        mqtt_host=settings.mqtt_host,
+        mqtt_port=settings.mqtt_port,
+        repo_dir=repo_dir,
+    )
 
 
 
@@ -214,7 +231,7 @@ def run_worker(settings: WorkerSettings) -> int:
             },
         )
         emit_stage_event("ready", "ok", "agent worker ready")
-        stage_ready(settings)
+        stage_mqtt_loop(settings, repo_dir=str(repo_dir))
         return 0
     except AgentInitError as exc:
         write_status(

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -58,7 +58,7 @@ def send_message(workspace_id: str, topic_id: str, body: MessageSend, request: R
         if conn.execute("SELECT 1 FROM workspaces WHERE id = ?", (workspace_id,)).fetchone() is None:
             raise HTTPException(404, "workspace not found")
         topic = conn.execute(
-            "SELECT id, worktree_path FROM topics WHERE id = ? AND workspace_id = ?",
+            "SELECT id, worktree_path, branch_name FROM topics WHERE id = ? AND workspace_id = ?",
             (topic_id, workspace_id),
         ).fetchone()
         if topic is None:
@@ -86,8 +86,10 @@ def send_message(workspace_id: str, topic_id: str, body: MessageSend, request: R
 
     payload = json.dumps({
         "message_id": message_id,
+        "adapter": agent["adapter"],
         "subagent": agent["subagent"],
         "worktree": topic["worktree_path"],
+        "branch": topic["branch_name"],
         "session_id": llm_session_id,
         "text": body.text.strip(),
         "attachments": [],

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.agent.mqtt_loop import (
+    _parse_prompt_topic,
+    _process_prompt,
+    _run_claude,
+    _run_codex,
+    _ensure_worktree,
+    _on_connect,
+    _on_message,
+)
+
+
+# --- _parse_prompt_topic ---
+
+def test_parse_prompt_topic_valid():
+    raw = "codex-slack/workspace/ws1/topic/t1/prompt"
+    assert _parse_prompt_topic(raw) == ("ws1", "t1")
+
+
+def test_parse_prompt_topic_rejects_response():
+    raw = "codex-slack/workspace/ws1/topic/t1/response"
+    assert _parse_prompt_topic(raw) is None
+
+
+def test_parse_prompt_topic_rejects_malformed():
+    assert _parse_prompt_topic("too/short") is None
+    assert _parse_prompt_topic("a/b/c/d/e/f/g") is None
+
+
+# --- _run_claude ---
+
+def test_run_claude_returns_stdout(tmp_path):
+    with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="Hello from claude\n", stderr="", returncode=0)
+        text, session = _run_claude(str(tmp_path), "say hi", None, None)
+    assert text == "Hello from claude"
+    assert session is None
+
+
+def test_run_claude_includes_resume_when_session_id(tmp_path):
+    with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
+        _run_claude(str(tmp_path), "continue", "ses-123", None)
+    cmd = mock_run.call_args.args[0]
+    assert "--resume" in cmd
+    assert "ses-123" in cmd
+
+
+def test_run_claude_not_found(tmp_path):
+    import subprocess as sp
+    with patch("src.agent.mqtt_loop.subprocess.run", side_effect=FileNotFoundError()):
+        text, _ = _run_claude(str(tmp_path), "hi", None, None)
+    assert "not found" in text
+
+
+def test_run_claude_timeout(tmp_path):
+    import subprocess as sp
+    with patch("src.agent.mqtt_loop.subprocess.run", side_effect=sp.TimeoutExpired("claude", 300)):
+        text, _ = _run_claude(str(tmp_path), "hi", None, None)
+    assert "timed out" in text
+
+
+# --- _run_codex ---
+
+def test_run_codex_returns_stdout(tmp_path):
+    with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="codex output\n", stderr="", returncode=0)
+        text, session = _run_codex(str(tmp_path), "do it")
+    assert text == "codex output"
+    assert session is None
+
+
+def test_run_codex_not_found(tmp_path):
+    with patch("src.agent.mqtt_loop.subprocess.run", side_effect=FileNotFoundError()):
+        text, _ = _run_codex(str(tmp_path), "hi")
+    assert "not found" in text
+
+
+# --- _ensure_worktree ---
+
+def test_ensure_worktree_skips_when_exists(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
+        _ensure_worktree(str(tmp_path / "repo"), str(wt), "feat/test")
+    mock_run.assert_not_called()
+
+
+def test_ensure_worktree_creates_with_new_branch(tmp_path):
+    wt = tmp_path / "wt"
+    with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        _ensure_worktree(str(tmp_path / "repo"), str(wt), "feat/new")
+    args = mock_run.call_args.args[0]
+    assert "worktree" in args
+    assert "add" in args
+    assert "-b" in args
+
+
+def test_ensure_worktree_falls_back_on_existing_branch(tmp_path):
+    import subprocess as sp
+    wt = tmp_path / "wt"
+    calls = []
+
+    def side_effect(cmd, **kwargs):
+        calls.append(cmd)
+        if "-b" in cmd:
+            raise sp.CalledProcessError(128, cmd)
+        return MagicMock(returncode=0)
+
+    with patch("src.agent.mqtt_loop.subprocess.run", side_effect=side_effect):
+        _ensure_worktree(str(tmp_path / "repo"), str(wt), "feat/existing")
+
+    assert len(calls) == 2
+    assert "-b" in calls[0]
+    assert "-b" not in calls[1]
+
+
+# --- _process_prompt ---
+
+def test_process_prompt_publishes_thinking_then_response(tmp_path):
+    client = MagicMock()
+    with patch("src.agent.mqtt_loop._run_claude", return_value=("response text", None)):
+        with patch("src.agent.mqtt_loop._ensure_worktree"):
+            _process_prompt(
+                client, "ws1", "t1",
+                {"message_id": "m1", "text": "hello", "adapter": "claude-code",
+                 "worktree": str(tmp_path), "branch": "feat/t", "session_id": None},
+                repo_dir=str(tmp_path),
+            )
+    published_topics = [c.args[0] for c in client.publish.call_args_list]
+    assert any("status" in t for t in published_topics)
+    assert any("response" in t for t in published_topics)
+
+
+def test_process_prompt_uses_codex_adapter(tmp_path):
+    client = MagicMock()
+    with patch("src.agent.mqtt_loop._run_codex", return_value=("codex out", None)) as mock_codex:
+        with patch("src.agent.mqtt_loop._ensure_worktree"):
+            _process_prompt(
+                client, "ws1", "t1",
+                {"message_id": "m1", "text": "run it", "adapter": "codex",
+                 "worktree": str(tmp_path), "branch": "feat/t", "session_id": None},
+                repo_dir=str(tmp_path),
+            )
+    mock_codex.assert_called_once()
+
+
+def test_process_prompt_skips_empty_text(tmp_path):
+    client = MagicMock()
+    _process_prompt(
+        client, "ws1", "t1",
+        {"message_id": "m1", "text": "", "adapter": "claude-code",
+         "worktree": str(tmp_path), "branch": "feat/t", "session_id": None},
+        repo_dir=str(tmp_path),
+    )
+    client.publish.assert_not_called()
+
+
+def test_process_prompt_response_payload_fields(tmp_path):
+    client = MagicMock()
+    with patch("src.agent.mqtt_loop._run_claude", return_value=("the answer", None)):
+        with patch("src.agent.mqtt_loop._ensure_worktree"):
+            _process_prompt(
+                client, "ws1", "t1",
+                {"message_id": "orig-id", "text": "q", "adapter": "claude-code",
+                 "worktree": str(tmp_path), "branch": "feat/t", "session_id": None},
+                repo_dir=str(tmp_path),
+            )
+    # Find the response publish call
+    response_call = next(
+        c for c in client.publish.call_args_list
+        if "response" in c.args[0]
+    )
+    payload = json.loads(response_call.args[1])
+    assert payload["reply_to"] == "orig-id"
+    assert payload["last_response"] == "the answer"
+    assert "message_id" in payload
+
+
+# --- _on_message dispatch ---
+
+def test_on_message_submits_to_executor():
+    client = MagicMock()
+    userdata = {"workspace_id": "ws1", "repo_dir": "/repo"}
+    msg = MagicMock()
+    msg.topic = "codex-slack/workspace/ws1/topic/t1/prompt"
+    msg.payload = json.dumps({"text": "hi", "adapter": "claude-code"}).encode()
+
+    with patch("src.agent.mqtt_loop._executor") as mock_exec:
+        _on_message(client, userdata, msg)
+    mock_exec.submit.assert_called_once()
+
+
+def test_on_message_ignores_malformed_json():
+    client = MagicMock()
+    userdata = {"workspace_id": "ws1", "repo_dir": ""}
+    msg = MagicMock()
+    msg.topic = "codex-slack/workspace/ws1/topic/t1/prompt"
+    msg.payload = b"not-json"
+    with patch("src.agent.mqtt_loop._executor") as mock_exec:
+        _on_message(client, userdata, msg)
+    mock_exec.submit.assert_not_called()
+
+
+# --- _on_connect ---
+
+def test_on_connect_subscribes_to_workspace_topic():
+    client = MagicMock()
+    reason = MagicMock()
+    reason.is_failure = False
+    _on_connect(client, {"workspace_id": "ws42"}, None, reason, None)
+    topic = client.subscribe.call_args.args[0]
+    assert "ws42" in topic
+    assert topic.endswith("/prompt")

--- a/tests/agent/test_worker.py
+++ b/tests/agent/test_worker.py
@@ -7,7 +7,7 @@ import subprocess
 import pytest
 
 from src.agent import worker
-from src.agent.worker import AgentInitError, WorkerSettings, run_worker, stage_preflight, stage_repo_sync, stage_workspace_prepare
+from src.agent.worker import AgentInitError, WorkerSettings, run_worker, stage_preflight, stage_repo_sync, stage_workspace_prepare, stage_mqtt_loop
 
 
 def _git(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -187,7 +187,7 @@ def test_run_worker_success_writes_ready_status(tmp_path, monkeypatch) -> None: 
         ready_poll_seconds=0.1,
     )
 
-    monkeypatch.setattr(worker, "stage_ready", lambda _settings: None)
+    monkeypatch.setattr(worker, "stage_mqtt_loop", lambda _settings, repo_dir: None)
 
     code = run_worker(settings)
     assert code == 0


### PR DESCRIPTION
## Summary
- Add \`src/agent/mqtt_loop.py\`: agent subscribes to \`codex-slack/workspace/{wid}/topic/+/prompt\`, invokes \`claude\` or \`codex\` CLI in the topic worktree, and publishes \`status\` (thinking/idle) and \`response\` back to MQTT
- Worktrees are created on-demand when the first prompt for a topic arrives; falls back gracefully if the branch already exists
- Add \`workspace_id\`, \`mqtt_host\`, \`mqtt_port\` to \`WorkerSettings\` (read from \`WORKSPACE_ID\` / \`MQTT_HOST\` / \`MQTT_PORT\`); \`stage_ready()\` idle poll replaced by \`stage_mqtt_loop()\`
- Master prompt payload extended with \`adapter\` and \`branch\` fields so the agent knows which CLI to invoke and which branch to use for the worktree; fix claude CLI flag to \`--dangerously-skip-permissions\`

## Test plan
- [ ] 154 unit tests pass: \`python -m pytest tests/master/ tests/agent/ -q\`
- [ ] Start agent container with \`WORKSPACE_ID\`, \`MQTT_HOST\`, \`MQTT_PORT\`, \`CLAUDE_CODE_OAUTH_TOKEN\` env vars
- [ ] Agent logs show \`agent.mqtt_connected subscribed=...topic/+/prompt\`
- [ ] Create a workspace and topic via the frontend at \`http://<host>:8080/\`
- [ ] Send a message from the TopicChat view — agent logs show \`agent.llm_start\` then \`agent.llm_done\`
- [ ] Git worktree created on first message: \`agent.worktree_created\` in logs
- [ ] Agent response appears in the chat UI via WebSocket within ~10s
- [ ] Subsequent messages to same topic reuse the existing worktree (\`agent.worktree_reused\` or no creation log)
- [ ] Testbed verified end-to-end: real Claude response ("2 + 2 = 4.") confirmed

🤖 Generated with repository automation