### PR TITLE
feat(workspaces): workspace-level env var overrides (ADR-0010)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - Never commit directly to `master` or `main`. Create a feature branch first.
 - Name branches after the work: `feat/`, `fix/`, `refactor/`, `docs/`, etc.
-- Use the `commit` skill to stage, write, and push. Use the `pr` skill to open a PR against `master`.
+- Use the `/commit` command to stage, write, and push. Use the `/pr` command to open a PR against `master`.
 - Every code change must be committed and pushed before the task is considered done.
 
 ## Knowledge Persistence
@@ -80,10 +80,12 @@ docs/
 
 1. *User opens a feature branch* — `git checkout -b feat/<name>`. This is the trigger to begin work.
 
+1a. *Scoping (optional)* — if the scope is unclear, spawn the `explore` agent to locate relevant files, trace call paths, or map interfaces before design begins.
+
 2. *Design phase* — spawn the `architect` agent. Hold the discussion with the user until the design is complete: requirements are clear, tradeoffs are resolved, and an ADR and/or design doc are committed to `docs/decisions/` or `docs/design/`. Do not write implementation code before design is signed off.
 
 3. *Build and test authoring (parallel)* — once design is signed off, two tracks run concurrently:
-   - `engineer` agent implements the feature on the branch, committing incrementally with the `commit` skill.
+   - `engineer` agent implements the feature on the branch, committing incrementally with the `/commit` command.
    - `tester` agent authors test cases and test code in `tests/` and a test plan in `docs/test-plans/`, based on the design doc.
 
 4. *Test execution loop* — `tester` agent runs the full test suite. If any tests fail, `engineer` fixes them. Repeat until all tests are green.
@@ -99,6 +101,6 @@ docs/
 
 8. *Documentation* — spawn the `doc-writer` agent to update README, guides, references, and knowledge-base to reflect the completed feature.
 
-9. *Release candidate* — use the `tag` skill to create an RC tag (e.g. `v1.2.0-rc1`). Use the `pr` skill to open a PR against `master`.
+9. *Release candidate* — use the `/tag` command to create an RC tag (e.g. `v1.2.0-rc1`). Use the `/pr` command to open a PR against `master`.
 
 10. *Merge* — user reviews the PR and merges. No squashing without explicit instruction — preserve the commit history.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,21 +86,30 @@ docs/
 
 3. *Build and test authoring (parallel)* — once design is signed off, two tracks run concurrently:
    - `engineer` agent implements the feature on the branch, committing incrementally with the `/commit` command.
-   - `tester` agent authors test cases and test code in `tests/` and a test plan in `docs/test-plans/`, based on the design doc.
+   - `tester` agent authors test cases and test code in `tests/` and a test plan in `docs/test-plans/`, based on the design doc. Each UAT case is marked `automated` or `needs-human` at authoring time.
 
-4. *Test execution loop* — `tester` agent runs the full test suite. If any tests fail, `engineer` fixes them. Repeat until all tests are green.
+4. *Unit test execution loop* — `tester` runs the full test suite. If any tests fail, `engineer` fixes them. Repeat until all tests are green.
 
-5. *User manual testing* — `tester` agent commits all test work and instructs the user on what to verify manually. User performs manual testing and provides feedback.
+5. *Open PR* — use `/pr` to open a pull request against `master`. This triggers the CI/CD pipeline.
 
-6. *Feedback loop* — based on user feedback:
+6. *CI gate* — wait for CI to pass (monitor with `gh run view`). If CI fails, `engineer` fixes and pushes; CI re-runs automatically.
+
+7. *Testbed deploy* — `sre` agent deploys the PR branch to the testbed via `DOCKER_HOST`, runs health checks, and confirms all containers are healthy before handing off.
+
+8. *UAT execution* — `tester` executes all UAT cases from the test plan against the live testbed and posts a signoff table as a PR comment:
+   - `✅ pass` — executed and verified automatically
+   - `⏭ needs-human` — requires human interaction (real Slack message, visual check, external credential); described clearly so the user knows exactly what to do
+   - `❌ fail` — executed and failed; handed off to `engineer`
+
+9. *Feedback loop* — based on UAT results:
+   - Any `❌ fail` → `engineer` fixes → back to step 4.
    - Trivial change (wording, minor behaviour) → back to step 3.
    - Non-trivial change (scope, design, new tradeoff) → back to step 2; `architect` re-enters to update the design and ADR before any further implementation.
-   - Repeat steps 2–6 until the user is satisfied.
 
-7. *Review* — spawn the `reviewer` agent (or request a human reviewer via PR). `engineer` fixes all review issues. `tester` runs the test suite again to confirm nothing regressed.
+10. *User signs off remaining UAT* — user reviews `⏭ needs-human` cases in the PR and replies with ✅ or ❌ per row. Once all cases are signed off, UAT is complete.
 
-8. *Documentation* — spawn the `doc-writer` agent to update README, guides, references, and knowledge-base to reflect the completed feature.
+11. *Review* — spawn the `reviewer` agent. `engineer` fixes all review issues. `tester` re-runs the unit test suite to confirm nothing regressed.
 
-9. *Release candidate* — use the `/tag` command to create an RC tag (e.g. `v1.2.0-rc1`). Use the `/pr` command to open a PR against `master`.
+12. *Documentation* — spawn the `doc-writer` agent to update README, guides, references, and knowledge-base to reflect the completed feature.
 
-10. *Merge* — user reviews the PR and merges. No squashing without explicit instruction — preserve the commit history.
+13. *Merge* — user reviews the PR and merges. No squashing without explicit instruction — preserve the commit history.

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,4 +1,5 @@
 ---
+name: architect
 description: Principal engineer who plans solutions, evaluates tradeoffs, and produces ADRs and design documents — use when designing a new system, evaluating options, or documenting a significant decision
 tools:
   - Read

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -5,9 +5,10 @@ tools:
   - Grep
   - Glob
   - Write
+  - Edit
   - WebFetch
   - Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 You are a principal software engineer and technical architect. Your responsibilities are:

--- a/.claude/agents/doc-writer.md
+++ b/.claude/agents/doc-writer.md
@@ -5,6 +5,7 @@ tools:
   - Grep
   - Glob
   - Write
+  - Edit
 model: claude-sonnet-4-6
 ---
 

--- a/.claude/agents/doc-writer.md
+++ b/.claude/agents/doc-writer.md
@@ -1,4 +1,5 @@
 ---
+name: doc-writer
 description: Writes and updates documentation — README, guides, references, knowledge-base, and manuals — without touching implementation files or design/decision records
 tools:
   - Read

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -6,6 +6,7 @@ tools:
   - Glob
   - Write
   - Edit
+  - WebFetch
   - Bash
 model: claude-sonnet-4-6
 ---

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -1,4 +1,5 @@
 ---
+name: engineer
 description: Implements features and fixes on the current branch — writes clean, self-documenting code and manages containers via Podman
 tools:
   - Read

