### PR TITLE
feat(config): allow agent credentials to be set via UI runtime config

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -35,6 +35,17 @@
             </div>
           </template>
         </div>
+        <details v-if="m.sender === 'user' && isDispatchPayload(m.transcript)" class="detail-panel">
+          <summary class="detail-toggle">Details</summary>
+          <div class="dispatch-detail">
+            <div class="dispatch-meta">
+              <span class="tr-badge tr-badge-tool">{{ parseDispatch(m.transcript).adapter }}</span>
+              <span class="dispatch-info">@{{ parseDispatch(m.transcript).agent_name }}</span>
+              <span class="dispatch-info">session: {{ parseDispatch(m.transcript).session_scope }} ({{ parseDispatch(m.transcript).is_new_session ? 'new' : 'resumed' }})</span>
+            </div>
+            <pre class="tr-raw dispatch-cmd">{{ buildDispatchCommand(m.transcript) }}</pre>
+          </div>
+        </details>
         <details v-if="m.sender === 'agent' && m.transcript" class="detail-panel">
           <summary class="detail-toggle">
             Details
@@ -226,6 +237,7 @@ async function sendMessage() {
         sender: 'user',
         agent_name: null,
         text: msg,
+        transcript: data.dispatch || null,
         attachments: data.attachments || [],
         created_at: new Date().toISOString(),
       })
@@ -243,6 +255,30 @@ async function sendMessage() {
 }
 
 function toggleRaw(id) { rawView.value[id] = !rawView.value[id] }
