### PR TITLE
fix(agent): remove 300s LLM timeout

### DIFF
--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -15,7 +15,7 @@ import paho.mqtt.client as mqtt
 LOGGER = logging.getLogger(__name__)
 
 _TOPIC_PARTS = 6  # codex-slack/workspace/{wid}/topic/{tid}/prompt
-_LLM_TIMEOUT = 300
+_LLM_TIMEOUT = None  # no timeout — claude/codex can run as long as needed
 
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="agent-llm")
 


### PR DESCRIPTION
## Summary

- Removes the hard 300-second timeout on `subprocess.run` for both `claude` and `codex` CLI invocations
- Long tasks (large refactors, multi-file edits) were being killed with `(claude timed out after 300s)` before completing
- `timeout=None` lets the process run until it exits naturally

## Test plan

- [ ] Send a prompt that takes longer than 5 minutes — agent should complete and reply normally instead of returning a timeout message

🤖 Generated with repository automation