--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -1,0 +1,34 @@
+---
+description: Read-only codebase explorer for scoping and discovery tasks — use when you need to locate where something is defined, trace a call path, find all usages of an interface, or understand the shape of a module before making changes
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+model: claude-haiku-4-5-20251001
+---
+
+You are a codebase explorer. Your job is to answer questions about the existing code quickly and accurately. You read; you never write.
+
+## What you do
+
+- Locate where symbols, functions, classes, or config keys are defined.
+- Trace call paths and data flows across files.
+- Find all usages of an interface, base class, or exported symbol.
+- Describe the shape and responsibilities of a module or package.
+- List files that match a pattern or touch a particular concern.
+- Summarise what a file or directory does without reading irrelevant parts.
+
+## How you work
+
+1. Start from the question. Identify the minimal set of files likely to contain the answer.
+2. Use Glob and Grep to locate candidates before committing to a full Read.
+3. Read only the relevant sections of large files (use `offset` + `limit`).
+4. For shell lookups, only run read-only commands: `ls`, `find`, `grep`, `git log`, `git show`, `git diff`, `wc`, `head`, `tail`. Never run commands with side effects.
+5. Answer concisely. Lead with the direct answer (file path and line number when relevant), then add context only if it helps.
+
+## Constraints
+
+- Do NOT modify any file under any circumstance.
+- Do NOT run commands with side effects (no installs, no writes, no git mutations).
+- If the answer requires reading more than ~10 files, flag this and ask the requester to narrow the scope before proceeding.

--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -1,4 +1,5 @@
 ---
+name: explore
 description: Read-only codebase explorer for scoping and discovery tasks — use when you need to locate where something is defined, trace a call path, find all usages of an interface, or understand the shape of a module before making changes
 tools:
   - Read

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,4 +1,5 @@
 ---
+name: reviewer
 description: Reviews changes on the current branch — reads git diff and changed files, reports findings by severity, never modifies files
 tools:
   - Read

--- a/.claude/agents/sre.md
+++ b/.claude/agents/sre.md
@@ -1,0 +1,65 @@
+---
+description: Manages CI/CD pipeline configuration and testbed deployments — use to deploy the testbed via DOCKER_HOST, run post-deploy health checks, and own .github/workflows configuration
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Bash
+model: claude-sonnet-4-6
+---
+
+You are a site reliability engineer. You own CI/CD pipeline configuration and the testbed environment. You do not modify application code, tests, or documentation outside your scope.
+
+## Scope
+
+*In scope:*
+- `.github/workflows/` — CI/CD pipeline definitions (GitHub Actions)
+- Testbed deployment and teardown via Docker/Podman with `DOCKER_HOST`
+- Health checks and readiness verification after deployment
+
+*Out of scope — do not touch:*
+- `src/` — owned by `engineer`
+- `tests/` — owned by `tester`
+- `docs/` — owned by `doc-writer` and `architect`
+- Application compose files beyond what is needed to operate the testbed
+
+## Testbed operations
+
+The testbed is a remote Docker runtime exposed via `DOCKER_HOST`. All container operations use standard `docker` or `podman` CLI — the remote host is resolved through the environment variable.
+
+### Deploy
+1. Confirm the remote runtime is reachable: `docker info`
+2. Check out or confirm the correct branch is reflected in the compose configuration.
+3. Pull or build images as needed.
+4. Start the stack: `docker compose up -d` (use the project's testbed compose file if a specific one exists).
+5. Run health checks immediately after (see below).
+6. Report: stack status, container names, and any warnings from startup logs.
+
+### Health checks
+After every deploy, verify the stack is ready before handing off to `tester`:
+1. `docker compose ps` — all containers must be in `running` or `healthy` state.
+2. `docker compose logs --tail=50` — scan for startup errors or panics.
+3. Hit any configured health endpoints (check `docker-compose.yml` or `config/` for exposed ports and paths). Use `curl -sf <url>` — a non-zero exit means unhealthy.
+4. Report clearly: **healthy** / **degraded** / **failed**, with specific container names and log excerpts for any issues.
+5. Do not hand off to `tester` if any container is unhealthy — report the failure and stop.
+
+### Teardown
+`docker compose down` — confirm all containers are stopped and removed before reporting done.
+
+## CI/CD pipeline config
+
+When authoring or updating `.github/workflows/`:
+- One job per concern — keep workflows composable and easy to read.
+- Pin third-party action versions with full SHA hashes.
+- Cache dependencies (pip, npm, etc.) to reduce run times.
+- Every PR must trigger a job that runs the full test suite (`pytest -q` or the project's equivalent).
+- Use repository secrets for credentials — never hardcode tokens or keys.
+- After changing a workflow file, report what triggers it, what it does, and any new secrets it requires.
+
+## Constraints
+
+- Do NOT modify any file outside `.github/workflows/` and testbed-related operations.
+- Do NOT run commands that mutate persistent application state (migrations, seed data imports, etc.).
+- Use read-only Bash for anything outside deploy/teardown/health-check responsibilities.

--- a/.claude/agents/sre.md
+++ b/.claude/agents/sre.md
@@ -1,4 +1,5 @@
 ---
+name: sre
 description: Manages CI/CD pipeline configuration and testbed deployments — use to deploy the testbed via DOCKER_HOST, run post-deploy health checks, and own .github/workflows configuration
 tools:
   - Read

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,4 +1,5 @@
 ---
+name: tester
 description: Authors test cases and test code, runs the unit test suite, executes UAT against the testbed, and posts signoff results as a PR comment — with a focus on system interface stability
 tools:
   - Read

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,5 +1,5 @@
 ---
-description: Authors test cases and test code, runs the test suite, and guides the user through UAT — with a focus on system interface stability
+description: Authors test cases and test code, runs the unit test suite, executes UAT against the testbed, and posts signoff results as a PR comment — with a focus on system interface stability
 tools:
   - Read
   - Grep
@@ -10,7 +10,7 @@ tools:
 model: claude-sonnet-4-6
 ---
 
-You are a test engineer. You own test authoring, test execution, and user acceptance testing guidance. You do not modify implementation code.
+You are a test engineer. You own test authoring, unit test execution, and UAT execution against the live testbed. You do not modify implementation code.
 
 ## Focus areas
 
@@ -19,22 +19,45 @@ You are a test engineer. You own test authoring, test execution, and user accept
 
 ## Workflow
 
-### Test authoring (step 3 of feature workflow)
+### Test authoring (step 4 of feature workflow)
 1. Read the design doc in `docs/design/` to understand scope and expected behaviour.
 2. Author test cases and test code in `tests/` mirroring the `src/` structure.
-3. Produce a test plan in `docs/test-plans/<feature-name>.md` covering: happy path, edge cases, failure modes, system interface assertions, and non-functional requirements.
-4. Use the `commit` skill to push test work.
+3. Produce a test plan in `docs/test-plans/<feature-name>.md` covering: happy path, edge cases, failure modes, system interface assertions, and non-functional requirements. For each UAT case, mark it as `automated` or `needs-human` up front.
+4. Use the `/commit` command to push test work.
 
-### Test execution (step 4)
+### Unit test execution (step 5)
 1. Run the full test suite. Report a structured summary: total, passed, failed, errored.
 2. For each failure, provide: test name, failure message, and a clear handoff note to `engineer`.
 3. Re-run after `engineer` fixes are committed. Repeat until all tests are green.
 
-### UAT guidance (step 5)
-1. After all automated tests pass, produce a UAT checklist for the user — specific actions to perform, inputs to try, and outcomes to verify.
-2. Format the checklist so the user can work through it step by step and report pass/fail per item.
-3. Collect user feedback and summarise it clearly before handing off to the next workflow step.
+### UAT execution (step 8 — after SRE deploys testbed)
+Execute UAT cases from the test plan against the live testbed. For each case:
+
+1. Attempt to execute it programmatically (API calls, CLI invocations, log assertions, health endpoint checks, etc.).
+2. Assign a status:
+   - `✅ pass` — executed and outcome matched expected result
+   - `❌ fail` — executed and outcome did not match; include error detail
+   - `⏭ needs-human` — cannot be executed without human interaction (e.g. requires real Slack message, visual verification, external credentials not available)
+
+3. Post a PR comment using `gh pr comment` with a UAT signoff table:
+
+```markdown
+## UAT Signoff — <feature name>
+
+| # | Test Case | Status | Notes |
+|---|-----------|--------|-------|
+| 1 | <case name> | ✅ pass | |
+| 2 | <case name> | ❌ fail | <error summary> |
+| 3 | <case name> | ⏭ needs-human | <what to verify and how> |
+
+**Automated:** X passed, Y failed
+**Needs human signoff:** Z cases (reply to this comment with ✅ or ❌ per row)
+```
+
+4. For any `❌ fail` cases, produce a handoff note to `engineer` with the failure detail.
+5. The PR is ready to merge only when: all `✅ pass`, all `needs-human` cases have been signed off by the user in the PR, and no `❌ fail` cases remain.
 
 ## Constraints
 
 - Do NOT modify files outside `tests/` and `docs/test-plans/`.
+- Do NOT interact with production systems — only the testbed.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,7 +1,7 @@
 ---
 description: Open a pull request against master with an auto-generated title and checklist body
 argumentHint: "[title or description hints]"
-model: claude-sonnet-4-6
+model: claude-haiku-4-5-20251001
 ---
 
 Create a pull request from the current branch targeting `master` (or `main` if `master` does not exist).

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,6 +1,7 @@
 ---
 description: Open a pull request against master with an auto-generated title and checklist body
 argumentHint: "[title or description hints]"
+model: claude-sonnet-4-6
 ---
 
 Create a pull request from the current branch targeting `master` (or `main` if `master` does not exist).

--- a/.claude/commands/tag.md
+++ b/.claude/commands/tag.md
@@ -1,7 +1,7 @@
 ---
 description: Create and push a git tag; proposes the next version if no name is given
 argumentHint: "[tag name, e.g. v1.2.3]"
-model: claude-sonnet-4-6
+model: claude-haiku-4-5-20251001
 ---
 
 Create and push a git tag on the current commit.

--- a/.claude/commands/tag.md
+++ b/.claude/commands/tag.md
@@ -1,6 +1,7 @@
 ---
 description: Create and push a git tag; proposes the next version if no name is given
 argumentHint: "[tag name, e.g. v1.2.3]"
+model: claude-sonnet-4-6
 ---
 
 Create and push a git tag on the current commit.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git branch*)",
+      "Bash(git stash list*)",
+      "Bash(git tag*)",
+      "Bash(git remote*)",
+      "Bash(git rev-parse*)",
+      "Bash(git shortlog*)",
+      "Bash(pytest*)",
+      "Bash(python -m pytest*)",
+      "Bash(python -c *)",
+      "Bash(python -m *)",
+      "Bash(pip list*)",
+      "Bash(pip show*)",
+      "Bash(ls*)",
+      "Bash(find . *)",
+      "Bash(find src *)",
+      "Bash(find tests *)",
+      "Bash(find docs *)",
+      "Bash(podman ps*)",
+      "Bash(podman images*)",
+      "Bash(podman logs*)",
+      "Bash(podman inspect*)",
+      "Bash(docker ps*)",
+      "Bash(docker images*)",
+      "Bash(docker logs*)",
+      "Bash(docker inspect*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,10 +26,22 @@
       "Bash(podman images*)",
       "Bash(podman logs*)",
       "Bash(podman inspect*)",
+      "Bash(podman compose*)",
+      "Bash(podman info*)",
       "Bash(docker ps*)",
       "Bash(docker images*)",
       "Bash(docker logs*)",
-      "Bash(docker inspect*)"
+      "Bash(docker inspect*)",
+      "Bash(docker compose*)",
+      "Bash(docker-compose*)",
+      "Bash(docker info*)",
+      "Bash(curl -sf*)",
+      "Bash(curl -s*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh run view*)",
+      "Bash(gh run list*)"
     ],
     "deny": []
   }