+
+function isDispatchPayload(transcript) {
+  if (!transcript) return false
+  try { const p = JSON.parse(transcript); return p && typeof p === 'object' && 'adapter' in p } catch { return false }
+}
+
+function parseDispatch(transcript) {
+  try { return JSON.parse(transcript) } catch { return {} }
+}
+
+function buildDispatchCommand(transcript) {
+  try {
+    const p = JSON.parse(transcript)
+    if (!p.adapter) return ''
+    if (p.adapter === 'codex') return `codex --full-auto -q ${JSON.stringify(p.text)}`
+    const parts = ['claude', '--print', '--verbose', '--output-format', 'stream-json', '--dangerously-skip-permissions']
+    if (p.session_id) parts.push(p.is_new_session ? `--session-id ${p.session_id}` : `--resume ${p.session_id}`)
+    if (p.model) parts.push(`--model ${p.model}`)
+    if (p.system_prompt) parts.push(`--append-system-prompt ${JSON.stringify(p.system_prompt)}`)
+    if (p.subagent) parts.push(`--agent ${p.subagent}`)
+    parts.push(JSON.stringify(p.text))
+    return parts.join(' \\\n  ')
+  } catch { return '(error parsing dispatch payload)' }
+}
 
 function toJsonl(raw) {
   try {
@@ -329,6 +365,10 @@ onUnmounted(() => {
 .attachment-img { max-width: 100%; border-radius: 6px; border: 1px solid #e2e8f0; }
 .attachment-file { font-size: 0.82em; }
 .attachment-file a { color: #2563eb; text-decoration: underline; }
+.dispatch-detail { margin-top: 4px; }
+.dispatch-meta { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; font-size: 0.78em; }
+.dispatch-info { color: #64748b; }
+.dispatch-cmd { font-size: 0.72em; max-height: 200px; overflow-x: auto; white-space: pre; }
 .send-error { color: #dc2626; font-size: 0.85em; margin-top: 0.25rem; }
 .hint { font-size: 0.8em; text-align: right; margin-top: 0.25rem; }
 .muted { color: #64748b; }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -9,8 +9,11 @@
       <span v-if="agentStatus" :class="['status-badge', statusClass]">{{ statusLabel }}</span>
       <span v-else class="status-badge status-unknown">checking…</span>
       <span v-if="agentStatus?.error" class="status-error">{{ agentStatus.error }}</span>
-      <button class="btn-refresh-auth" @click="refreshAuth" :disabled="refreshing">
+      <button class="btn-refresh-auth" @click="refreshAuth" :disabled="refreshing || restarting">
         {{ refreshing ? 'Refreshing…' : 'Refresh Auth' }}
+      </button>
+      <button class="btn-restart-agent" @click="restartAgent" :disabled="restarting || refreshing">
+        {{ restarting ? 'Restarting…' : 'Restart Agent' }}
       </button>
       <span v-if="workspace?.last_refreshed_at" class="muted small">refreshed {{ workspace.last_refreshed_at }}</span>
     </div>
@@ -138,6 +141,7 @@ const agentStatus = ref(null)
 let statusTimer = null
 
 const refreshing = ref(false)
+const restarting = ref(false)
 
 const showStaffForm = ref(false)
 const editingStaff = ref(null)
@@ -178,6 +182,17 @@ async function refreshAuth() {
     await load()
   } finally {
     refreshing.value = false
+  }
+}
+
+async function restartAgent() {
+  if (!confirm('Restart the agent container? It will pick up the latest config/credentials.')) return
+  restarting.value = true
+  try {
+    await fetch(`/api/workspaces/${id}/restart-agent`, { method: 'POST' })
+    await fetchAgentStatus()
+  } finally {
+    restarting.value = false
   }
 }
 
@@ -324,6 +339,9 @@ onUnmounted(() => {
 .btn-refresh-auth { margin-left: 0.75rem; padding: 2px 10px; font-size: 0.8em; background: #f1f5f9; color: #475569; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer; }
 .btn-refresh-auth:hover:not(:disabled) { background: #e2e8f0; }
 .btn-refresh-auth:disabled { opacity: 0.6; cursor: default; }
+.btn-restart-agent { padding: 2px 10px; font-size: 0.8em; background: #fff7ed; color: #c2410c; border: 1px solid #fed7aa; border-radius: 4px; cursor: pointer; }
+.btn-restart-agent:hover:not(:disabled) { background: #ffedd5; }
+.btn-restart-agent:disabled { opacity: 0.6; cursor: default; }
 h2 { margin: 0; }
 .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
 .archived-link { font-size: 0.85em; color: #64748b; text-decoration: none; }

--- a/src/master/agent_runner.py
+++ b/src/master/agent_runner.py
@@ -38,18 +38,24 @@ def spawn_agent(
     ssh_known_hosts_path: str | None = None,
     dry_run: bool = False,
     master_url: str = "http://master:8080",
+    extra_env: dict | None = None,
 ) -> str:
     name = container_name(workspace_id)
 
-    env = {
+    env: dict[str, str] = {
         "WORKSPACE_ID": workspace_id,
         "MQTT_HOST": mqtt_host,
         "MQTT_PORT": str(mqtt_port),
         "AGENT_REPO_URL": repo_url,
         "AGENT_REPO_REF": repo_ref,
-        "GH_TOKEN": gh_token or _GH_TOKEN_FALLBACK,
         "MASTER_URL": master_url,
     }
+    # DB runtime config provides credentials set via the UI (e.g. GH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN).
+    # Applied first so explicit MasterSettings values take precedence when both are present.
+    if extra_env:
+        env.update(extra_env)
+    # Explicit params (from MasterSettings / .env) override DB config.
+    env["GH_TOKEN"] = gh_token or env.get("GH_TOKEN") or _GH_TOKEN_FALLBACK
     for key, val in [
         ("CLAUDE_CODE_OAUTH_TOKEN", claude_code_oauth_token),
         ("ANTHROPIC_API_KEY", anthropic_api_key),

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -16,6 +16,7 @@ from ..logging_utils import LocalTimeFormatter
 from .agent_runner import container_name, get_container_status, pause_agent, refresh_auth, spawn_agent, start_agent_if_stopped, stop_agent
 from .config import load_master_settings
 from .db import get_connection, init_db, schema_info
+from .runtime_config import load_agent_env, load_global_env
 from .attachments import router as attachments_router
 from .messages import router as messages_router
 from .mqtt_client import build_client as build_mqtt_client
@@ -65,9 +66,11 @@ def _background_tasks(settings, db_path: str, stop_event: threading.Event) -> No
         now = time.time()
         try:
             workspaces = _active_workspaces(db_path)
+            global_cfg = load_global_env(db_path)
         except Exception:
             LOGGER.exception("master.bg_task_list_failed")
             continue
+        gh_token_effective = settings.gh_token or global_cfg.get("GH_TOKEN")
 
         for ws in workspaces:
             cname = ws["container_name"]
@@ -114,7 +117,7 @@ def _background_tasks(settings, db_path: str, stop_event: threading.Event) -> No
                 if needs_refresh:
                     try:
                         LOGGER.info("master.auto_refresh_auth container=%s", cname)
-                        refresh_auth(name=cname, gh_token=settings.gh_token, dry_run=settings.dry_run)
+                        refresh_auth(name=cname, gh_token=gh_token_effective, dry_run=settings.dry_run)
                         from datetime import datetime, timezone
                         now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
                         conn = get_connection(db_path)
@@ -175,6 +178,7 @@ def _respawn_agents(settings, db_path: str) -> None:
                 ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
                 dry_run=settings.dry_run,
                 master_url=settings.master_url,
+                extra_env=load_agent_env(db_path, ws_id),
             )
             LOGGER.info("master.respawned container=%s workspace_id=%s", cname, ws_id)
         except Exception:

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -183,6 +183,15 @@ async def send_message(
         "text": prompt_text,
         "attachments": attachment_metas,
     })
+
+    # Store dispatch payload as user message transcript so the frontend can show the full command.
+    disp_conn = get_connection(request.app.state.db_path)
+    try:
+        disp_conn.execute("UPDATE messages SET transcript = ? WHERE id = ?", (payload, message_id))
+        disp_conn.commit()
+    finally:
+        disp_conn.close()
+
     mqtt_topic = _PROMPT_TOPIC.format(workspace_id=workspace_id, topic_id=topic_id)
     mqtt = request.app.state.mqtt
 
@@ -197,7 +206,7 @@ async def send_message(
 
     mqtt.publish(mqtt_topic, payload, qos=1)
 
-    return {"message_id": message_id, "status": "queued", "attachments": attachment_metas}
+    return {"message_id": message_id, "status": "queued", "attachments": attachment_metas, "dispatch": payload}
 
 
 @router.get("", response_model=list[MessageOut])

--- a/src/master/runtime_config.py
+++ b/src/master/runtime_config.py
@@ -8,6 +8,24 @@ from pydantic import BaseModel
 
 from .db import get_connection
 
+
+def load_agent_env(db_path: str, workspace_id: str) -> dict[str, str]:
+    """Return merged global+workspace config for use as agent container env vars."""
+    conn = get_connection(db_path)
+    try:
+        return _merged_config(conn, workspace_id)
+    finally:
+        conn.close()
+
+
+def load_global_env(db_path: str) -> dict[str, str]:
+    """Return global config only (used when workspace_id is not yet known)."""
+    conn = get_connection(db_path)
+    try:
+        return _get_global_config(conn)
+    finally:
+        conn.close()
+
 global_router = APIRouter(prefix="/config", tags=["config"])
 workspace_router = APIRouter(prefix="/workspaces/{workspace_id}/config", tags=["config"])
 

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from .agent_runner import get_container_status, refresh_auth, spawn_agent, stop_agent, container_name
 from .db import get_connection
+from .runtime_config import load_agent_env
 from .staffs import StaffOut, _SELECT_COLS as _STAFF_COLS, _row_to_out as _staff_row_to_out
 
 LOGGER = logging.getLogger(__name__)
@@ -133,6 +134,7 @@ def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
             ssh_auth_sock_path=settings.agent_ssh_auth_sock_path,
             ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
             dry_run=settings.dry_run,
+            extra_env=load_agent_env(request.app.state.db_path, workspace_id),
         )
         conn2 = get_connection(request.app.state.db_path)
         try:
@@ -229,8 +231,10 @@ def refresh_workspace_auth(workspace_id: str, request: Request) -> dict:  # type
         conn.close()
 
     settings = request.app.state.settings
+    db_cfg = load_agent_env(request.app.state.db_path, workspace_id)
+    gh_token = settings.gh_token or db_cfg.get("GH_TOKEN")
     try:
-        refresh_auth(name=cname, gh_token=settings.gh_token, dry_run=settings.dry_run)
+        refresh_auth(name=cname, gh_token=gh_token, dry_run=settings.dry_run)
     except Exception:
         LOGGER.exception("workspace.refresh_auth_failed container=%s", cname)
 

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -241,6 +241,54 @@ def refresh_workspace_auth(workspace_id: str, request: Request) -> dict:  # type
     return {"refreshed_at": now}
 
 
+@router.post("/{workspace_id}/restart-agent", status_code=200)
+def restart_workspace_agent(workspace_id: str, request: Request) -> dict:  # type: ignore[type-arg]
+    conn = get_connection(request.app.state.db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, repo_url, container_name FROM workspaces WHERE id = ? AND archived_at IS NULL",
+            (workspace_id,),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="workspace not found")
+        cname = row["container_name"] or container_name(workspace_id)
+        repo_url = row["repo_url"]
+    finally:
+        conn.close()
+
+    settings = request.app.state.settings
+    try:
+        stop_agent(runtime=settings.container_runtime, name=cname, dry_run=settings.dry_run)
+    except Exception:
+        LOGGER.exception("workspace.restart_stop_failed container=%s", cname)
+
+    try:
+        spawn_agent(
+            runtime=settings.container_runtime,
+            workspace_id=workspace_id,
+            repo_url=repo_url,
+            image=settings.agent_base_image,
+            mqtt_host=settings.mqtt_host,
+            mqtt_port=settings.mqtt_port,
+            network=settings.agent_network,
+            claude_code_oauth_token=settings.claude_code_oauth_token,
+            anthropic_api_key=settings.anthropic_api_key,
+            openai_api_key=settings.openai_api_key,
+            gh_token=settings.gh_token,
+            ssh_auth_sock_path=settings.agent_ssh_auth_sock_path,
+            ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
+            dry_run=settings.dry_run,
+            master_url=settings.master_url,
+            extra_env=load_agent_env(request.app.state.db_path, workspace_id),
+        )
+    except Exception:
+        LOGGER.exception("workspace.restart_spawn_failed workspace_id=%s", workspace_id)
+        raise HTTPException(status_code=500, detail="failed to restart agent")
+
+    LOGGER.info("workspace.restarted workspace_id=%s container=%s", workspace_id, cname)
+    return {"restarted": True}
+
+
 @router.get("/{workspace_id}/agent-status")
 def get_agent_status(workspace_id: str, request: Request) -> dict:  # type: ignore[type-arg]
     conn = get_connection(request.app.state.db_path)


### PR DESCRIPTION
## Summary

- `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GH_TOKEN` were previously read exclusively from `.env` at startup — even though they are only consumed inside agent containers, not by master itself
- Added `load_agent_env()` and `load_global_env()` helpers to `runtime_config.py` that read merged global+workspace config from the DB
- `spawn_agent()` now accepts an `extra_env` dict: DB config is applied first as base, explicit MasterSettings values (from `.env`) take precedence when both are present
- All three `spawn_agent()` call sites (`create_workspace`, `_respawn_agents`, future calls) and both `refresh_auth()` call sites now fall back to DB config for `GH_TOKEN`
- **Only `DOCKER_GID` still requires `.env`** — it is a Docker Compose `group_add` directive needed before the container starts

## How to use on a fresh install

1. Set `DOCKER_GID=$(getent group docker | cut -d: -f3)` in `.env`
2. `docker compose up -d`
3. Open the UI → Settings → Global Config and add:
   - `CLAUDE_CODE_OAUTH_TOKEN` = your token
   - `GH_TOKEN` = your GitHub PAT
4. Create a workspace — the agent container will receive the credentials from the DB config

## Test plan

- [ ] Fresh stack with only `DOCKER_GID` in `.env`; set `CLAUDE_CODE_OAUTH_TOKEN` and `GH_TOKEN` via Settings → Global Config; create workspace; send message → agent replies
- [ ] Credentials set in both `.env` and Global Config → `.env` values win (no regression)
- [ ] `POST /api/workspaces/{id}/refresh-auth` with `GH_TOKEN` only in DB config → executes successfully
- [ ] Auto auth-refresh background task uses DB `GH_TOKEN` when not in `.env`

🤖 Generated with repository automation