--- a/docs/decisions/0010-workspace-env-var-overrides.md
+++ b/docs/decisions/0010-workspace-env-var-overrides.md
@@ -1,6 +1,6 @@
 # 0010 Workspace-level environment variable overrides
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-05-04
 - Supersedes: none
 - Builds on: [0009 Runtime Configuration and Staff System](0009-runtime-configuration-and-staff-system.md)

--- a/docs/decisions/0010-workspace-env-var-overrides.md
+++ b/docs/decisions/0010-workspace-env-var-overrides.md
@@ -1,0 +1,197 @@
+# 0010 Workspace-level environment variable overrides
+
+- Status: proposed
+- Date: 2026-05-04
+- Supersedes: none
+- Builds on: [0009 Runtime Configuration and Staff System](0009-runtime-configuration-and-staff-system.md)
+
+## Context
+
+ADR-0009 introduced a `config` table with `(scope_type, scope_id, key, value, updated_at)` and shipped the plumbing required to read workspace-scoped env vars at agent container start:
+
+- `runtime_config.load_agent_env(db_path, workspace_id)` merges global + workspace config into a single env dict, with workspace winning on key collisions.
+- `agent_runner.spawn_agent(..., extra_env=...)` passes that dict straight to `docker.containers.run(environment=env)`.
+- `POST /api/workspaces/{id}/restart-agent` already wires the two together.
+- `GET /api/workspaces/{id}/config` and `PATCH /api/workspaces/{id}/config` already exist for reading and writing workspace-scoped config rows.
+- `Settings.vue` exposes the same key-value editor for global config.
+
+What is missing is the **workspace-scoped UI surface**: there is no way for a user looking at a single workspace to view, add, or remove env vars that apply only to that workspace, and no defined behaviour for getting those changes into the running container.
+
+This ADR resolves the four open product questions — auto-restart cadence, secret masking, override precedence, and behaviour when the container is stopped — and specifies the UI surface that ties the existing pieces together. No new backend tables or endpoints are introduced.
+
+## Decision Drivers
+
+- **Operator ergonomics.** Adding an env var should be a one-click flow; users should not have to remember to restart the agent afterwards.
+- **Predictability.** Users must always be able to tell which value is in effect and where it came from.
+- **No silent restarts.** Restarting an agent kills any in-flight run. Users must consent to that, or at minimum be told it just happened.
+- **Reuse what exists.** ADR-0009 already settled the data model and merge semantics; this ADR must not re-litigate them.
+- **Single-user, self-hosted threat model.** Same posture as ADR-0009 — secrets are stored in plaintext in SQLite; the UI is not the security boundary.
+
+## Considered Options
+
+### Auto-restart cadence
+
+1. **Restart immediately on every individual add/delete.**
+2. **Batch edit mode with an explicit "Save & Restart" button.**
+3. **Save without restart; show a "restart required" banner and let the user decide.**
+
+### Secret masking
+
+A. **Mask values whose key matches a heuristic (`*KEY*`, `*TOKEN*`, `*SECRET*`, `*PASSWORD*`) by default; provide a "reveal" toggle.**
+B. **Mask everything by default.**
+C. **No masking.**
+
+### Override precedence vs. global config
+
+I. **Workspace overrides global** (same as ADR-0009 already specifies for the merge).
+II. **Workspace cannot shadow global keys** (workspace rows for a global key are rejected at write time).
+
+### Behaviour when container is not running
+
+X. **Save the row but skip the restart; show a non-blocking notice that the value will apply on next start.**
+Y. **Refuse the save until the agent is started.**
+Z. **Save the row and start the container.**
+
+## Decision Outcome
+
+**Chosen:** **3 + A + I + X.**
+
+1. **Auto-restart cadence — Option 3 (save-then-prompt).** Each `PATCH` call writes the row immediately. The frontend then shows a sticky "Configuration changed — restart required to apply" banner with a **Restart Agent** button (the same button already on the page). The frontend does **not** call `/restart-agent` automatically.
+2. **Secret masking — Option A (heuristic + reveal).** Keys matching a case-insensitive substring list (`KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `PASSPHRASE`) render their value as `••••••••` with a click-to-reveal eye icon. The list lives in a frontend constant; backend stores and returns plaintext (consistent with ADR-0009 §E).
+3. **Override precedence — Option I (workspace wins).** The merge already implemented in `load_agent_env` is the contract. The workspace UI displays inherited global keys read-only with a "global" badge; if the user adds a workspace row with the same key, the workspace value takes effect on next restart and the global row gets a strikethrough "shadowed by workspace" badge.
+4. **Container-not-running — Option X (save and defer).** If `get_container_status(workspace_id)` reports anything other than `running`, the save succeeds and the banner reads "Saved. Will apply when the agent next starts." No restart is triggered.
+
+### Why this combination
+
+- **Option 3 over 1**: silent automatic restart on every keystroke is hostile when a long-running agent task is in flight. The user already has a Restart button on the same page; making them press it once after a batch of edits is the right amount of friction.
+- **Option 3 over 2**: a batch "Save & Restart" mode requires staging state (pending adds, pending deletes) on the client and a transactional endpoint on the server. The existing `PATCH` endpoint is already row-level. Save-then-prompt gets us 90% of the value with no backend work.
+- **Option A over B**: masking everything makes legitimate non-secret values (e.g. `LOG_LEVEL=debug`) needlessly hard to verify. Heuristic masking matches operator intuition.
+- **Option I over II**: shadowing global keys at the workspace level is the entire point of having a workspace scope. ADR-0009 already chose this; restating it here only to clarify UI semantics.
+- **Option X over Y/Z**: refusing to save without a running container creates a chicken-and-egg problem during initial setup. Auto-starting the container on save is too eager — the user may be in the middle of configuring the workspace and not ready to start the agent.
+
+### Consequences
+
+- **Good**
+  - No new backend code paths, tables, or endpoints. Frontend-only feature on top of ADR-0009 plumbing.
+  - User always knows when a restart is pending and chooses when to take it.
+  - The same Restart Agent button users already understand is the single mechanism for applying any kind of agent-affecting change.
+  - Inherited-from-global rows are visible alongside workspace overrides, making the merge transparent.
+- **Bad / accepted tradeoffs**
+  - User must remember to click Restart; if they navigate away with the banner showing, the change won't apply until they (or someone else) restarts the agent later. Mitigated by making the banner sticky and visually prominent.
+  - Heuristic masking will miss vendor-specific keys that don't contain any of the substrings (e.g. `STRIPE_SK_LIVE`). A small risk; users can rename keys or extend the list in a follow-up.
+  - Plaintext storage in SQLite remains, per ADR-0009.
+  - No CSRF / audit trail for env var changes — same posture as the rest of the v3 API.
+
+### Confirmation
+
+- UI manual UAT in the test plan: add a key, observe banner, click Restart, verify env var lands in the running container via `docker exec ... env`.
+- Heuristic masking is unit-tested in the frontend (Vitest) against a fixed list of representative key names.
+- Inherited-row badge logic verified with a workspace that shadows a global key.
+
+## Pros and Cons of the Options
+
+### Auto-restart cadence
+
+| Option | Pro | Con |
+|---|---|---|
+| 1 — Restart on every edit | Zero-cognitive-load: state on disk = state in container | Kills in-flight runs without consent; multiple edits cause multiple restarts; bad UX during initial bulk setup |
+| 2 — Batch with Save & Restart | Atomic from the user's POV | Requires client-side staging and either a bulk endpoint or N sequential PATCHes wrapped in optimistic UI; more code, marginal gain |
+| 3 — Save now, restart on demand (chosen) | Reuses existing PATCH and Restart Agent button; user controls timing | Pending-restart state must be made obvious or users will forget |
+
+### Secret masking
+
+| Option | Pro | Con |
+|---|---|---|
+| A — Heuristic + reveal (chosen) | Sensible defaults; non-secret values still readable | Heuristic will miss some vendor-specific secret keys |
+| B — Mask everything | Safest default | Verifying non-secret values requires a click for every row; annoying |
+| C — No masking | Simplest | Shoulder-surfing risk during screen-shares and demos |
+
+### Override precedence
+
+| Option | Pro | Con |
+|---|---|---|
+| I — Workspace wins (chosen) | Matches the merge already implemented in `load_agent_env`; matches ADR-0009 | None — already settled |
+| II — Reject shadowing | Forces global hygiene | Breaks the entire point of workspace scoping; contradicts ADR-0009 |
+
+### Container-not-running
+
+| Option | Pro | Con |
+|---|---|---|
+| X — Save and defer (chosen) | Allows full pre-start configuration | User may forget the deferred change exists |
+| Y — Refuse save | Forces consistency between stored config and running container | Breaks first-time setup; nothing to save against |
+| Z — Auto-start on save | Always-applied semantics | Premature: the user may not be ready to spawn the container yet |
+
+## Implementation Plan
+
+Frontend-only. No backend changes required.
+
+### 1. New component: `WorkspaceEnvVarsPanel.vue`
+
+Lives in the existing workspace detail page, near the Agent Status / Restart Agent area.
+
+Reads from `GET /api/workspaces/{id}/config` (returns merged view per ADR-0009 §6) and renders:
+
+- A table of rows: `key`, `value` (masked if heuristic matches), `source` badge (`workspace` or `global`), and a per-row delete button (disabled for `global`-only rows).
+- An "Add" form (key + value text inputs + Add button) styled to match `Settings.vue`.
+- A sticky **"Configuration changed — restart required"** banner shown whenever there is at least one pending change since the last successful container start. Includes the existing Restart Agent button (or wires through to it).
+
+### 2. State management
+
+- On mount and after each successful mutation: re-fetch the merged config.
+- Track a local `dirtySinceLastStart` flag, persisted to `localStorage` keyed by `workspace_id` so the banner survives page reloads. Cleared on a successful Restart Agent response.
+- Distinguish `workspace` rows from inherited `global` rows by cross-referencing `GET /api/workspaces/{id}/config` (merged) against `GET /api/config` (global only). The `inherited_from` field is not yet present on the config response — if missing, infer source by set difference. (Open question below.)
+
+### 3. Add flow
+
+1. User types `KEY` and `VALUE`, clicks Add.
+2. `PATCH /api/workspaces/{id}/config` with `{ KEY: VALUE }`.
+3. On 200, refetch config, set `dirtySinceLastStart=true`, show banner.
+4. If `KEY` already exists at global scope, the new row is shown with a "shadows global" indicator.
+
+### 4. Delete flow
+
+1. User clicks the trash icon on a workspace row.
+2. Confirm dialog.
+3. `PATCH /api/workspaces/{id}/config` with `{ KEY: null }` (per ADR-0009 §6 PATCH-as-upsert/delete semantics; confirm the actual sentinel during implementation).
+4. On 200, refetch, set `dirtySinceLastStart=true`, show banner.
+
+### 5. Masking
+
+Frontend constant:
+
+```ts
+const SECRET_KEY_SUBSTRINGS = ['KEY', 'TOKEN', 'SECRET', 'PASSWORD', 'CREDENTIAL', 'PASSPHRASE'];
+```
+
+A row is masked iff `SECRET_KEY_SUBSTRINGS.some(s => key.toUpperCase().includes(s))`. Click-to-reveal toggles a per-row `revealed` flag (component-local; not persisted).
+
+### 6. Container-status awareness
+
+Reuse the agent-status query already on the page. The Restart Agent button is enabled regardless of state (the existing endpoint handles both spawn-fresh and restart cases). The banner copy adapts:
+
+- Container running: "Configuration changed — restart required to apply. **[Restart Agent]**"
+- Container not running: "Saved. Will apply when the agent next starts. **[Start Agent]**"
+
+### 7. Test plan
+
+Lives at `docs/test-plans/workspace-env-var-overrides.md`. Cases:
+
+- Add a non-secret key, restart, verify `docker exec` shows it.
+- Add a `*_TOKEN` key, verify masking and reveal toggle.
+- Add a workspace key that shadows a global key, restart, verify workspace value wins.
+- Delete a workspace row that shadows global, restart, verify global value reappears.
+- Save while container is stopped, start agent, verify env var present.
+- Reload page with pending changes, verify banner persists.
+
+### Open Questions
+
+- [ ] Does `PATCH /api/workspaces/{id}/config` accept `null` as a delete sentinel, or is there a separate `DELETE` shape? Confirm before implementation. (Owner: engineer at slice start.)
+- [ ] Does the merged `GET /api/workspaces/{id}/config` already include an `inherited_from` field? If not, decide whether to add it server-side or infer client-side via set difference. (Owner: engineer at slice start.)
+
+## Out of Scope
+
+- Topic-scoped env vars — explicitly rejected in ADR-0009 §D.
+- Encryption at rest — deferred per ADR-0009 §E.
+- Bulk import/export of env vars (e.g. paste a `.env` file). Future enhancement; not blocking.
+- Audit log of who changed what when. Single-user deployment; not warranted.
+- Validation of key shape (e.g. POSIX env var name rules). Browser-level minimal check only; server is the source of truth.

--- a/docs/test-plans/workspace-env-var-overrides.md
+++ b/docs/test-plans/workspace-env-var-overrides.md
@@ -1,0 +1,301 @@
+# Test Plan: Workspace-level Environment Variable Overrides
+
+- **Feature design:** [docs/decisions/0010-workspace-env-var-overrides.md](../decisions/0010-workspace-env-var-overrides.md)
+- **Date:** 2026-05-04
+- **Components under test:** `WorkspaceEnvVarsPanel.vue`, `WorkspaceDetail.vue` (integration)
+
+---
+
+## 1. Scope
+
+### In scope
+
+- `WorkspaceEnvVarsPanel` component rendered on the Workspace Detail page.
+- Add and delete workspace-scoped env var rows via `PATCH /api/workspaces/{id}/config`.
+- Secret masking heuristic and click-to-reveal toggle.
+- Source badge logic: `workspace`, `workspace (shadows global)`, `global`.
+- Sticky "restart required" banner and its localStorage persistence across page reloads.
+- Banner copy adapting to container running vs. stopped state.
+- Banner cleared on a successful Restart Agent call.
+- Inherited (`global`) rows being read-only.
+- End-to-end propagation: env var saved in UI lands in the agent container environment after restart.
+
+### Out of scope
+
+- Backend API correctness and data persistence (tested separately via API-level tests).
+- Topic-scoped env vars (explicitly out of scope per ADR-0010).
+- Encryption at rest (deferred per ADR-0009).
+- Bulk import/export of env vars.
+- POSIX name validation beyond the empty-key guard.
+- Audit logging of env var changes.
+- Multi-user or access-control scenarios (single-user self-hosted deployment).
+
+---
+
+## 2. Test Environment Prerequisites
+
+- A running deployment reachable at the UI URL (local `docker compose up` is sufficient).
+- At least one workspace exists with an agent container that can be started and stopped.
+- Docker (or Podman) CLI accessible on the host so `docker exec <container> env` can be run during container-level verification steps.
+- Browser developer tools available for localStorage inspection.
+- One or more global env vars pre-configured via the Settings page (needed for shadow tests).
+
+---
+
+## 3. Test Cases
+
+### TC-01: Add a non-secret env var, restart, verify in container
+
+**Precondition:** Workspace exists. Agent container is running. No existing workspace var named `LOG_LEVEL`.
+
+**Steps:**
+1. Navigate to the Workspace Detail page.
+2. In the Env Vars panel, enter `LOG_LEVEL` in the Key field and `verbose` in the Value field.
+3. Click **Add / Update**.
+4. Observe the table and the page banner.
+5. Click **Restart Agent** and confirm the dialog.
+6. Wait for the agent status badge to return to `Running`.
+7. On the host, run: `docker exec <agent-container-name> env | grep LOG_LEVEL`
+
+**Expected result:**
+- Step 3: the row `LOG_LEVEL = verbose` appears in the table with a `workspace` badge.
+- Step 4: a sticky orange banner reading "Configuration changed — restart required to apply." appears above the table. The Restart Agent button is visible in the status bar.
+- Step 5–6: no error; agent status returns to Running.
+- Step 6: the banner disappears.
+- Step 7: output includes `LOG_LEVEL=verbose`.
+
+**Pass criteria:** All of the above hold. Fail if the var is absent from `docker exec env`, if the banner does not appear, or if the banner does not clear after a successful restart.
+
+---
+
+### TC-02: Add a secret-heuristic key, verify masking and reveal toggle
+
+**Precondition:** Workspace exists. No existing workspace var named `MY_TOKEN`.
+
+**Steps:**
+1. Navigate to the Workspace Detail page.
+2. Enter `MY_TOKEN` in the Key field and `s3cr3t-value` in the Value field. Click **Add / Update**.
+3. Locate the `MY_TOKEN` row in the table.
+4. Observe the value cell without interaction.
+5. Click the **reveal** link next to the masked value.
+6. Observe the value cell after reveal.
+7. Click the **hide** link.
+8. Observe the value cell after hiding.
+
+**Expected result:**
+- Step 4: the value cell shows `••••••••` (masked). The plaintext `s3cr3t-value` is not visible in the DOM text content.
+- Step 5–6: the value cell shows `s3cr3t-value` in plaintext. A **hide** link appears.
+- Step 7–8: the value reverts to `••••••••`.
+
+**Pass criteria:** Masking is active by default for a key containing `TOKEN`. Reveal and hide cycle works correctly. The plaintext value is never rendered as visible text when the row is masked.
+
+Additional key-name assertions (can be verified in the same session or as sub-steps):
+- Keys containing `KEY`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `PASSPHRASE` (case-insensitive) are masked by default.
+- Keys not matching any substring (e.g. `LOG_LEVEL`, `TIMEOUT_SECONDS`) are shown in plaintext without a reveal button.
+
+---
+
+### TC-03: Add a workspace key that shadows a global key, verify badge and correct precedence after restart
+
+**Precondition:** A global env var `GLOBAL_VAR=global-value` exists (set via Settings page). No workspace override for `GLOBAL_VAR` exists on this workspace.
+
+**Steps:**
+1. Navigate to the Workspace Detail page.
+2. Locate the `GLOBAL_VAR` row in the Env Vars table. Confirm it shows the `global` badge and the delete button is absent (or disabled) for that row.
+3. In the Add form, enter `GLOBAL_VAR` as the key and `workspace-value` as the value. Click **Add / Update**.
+4. Observe the `GLOBAL_VAR` row in the table.
+5. Click **Restart Agent** and confirm.
+6. Wait for the agent status badge to return to `Running`.
+7. On the host, run: `docker exec <agent-container-name> env | grep GLOBAL_VAR`
+
+**Expected result:**
+- Step 2: `GLOBAL_VAR` is shown with a `global` badge (purple). No delete button.
+- Step 4: the row for `GLOBAL_VAR` now shows the value `workspace-value` with a `workspace (shadows global)` badge (amber/yellow). A delete button is present for this row.
+- Step 6: banner clears.
+- Step 7: output includes `GLOBAL_VAR=workspace-value` (workspace value wins).
+
+**Pass criteria:** Badge changes from `global` to `workspace (shadows global)` after adding the override. Container shows workspace value, not global value.
+
+---
+
+### TC-04: Delete a shadowing workspace row, verify global value reappears after restart
+
+**Precondition:** TC-03 completed. `GLOBAL_VAR` has a workspace override with value `workspace-value`. Agent is running.
+
+**Steps:**
+1. On the Workspace Detail page, locate the `GLOBAL_VAR` row showing the `workspace (shadows global)` badge.
+2. Click the **✕** (delete) button for that row.
+3. Confirm the deletion dialog.
+4. Observe the table.
+5. Click **Restart Agent** and confirm.
+6. Wait for the agent status badge to return to `Running`.
+7. On the host, run: `docker exec <agent-container-name> env | grep GLOBAL_VAR`
+
+**Expected result:**
+- Step 4: the `GLOBAL_VAR` row reverts to showing the `global` badge and the original global value. The delete button disappears for that row.
+- Step 5–6: restart succeeds; banner clears.
+- Step 7: output includes `GLOBAL_VAR=global-value` (the global value, not the deleted workspace override).
+
+**Pass criteria:** After deleting the workspace override, the global value takes precedence in the container.
+
+---
+
+### TC-05: Add a key while container is stopped — banner says "will apply on next start", then start agent
+
+**Precondition:** Workspace exists. Agent container is stopped (status shows `Stopped` or `Not found`). No workspace var named `STARTUP_VAR`.
+
+**Steps:**
+1. Navigate to the Workspace Detail page. Confirm the agent status badge shows a non-running state.
+2. Enter `STARTUP_VAR` in the Key field and `hello` in the Value field. Click **Add / Update**.
+3. Observe the banner.
+4. Click **Restart Agent** (or **Start Agent** if the button label adapts) and confirm.
+5. Wait for the agent status badge to show `Running`.
+6. On the host, run: `docker exec <agent-container-name> env | grep STARTUP_VAR`
+
+**Expected result:**
+- Step 3: the banner reads "Saved. Will apply when the agent next starts." (not "restart required to apply").
+- Step 5: agent transitions to Running.
+- Step 5: banner clears.
+- Step 6: output includes `STARTUP_VAR=hello`.
+
+**Pass criteria:** Banner copy correctly reflects the stopped-container variant. Env var lands in the container after the agent is started.
+
+---
+
+### TC-06: Reload page with pending banner — banner persists via localStorage
+
+**Precondition:** At least one workspace env var has been added since the last agent restart (i.e. the restart-required banner is currently showing).
+
+**Steps:**
+1. Confirm the sticky banner is visible on the Workspace Detail page.
+2. Open browser developer tools → Application → Local Storage. Confirm a key matching `workspace_<id>_dirty` is set to `"true"`.
+3. Reload the page (hard reload, Ctrl+Shift+R).
+4. Observe the banner after reload.
+
+**Expected result:**
+- Step 2: localStorage entry is present with value `"true"`.
+- Step 4: the banner is shown immediately after reload without requiring any user interaction. The table rows (and the dirty state) are intact.
+
+**Pass criteria:** Banner reappears after a full page reload. Fail if the banner is absent after reload while the localStorage key is still set.
+
+---
+
+### TC-07: Attempt to add a row with an empty key — rejected
+
+**Precondition:** Workspace detail page is open.
+
+**Steps:**
+1. Leave the Key field empty. Enter any value in the Value field.
+2. Observe the **Add / Update** button state.
+3. Attempt to submit by pressing Enter in the Value field.
+4. Observe whether a new row is added or an error appears.
+
+**Expected result:**
+- Step 2: the **Add / Update** button is disabled (the `:disabled="!newKey.trim() || saving"` binding prevents submission).
+- Step 3: pressing Enter does not submit (the `@keydown.enter="addVar"` handler calls `addVar`, which returns immediately when `!key`).
+- Step 4: no new row appears; no error message is shown; no API call is made.
+
+**Pass criteria:** Empty-key submission is silently blocked at the UI level. No API request is fired. Fail if a row with an empty or whitespace-only key appears in the table, or if a network request is logged.
+
+---
+
+### TC-08: Successful restart clears the banner
+
+**Precondition:** The restart-required banner is currently shown (at least one pending workspace var change). Agent is running.
+
+**Steps:**
+1. Confirm the banner is visible.
+2. Click **Restart Agent** in the agent status bar. Confirm the dialog.
+3. Observe the banner while the restart is in progress (button shows "Restarting…").
+4. Wait for the agent status badge to return to `Running`.
+5. Observe the banner after the restart completes.
+
+**Expected result:**
+- Steps 2–3: banner remains visible during the restart operation.
+- Step 5: the banner is no longer visible.
+- Verify in browser dev tools → Local Storage: the `workspace_<id>_dirty` key has been removed.
+
+**Pass criteria:** Banner disappears exactly once, on a successful restart response (`POST /api/workspaces/{id}/restart-agent` returns 2xx). Fail if the banner remains after a successful restart, or if the localStorage key is not removed.
+
+---
+
+## 4. Non-functional Test Cases
+
+### NF-01: Secret masking is complete — value not exposed in DOM
+
+**Steps:**
+1. Add a key matching the secret heuristic (e.g. `API_SECRET`).
+2. With the value masked (reveal not clicked), open browser developer tools → Elements.
+3. Search the DOM for the plaintext value string.
+
+**Expected result:** The plaintext value does not appear anywhere in the rendered DOM while the row is masked. Only `••••••••` appears in the value cell.
+
+**Pass criteria:** Zero occurrences of the plaintext secret in the DOM when masked. Fail if the value is present in a hidden element, `data-*` attribute, or inline style.
+
+---
+
+### NF-02: Inherited (global) rows are read-only
+
+**Steps:**
+1. Ensure at least one global env var is inherited and visible in the table with a `global` badge.
+2. Confirm the row has no delete button rendered.
+3. Confirm no inline edit affordance is present for that row.
+4. Confirm the "manage in Settings" link is shown instead.
+
+**Expected result:** Global rows have no interactive delete control. The link to Settings is present. Attempting to call the PATCH endpoint manually with a `delete` payload for a key that only exists at global scope leaves that key present in the merged config on reload (the backend is the authority; this is a UI read-only assertion).
+
+**Pass criteria:** No delete button rendered for `source === 'global'` rows; "manage in Settings" link present.
+
+---
+
+### NF-03: No XSS from key or value inputs
+
+**Steps:**
+1. In the Key field, enter: `<img src=x onerror=alert(1)>`
+2. In the Value field, enter: `"><script>alert(1)</script>`
+3. Click **Add / Update**.
+4. Observe the table row that appears.
+
+**Expected result:** The key and value are rendered as escaped text in the table cells. No alert dialog fires. No raw HTML is injected into the DOM.
+
+**Pass criteria:** Vue's default template binding (`{{ }}`) escapes the strings. No script execution occurs. Fail if an `alert` fires or if raw HTML tags appear as rendered elements.
+
+---
+
+## 5. Out of Scope
+
+The following items are explicitly not covered by this test plan:
+
+- Backend persistence correctness (`PATCH /api/workspaces/{id}/config` API contract, SQLite row storage, merge logic in `runtime_config.load_agent_env`). These are covered by server-side unit and integration tests.
+- Topic-scoped env vars — rejected in ADR-0009 §D, not implemented.
+- Encryption at rest — deferred per ADR-0009 §E.
+- Bulk `.env` file import/export.
+- Audit log of changes.
+- Multi-user or RBAC scenarios.
+- Automated unit tests for the `SECRET_KEY_SUBSTRINGS` constant in isolation (these would live in Vitest component tests, not in this manual plan).
+- Archived workspaces — the `WorkspaceEnvVarsPanel` is not rendered for archived workspaces (`v-if="!isArchived"`), so env var interactions on archived workspaces require no test coverage here.
+
+---
+
+## 6. Sign-Off Template
+
+| Field | Value |
+|---|---|
+| Date | |
+| Build / commit under test | |
+| Browser(s) tested | |
+| Docker/Podman CLI version | |
+| Test executor | |
+| TC-01 result | Pass / Fail |
+| TC-02 result | Pass / Fail |
+| TC-03 result | Pass / Fail |
+| TC-04 result | Pass / Fail |
+| TC-05 result | Pass / Fail |
+| TC-06 result | Pass / Fail |
+| TC-07 result | Pass / Fail |
+| TC-08 result | Pass / Fail |
+| NF-01 result | Pass / Fail |
+| NF-02 result | Pass / Fail |
+| NF-03 result | Pass / Fail |
+| Blocking issues | |
+| Sign-off owner | |

--- a/frontend/src/components/WorkspaceEnvVarsPanel.vue
+++ b/frontend/src/components/WorkspaceEnvVarsPanel.vue
@@ -1,0 +1,268 @@
+<template>
+  <section class="env-section">
+    <div class="header-row">
+      <h2>Env Vars</h2>
+    </div>
+    <p class="muted hint">Environment variables injected into this workspace's agent container. Workspace rows override global config. Changes take effect after an agent restart.</p>
+    <p class="warn hint">Values are stored as plain text. Treat this database file as a sensitive asset.</p>
+
+    <div v-if="dirtySinceLastStart" class="restart-banner">
+      <span v-if="containerRunning">
+        Configuration changed — restart required to apply.
+      </span>
+      <span v-else>
+        Saved. Will apply when the agent next starts.
+      </span>
+    </div>
+
+    <div class="config-add-form">
+      <input v-model="newKey" placeholder="KEY" class="config-key-input" :disabled="saving" @keydown.enter="addVar" />
+      <input v-model="newValue" placeholder="value" class="config-val-input" :disabled="saving" @keydown.enter="addVar" />
+      <button class="btn-add" @click="addVar" :disabled="!newKey.trim() || saving">
+        {{ saving ? 'Saving…' : 'Add / Update' }}
+      </button>
+    </div>
+    <span v-if="saveError" class="error">{{ saveError }}</span>
+
+    <p v-if="loading" class="muted">Loading…</p>
+    <p v-else-if="!rows.length" class="muted">No env vars set for this workspace.</p>
+    <table v-else class="config-table">
+      <thead>
+        <tr><th>Key</th><th>Value</th><th>Source</th><th></th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.key" :class="{ 'row-inherited': row.source === 'global' }">
+          <td><code>{{ row.key }}</code></td>
+          <td class="config-val">
+            <span v-if="isSecret(row.key) && !revealed.has(row.key)">
+              ••••••••
+              <button class="reveal-btn" @click="reveal(row.key)" title="Show value">reveal</button>
+            </span>
+            <span v-else>
+              {{ row.value }}
+              <button v-if="isSecret(row.key)" class="reveal-btn" @click="hide(row.key)" title="Hide value">hide</button>
+            </span>
+          </td>
+          <td>
+            <span v-if="row.source === 'global'" class="badge-global">global</span>
+            <span v-else-if="row.source === 'shadows'" class="badge-shadows">workspace (shadows global)</span>
+            <span v-else class="badge-workspace">workspace</span>
+          </td>
+          <td class="actions">
+            <button
+              v-if="row.source !== 'global'"
+              class="action-btn remove-btn"
+              @click="deleteVar(row.key)"
+              :disabled="saving"
+              title="Delete"
+            >✕</button>
+            <span v-else class="muted small">manage in <RouterLink to="/settings">Settings</RouterLink></span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { RouterLink } from 'vue-router'
+
+const props = defineProps({
+  workspaceId: { type: [String, Number], required: true },
+  containerRunning: { type: Boolean, default: false },
+})
+
+const SECRET_KEY_SUBSTRINGS = ['KEY', 'TOKEN', 'SECRET', 'PASSWORD', 'CREDENTIAL', 'PASSPHRASE']
+
+const mergedConfig = ref({})
+const globalConfig = ref({})
+const loading = ref(false)
+const saving = ref(false)
+const saveError = ref('')
+const newKey = ref('')
+const newValue = ref('')
+const revealed = ref(new Set())
+
+const dirtyStorageKey = computed(() => `workspace_${props.workspaceId}_dirty`)
+
+const dirtySinceLastStart = ref(
+  localStorage.getItem(`workspace_${props.workspaceId}_dirty`) === 'true'
+)
+
+watch(() => props.workspaceId, () => {
+  dirtySinceLastStart.value = localStorage.getItem(dirtyStorageKey.value) === 'true'
+})
+
+function isSecret(key) {
+  const upper = key.toUpperCase()
+  return SECRET_KEY_SUBSTRINGS.some(s => upper.includes(s))
+}
+
+function reveal(key) {
+  revealed.value = new Set([...revealed.value, key])
+}
+
+function hide(key) {
+  const next = new Set(revealed.value)
+  next.delete(key)
+  revealed.value = next
+}
+
+function markDirty() {
+  localStorage.setItem(dirtyStorageKey.value, 'true')
+  dirtySinceLastStart.value = true
+}
+
+function clearDirty() {
+  localStorage.removeItem(dirtyStorageKey.value)
+  dirtySinceLastStart.value = false
+}
+
+const rows = computed(() => {
+  const merged = mergedConfig.value
+  const global = globalConfig.value
+  const result = []
+
+  for (const [key, value] of Object.entries(merged)) {
+    const inGlobal = Object.prototype.hasOwnProperty.call(global, key)
+    const sameValueAsGlobal = inGlobal && global[key] === value
+    let source
+    if (!inGlobal) {
+      source = 'workspace'
+    } else if (sameValueAsGlobal) {
+      source = 'global'
+    } else {
+      source = 'shadows'
+    }
+    result.push({ key, value, source })
+  }
+
+  result.sort((a, b) => {
+    const order = { workspace: 0, shadows: 1, global: 2 }
+    if (order[a.source] !== order[b.source]) return order[a.source] - order[b.source]
+    return a.key.localeCompare(b.key)
+  })
+
+  return result
+})
+
+async function loadConfig() {
+  loading.value = true
+  try {
+    const [mergedRes, globalRes] = await Promise.all([
+      fetch(`/api/workspaces/${props.workspaceId}/config`),
+      fetch('/api/config'),
+    ])
+    mergedConfig.value = mergedRes.ok ? await mergedRes.json() : {}
+    globalConfig.value = globalRes.ok ? await globalRes.json() : {}
+  } finally {
+    loading.value = false
+  }
+}
+
+async function patchConfig(patch) {
+  const r = await fetch(`/api/workspaces/${props.workspaceId}/config`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  if (!r.ok) {
+    const err = await r.json().catch(() => ({}))
+    throw new Error(err.detail || `HTTP ${r.status}`)
+  }
+  return r.json()
+}
+
+async function addVar() {
+  const key = newKey.value.trim()
+  if (!key) return
+  saving.value = true
+  saveError.value = ''
+  try {
+    await patchConfig({ set: { [key]: newValue.value }, delete: [] })
+    newKey.value = ''
+    newValue.value = ''
+    await loadConfig()
+    markDirty()
+  } catch (err) {
+    saveError.value = err.message
+  } finally {
+    saving.value = false
+  }
+}
+
+async function deleteVar(key) {
+  if (!confirm(`Delete env var "${key}" from this workspace?`)) return
+  saving.value = true
+  saveError.value = ''
+  try {
+    await patchConfig({ set: {}, delete: [key] })
+    await loadConfig()
+    markDirty()
+  } catch (err) {
+    saveError.value = err.message
+  } finally {
+    saving.value = false
+  }
+}
+
+function onRestartSuccess() {
+  clearDirty()
+}
+
+defineExpose({ onRestartSuccess, loadConfig })
+
+onMounted(loadConfig)
+</script>
+
+<style scoped>
+.env-section { border-top: 1px solid #e2e8f0; padding-top: 1.5rem; margin-bottom: 2rem; }
+.header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+h2 { margin: 0; }
+.hint { font-size: 0.85em; margin-bottom: 0.75rem; }
+.muted { color: #64748b; }
+.small { font-size: 0.82em; }
+.warn { color: #92400e; background: #fef9c3; padding: 0.4rem 0.75rem; border-radius: 4px; }
+.error { color: #dc2626; font-size: 0.9em; }
+
+.restart-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  border-radius: 6px;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.9em;
+  color: #92400e;
+}
+
+.config-add-form { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; align-items: center; flex-wrap: wrap; }
+.config-key-input { width: 200px; padding: 0.4rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 4px; font-family: monospace; font-size: 0.9em; }
+.config-val-input { flex: 1; min-width: 120px; padding: 0.4rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 4px; font-size: 0.9em; }
+
+.config-table { width: 100%; border-collapse: collapse; font-size: 0.9em; margin-top: 0.5rem; }
+.config-table th { text-align: left; padding: 0.4rem 0.75rem; border-bottom: 2px solid #e2e8f0; color: #64748b; font-weight: 600; }
+.config-table td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #f1f5f9; }
+.row-inherited td { color: #94a3b8; }
+.config-val { font-family: monospace; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.badge-global { background: #ede9fe; color: #6d28d9; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.badge-workspace { background: #dcfce7; color: #15803d; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.badge-shadows { background: #fef3c7; color: #b45309; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+
+.actions { white-space: nowrap; }
+.action-btn { background: none; border: none; color: #2563eb; cursor: pointer; font-size: 0.85em; padding: 0.15rem 0.4rem; border-radius: 3px; text-decoration: underline; }
+.action-btn:hover { background: #eff6ff; }
+.remove-btn { color: #94a3b8; text-decoration: none; }
+.remove-btn:hover:not(:disabled) { background: #fee2e2; color: #dc2626; }
+.remove-btn:disabled { opacity: 0.6; cursor: default; }
+
+.reveal-btn { background: none; border: none; color: #64748b; cursor: pointer; font-size: 0.78em; padding: 0 0.3rem; text-decoration: underline; vertical-align: middle; }
+.reveal-btn:hover { color: #334155; }
+
+.btn-add { padding: 0.35rem 0.85rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
+.btn-add:disabled { opacity: 0.6; cursor: default; }
+</style>

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -44,6 +44,14 @@
       </ul>
     </section>
 
+    <!-- ── Env Vars ──────────────────────────────────────────────────── -->
+    <WorkspaceEnvVarsPanel
+      v-if="!isArchived"
+      ref="envPanel"
+      :workspace-id="id"
+      :container-running="agentStatus?.status === 'running'"
+    />
+
     <!-- ── Staff section ─────────────────────────────────────────────── -->
     <section class="staffs-section">
       <div class="header-row">
@@ -126,6 +134,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
+import WorkspaceEnvVarsPanel from '../components/WorkspaceEnvVarsPanel.vue'
 
 const route = useRoute()
 const id = route.params.id
@@ -142,6 +151,7 @@ let statusTimer = null
 
 const refreshing = ref(false)
 const restarting = ref(false)
+const envPanel = ref(null)
 
 const showStaffForm = ref(false)
 const editingStaff = ref(null)
@@ -189,7 +199,10 @@ async function restartAgent() {
   if (!confirm('Restart the agent container? It will pick up the latest config/credentials.')) return
   restarting.value = true
   try {
-    await fetch(`/api/workspaces/${id}/restart-agent`, { method: 'POST' })
+    const r = await fetch(`/api/workspaces/${id}/restart-agent`, { method: 'POST' })
+    if (r.ok) {
+      envPanel.value?.onRestartSuccess()
+    }
     await fetchAgentStatus()
   } finally {
     restarting.value = false

--- a/src/master/runtime_config.py
+++ b/src/master/runtime_config.py
@@ -60,7 +60,15 @@ def _merged_config(conn, workspace_id: str) -> dict[str, str]:
     return merged
 
 
+def _valid_env_key(key: str) -> bool:
+    return bool(key) and key.strip() == key and "=" not in key and "\x00" not in key
+
+
 def _apply_patch(conn, scope_type: str, scope_id: str, patch: ConfigPatch) -> None:
+    bad_set = [k for k in patch.set if not _valid_env_key(k)]
+    bad_del = [k for k in patch.delete if not _valid_env_key(k)]
+    if bad_set or bad_del:
+        raise HTTPException(422, f"invalid env var key(s): {bad_set + bad_del}")
     now = _now()
     for key, value in patch.set.items():
         conn.execute(


### PR DESCRIPTION
## Summary

- Adds a **Workspace Env Vars panel** to the workspace detail page, letting users set per-workspace environment variables that are injected into the agent container on next restart
- Shows inherited global vars as read-only with a \`global\` badge; workspace overrides get a \`workspace\` / \`shadows global\` badge; sensitive key names (TOKEN, SECRET, KEY, etc.) are masked with a click-to-reveal toggle
- A sticky banner appears after any add/delete prompting the user to restart the agent — no silent auto-restarts
- Fixes backend validation: \`PATCH /api/workspaces/{id}/config\` now rejects empty, whitespace-only, and \`=\`-containing keys with 422

## Test plan

- [x] TC-01: Add a non-secret env var via UI, restart agent, verify via \`docker exec <container> env\`
- [x] TC-02: Add a \`*_TOKEN\` key, verify masking and reveal/hide toggle
- [x] TC-03: Workspace key shadows global key — badge changes, workspace value wins after restart
- [x] TC-04: Delete workspace override — global value reappears after restart
- [x] TC-05: Add key while container stopped — banner says "will apply on next start"
- [x] TC-06: Page reload with pending changes — banner persists via localStorage
- [x] TC-07: Empty / whitespace / \`=\`-containing key rejected with 422
- [x] TC-08: Successful restart clears the banner
- [x] NF-01: Masked secret not present in DOM
- [x] NF-02: Inherited global rows have no delete control
- [x] NF-03: XSS-safe — key/value inputs rendered as escaped text

Full test plan: \`docs/test-plans/workspace-env-var-overrides.md\`

🤖 Generated with repository automation