### PR TITLE
feat(ci): RC-based three-environment CI/CD pipeline

### DIFF
--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -1,0 +1,123 @@
+name: Build on Demand
+
+# Builds both images from any branch, tag, or commit SHA and pushes
+# :sha-<short-hash> to GHCR.  Intended for agent-driven test bed deploys.
+#
+# Usage (agent or human)
+# ----------------------
+#   gh workflow run build-on-demand.yml \
+#     --ref feat/my-branch \
+#     --field ref=feat/my-branch \
+#     --field label=feat-my-branch
+#
+# The agent waits synchronously on the run ID:
+#   gh run watch <run-id>
+#
+# The resulting :sha-<hash> image is a dead-end tag — it cannot enter the
+# staging or production promotion chain without an explicit promote action.
+#
+# See docs/design/cicd-pipeline.md for the full pipeline design.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or full commit SHA to build from"
+        required: true
+        default: "master"
+      label:
+        description: "Optional human-readable label (e.g. feat-auth). Adds :label-<value> tag."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push (${{ inputs.ref }})
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          MASTER_TAGS="ghcr.io/${{ github.repository_owner }}/codex-slack-master:sha-${{ steps.sha.outputs.short }}"
+          AGENT_TAGS="ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:sha-${{ steps.sha.outputs.short }}"
+          if [[ -n "${{ inputs.label }}" ]]; then
+            MASTER_TAGS="${MASTER_TAGS},ghcr.io/${{ github.repository_owner }}/codex-slack-master:label-${{ inputs.label }}"
+            AGENT_TAGS="${AGENT_TAGS},ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:label-${{ inputs.label }}"
+          fi
+          echo "master=${MASTER_TAGS}" >> "$GITHUB_OUTPUT"
+          echo "agent=${AGENT_TAGS}"   >> "$GITHUB_OUTPUT"
+
+      # ── Master image ────────────────────────────────────────────────────────
+      - name: Build and push master image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.master }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── Agent-minimal image (smoke-tested before push) ───────────────────────
+      - name: Build agent-minimal image for smoke test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.agent-minimal
+          load: true
+          tags: codex-slack-agent-minimal:demand-smoke
+          cache-from: type=gha
+
+      - name: Smoke test agent-minimal runtime contract
+        run: |
+          docker run --rm codex-slack-agent-minimal:demand-smoke sh -lc '
+            codex --version &&
+            claude --version &&
+            gh --version &&
+            python -m src.agent.main --help >/dev/null
+          '
+
+      - name: Push agent-minimal image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.agent-minimal
+          push: true
+          tags: ${{ steps.tags.outputs.agent }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## Build complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image | Tags |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| master | \`${{ steps.tags.outputs.master }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| agent-minimal | \`${{ steps.tags.outputs.agent }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Deploy to test bed with image tag: \`sha-${{ steps.sha.outputs.short }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,0 +1,101 @@
+name: Build RC Image
+
+# Triggers on v*-rc* tags pushed to any branch (e.g. v1.2.3-rc1).
+# Builds both images from the tagged commit and pushes two tags:
+#
+#   :v1.2.3-rc1  — immutable, permanent audit trail for this RC
+#   :rc          — mutable, always points to the latest RC
+#
+# The staging CD daemon tracks :rc and auto-deploys when the digest changes.
+# Each new RC tag advances staging automatically — no manual promote step.
+#
+# Tag the RC on the feature branch BEFORE merging to master:
+#   git tag v1.2.3-rc1 && git push --tags
+#
+# If UAT finds issues: fix on the branch, push v1.2.3-rc2, repeat.
+# When UAT passes: merge PR, then push the release tag (v1.2.3) on master
+# to trigger promote-release.yml.
+#
+# See docs/design/cicd-pipeline.md for the full pipeline design.
+
+on:
+  push:
+    tags:
+      - "v*-rc*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-rc:
+    name: Build RC ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout RC tag
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Master image ────────────────────────────────────────────────────────
+      - name: Build and push master RC image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/codex-slack-master:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/codex-slack-master:rc
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── Agent-minimal image (smoke-tested before push) ────────────────────
+      - name: Build agent-minimal RC image for smoke test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.agent-minimal
+          load: true
+          tags: codex-slack-agent-minimal:rc-smoke
+          cache-from: type=gha
+
+      - name: Smoke test agent-minimal runtime contract
+        run: |
+          docker run --rm codex-slack-agent-minimal:rc-smoke sh -lc '
+            codex --version &&
+            claude --version &&
+            gh --version &&
+            python -m src.agent.main --help >/dev/null
+          '
+
+      - name: Push agent-minimal RC image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.agent-minimal
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:rc
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## RC build complete: \`${{ github.ref_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Both images pushed with tags \`${{ github.ref_name }}\` and \`rc\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Staging CD daemon will auto-deploy the new \`:rc\` image within the next poll cycle." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "After UAT sign-off: merge the PR, then tag master with the release version to trigger promote-release.yml." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,83 @@
+name: CI — PR Tests
+
+# Runs on every pull-request commit targeting master.
+# Purpose: gate merges on a passing test suite and valid Docker builds.
+# No images are pushed here; publishing only happens from publish-*.yml on master/tags.
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "requirements.txt"
+      - "Dockerfile"
+      - "Dockerfile.agent-minimal"
+      - "docker/entrypoint.sh"
+      - ".github/workflows/ci-pr.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Unit / integration tests ──────────────────────────────────────────────
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest --tb=short -q
+
+  # ── 2. Docker build validation (no push) ────────────────────────────────────
+  docker-build:
+    name: Docker build check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build master image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build agent-minimal image + smoke test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.agent-minimal
+          load: true
+          tags: codex-slack-agent-minimal:pr-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test agent-minimal runtime contract
+        run: |
+          docker run --rm codex-slack-agent-minimal:pr-smoke sh -lc '
+            codex --version &&
+            claude --version &&
+            gh --version &&
+            python -m src.agent.main --help >/dev/null
+          '

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,87 @@
+name: Promote RC to Release
+
+# Triggers on v* (non-rc) tags pushed to master, e.g. v1.2.3.
+#
+# Does NOT rebuild the images. Instead it retags the current :rc image
+# (by digest) as the release version in GHCR.  This guarantees that
+# production receives the exact same image bits that ran on staging
+# during UAT — no build-time variance possible.
+#
+# Promotion workflow:
+#   1. UAT sign-off on staging (:rc image)
+#   2. Merge PR to master (rebase, linear history)
+#   3. git tag v1.2.3 && git push --tags   ← triggers this workflow
+#   4. Operator updates production .env: CD_IMAGE_TAG=v1.2.3
+#   5. Production CD daemon detects new :v1.2.3 digest and deploys
+#
+# IMPORTANT: only push release tags (v1.2.3) to master — not to feature
+# branches.  This workflow has no runtime guard against branch tags; by
+# convention and branch protection, release tags belong on master only.
+#
+# See docs/design/cicd-pipeline.md for the full pipeline design.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Only run for non-rc tags (rc tags are handled by build-rc.yml).
+# Using a job-level `if` rather than a tag pattern because GitHub Actions
+# glob syntax cannot negate suffixes reliably.
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  promote:
+    name: Promote :rc → ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-rc') }}
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Retag master image: :rc → :v1.2.3
+      - name: Retag master image
+        run: |
+          docker pull ghcr.io/${{ github.repository_owner }}/codex-slack-master:rc
+          docker tag  ghcr.io/${{ github.repository_owner }}/codex-slack-master:rc \
+                      ghcr.io/${{ github.repository_owner }}/codex-slack-master:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository_owner }}/codex-slack-master:${{ github.ref_name }}
+
+      # Retag agent-minimal image: :rc → :v1.2.3
+      - name: Retag agent-minimal image
+        run: |
+          docker pull ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:rc
+          docker tag  ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:rc \
+                      ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository_owner }}/codex-slack-agent-minimal:${{ github.ref_name }}
+
+      - name: Verify digest match
+        run: |
+          RC_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+            ghcr.io/${{ github.repository_owner }}/codex-slack-master:rc)
+          REL_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+            ghcr.io/${{ github.repository_owner }}/codex-slack-master:${{ github.ref_name }})
+          echo "rc digest:      ${RC_DIGEST}"
+          echo "release digest: ${REL_DIGEST}"
+          if [[ "${RC_DIGEST}" != "${REL_DIGEST}" ]]; then
+            echo "::error::Digest mismatch — release image does not match :rc image"
+            exit 1
+          fi
+          echo "Digest match confirmed."
+
+      - name: Summary
+        run: |
+          echo "## Release promoted: \`${{ github.ref_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Both images retagged from \`:rc\` → \`${{ github.ref_name }}\` (no rebuild)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Production image is bit-identical to the image UAT-approved on staging." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Next step:** update \`CD_IMAGE_TAG=${{ github.ref_name }}\` in production \`.env\` and restart the CD daemon." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-agent-minimal.yml
+++ b/.github/workflows/publish-agent-minimal.yml
@@ -1,17 +1,19 @@
 name: Publish Minimal Agent Image
 
+# Manual / ad-hoc build of the agent-minimal worker image.
+#
+# Automated builds are handled by dedicated workflows:
+#   - ci-pr.yml          — PR gate (build, no push)
+#   - build-on-demand.yml — agent test bed builds (:sha-<hash>)
+#   - build-rc.yml        — RC builds from feature branch tags (:v1.2.3-rc1, :rc)
+#   - promote-release.yml — release promotion by retagging :rc → :v1.2.3
+#
+# This workflow is retained for ad-hoc manual builds only.
+# It no longer triggers on master branch pushes or version tags.
+#
+# See docs/design/cicd-pipeline.md for the full pipeline design.
+
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - "v*"
-    paths:
-      - "Dockerfile.agent-minimal"
-      - "docker/entrypoint.sh"
-      - "src/**"
-      - "requirements.txt"
-      - ".github/workflows/publish-agent-minimal.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -1,29 +1,19 @@
 name: Publish Master Image
 
-# Builds and pushes the master orchestrator image to GHCR.
+# Manual / ad-hoc build of the master orchestrator image.
 #
-# Tag strategy
-# ------------
-# - Push to `master`  → image tagged `latest`  (staging environment tracks this)
-# - Push of `v*` tag  → image tagged with the semver (production environment tracks this)
-# - Every push        → image additionally tagged `sha-<short-commit>` for pinned rollbacks
+# Automated builds are handled by dedicated workflows:
+#   - ci-pr.yml          — PR gate (build, no push)
+#   - build-on-demand.yml — agent test bed builds (:sha-<hash>)
+#   - build-rc.yml        — RC builds from feature branch tags (:v1.2.3-rc1, :rc)
+#   - promote-release.yml — release promotion by retagging :rc → :v1.2.3
 #
-# The CD daemon on each environment watches the relevant tag and auto-deploys
-# when the digest changes.
+# This workflow is retained for ad-hoc manual builds only.
+# It no longer triggers on master branch pushes or version tags.
+#
+# See docs/design/cicd-pipeline.md for the full pipeline design.
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - "v*"
-    paths:
-      - "Dockerfile"
-      - "docker/entrypoint.sh"
-      - "src/**"
-      - "config/**"
-      - "requirements.txt"
-      - ".github/workflows/publish-master.yml"
   workflow_dispatch:
 
 permissions:
@@ -54,12 +44,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/codex-slack-master
           tags: |
-            # "latest" on every push to master — staging tracks this
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
-            # Short commit SHA for pinned rollback references
             type=sha,prefix=sha-
-            # Semver tag on releases — production tracks this
-            type=ref,event=tag
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,26 @@ pytest -q                  # run full test suite
 
 For containerised development, start with [`docs/manuals/ops-manual.md`](docs/manuals/ops-manual.md) and [`docs/guides/container-runtime.md`](docs/guides/container-runtime.md).
 
+## CI/CD and Deployments
+
+The project uses a three-environment pipeline (test bed → staging → production) with
+RC-based promotion. No code reaches master before UAT sign-off.
+
+**Read [`docs/design/cicd-pipeline.md`](docs/design/cicd-pipeline.md) before:**
+- Triggering any image build or deployment action
+- Pushing version tags (RC or release)
+- Making changes to `.github/workflows/`
+- Deploying to or troubleshooting any environment
+
+Key rules for agents:
+- Use `gh workflow run build-on-demand.yml --ref <branch>` to build images for test bed
+  use. Wait on the run ID with `gh run watch <run-id>` before deploying.
+- Tag the feature branch with `v<semver>-rc<N>` to trigger a staging RC build.
+  Do not tag master with RC tags.
+- Never push `:rc`, `:staging`, or release semver tags manually — those are owned by
+  `build-rc.yml` and `promote-release.yml` respectively.
+- Production `CD_IMAGE_TAG` is updated by a human operator after UAT sign-off, not by agents.
+
 ## Coding Style & Naming Conventions
 
 Until language-specific configs are added:

--- a/docs/decisions/0005-cicd-pipeline-design.md
+++ b/docs/decisions/0005-cicd-pipeline-design.md
@@ -11,12 +11,14 @@ Actions publish workflows (push-triggered, master/tag only) and a custom CD daem
 (`src/cd/`) that polls GHCR for digest changes and redeploys via docker compose. There was
 no PR-time test gate and no written policy for how code flows between environments.
 
-Three design questions needed resolution:
+Five design questions needed resolution:
 
 1. Should Jenkins be adopted alongside or instead of GitHub Actions?
-2. Is the CD daemon (pull-based CD) the right deployment model, or should GitHub Actions
-   push-deploy directly to hosts?
+2. Is the CD daemon (pull-based CD) the right deployment model for all environments?
 3. What are the formal trigger points and promotion rules for the three environments?
+4. How should the test bed be managed given that its primary operator is an LLM agent?
+5. How do we ensure master only receives UAT-approved code, and that the image deployed
+   to production is bit-identical to the image that was tested on staging?
 
 ## Decision
 
@@ -27,122 +29,189 @@ and publishing. Jenkins would add an additional server to operate, a separate se
 plugin lifecycle management, and network access requirements between Jenkins and GHCR — with
 no capability gain over what GitHub Actions provides for this project.
 
-If the team later requires on-premises build agents that cannot reach GitHub, self-hosted
-GitHub Actions runners satisfy that requirement without Jenkins.
+The master orchestrator's `gh` CLI is the bridge between the LLM agent and GitHub Actions
+workflows — no separate CI server is needed for agent-triggered builds.
 
-### 2. Retain the pull-based CD daemon
+### 2. CD daemon on staging and production; agent control on test bed
 
-The CD daemon (`src/cd/`) follows the pull-based deployment pattern: it runs on the
-deployment host, polls GHCR for digest changes, and invokes docker compose to redeploy. This
-is retained as the deployment mechanism for both staging and production.
+The CD daemon is retained for staging and production but is **not used on the test bed**.
 
-**Why pull-based fits this project:**
+**Why pull-based fits staging and production:**
 
 - The deployment host may be behind NAT or a firewall. Pull-based requires only outbound
-  connections from the host to GHCR; no inbound SSH port or GitHub runner IP allowlist is
-  needed.
-- The daemon provides rollback-on-failure built in: if a health check fails after deploy it
+  connections to GHCR; no inbound SSH port or GitHub runner IP allowlist is needed.
+- The daemon provides rollback-on-failure: if a health check fails after deploy it
   re-pulls and redeploys the previous digest automatically.
 - The daemon is already implemented, tested, and in use.
 
-**Known limitations and mitigations:**
+**Why the test bed is agent-managed:**
 
-- *Polling lag* — the default poll interval is 300 s (5 min). A future improvement is to
-  add a webhook receiver endpoint to the daemon so the GitHub Actions publish workflow can
-  trigger an immediate check via HTTP POST rather than waiting for the next poll cycle.
-- *Silent daemon failure* — if the daemon process dies, deployments stop without alerting.
-  The compose file should set `restart: unless-stopped` on the daemon service, and Slack/
-  Discord webhook notifications should be monitored.
+The test bed's purpose is pre-UAT development testing by LLM agents. Agents need to deploy
+arbitrary builds on demand, iterate rapidly, and control the exact deploy lifecycle. A
+passive polling daemon cannot do this. The agent already controls container lifecycle via
+the Podman socket the master orchestrator holds.
 
-**Rejected alternative — push-based SSH deploy from GHA:**
+### 3. No merge to master before UAT sign-off
 
-After image push a GHA job would SSH into the deployment host and run
-`docker compose pull && docker compose up -d`. This is simpler operationally and makes
-deploy history visible in GitHub, but requires an SSH key stored in GHA secrets and an
-inbound firewall rule for GitHub runner IP ranges. Given that this project already has the
-daemon and the firewall constraint is real, push-based is not adopted at this time.
+Code is built and tested from the feature branch. `master` only receives commits after UAT
+is complete. This is enforced by:
 
-### 3. Three-environment promotion path
+- Building release candidate images from RC tags on the feature branch (not from master)
+- Requiring the PR to be approved (UAT sign-off) before it can be merged
+- Enforcing linear history on master (rebase-only merges, no merge commits)
+- Requiring branches to be up to date before merging
+
+Master is a stable, always-releasable pointer. It receives new commits through fast-forward-
+equivalent rebase merges only after the code has been UAT-approved on staging.
+
+### 4. Three-environment promotion path
 
 ```
-PR branch  ──► CI jobs (pytest + docker build) ──► merge gate
-                                                         │
-                                                   merge to master
-                                                         │
-                                              build + push :latest + :sha-<hash>
-                                                         │
-                                                      STAGING
-                                             (daemon tracks :latest)
-                                                         │
-                                              human decision: tag release
-                                                         │
-                                                git tag v1.2.3 + push
-                                                         │
-                                              build + push :v1.2.3
-                                                         │
-                                                    PRODUCTION
-                                             (daemon tracks :v1.2.3)
+feat/x branch
+      │
+      │  agent: build-on-demand.yml → :sha-<hash> → test bed
+      │  agent: creates PR, runs ci-pr.yml gate
+      │
+      ▼  git tag v1.2.3-rc1 (on branch)
+         build-rc.yml: builds both images
+         pushes :v1.2.3-rc1 (immutable) + :rc (mutable)
+      │
+      ▼  STAGING ← CD daemon, CD_IMAGE_TAG=rc
+         auto-deploys on new :rc digest
+         user + agent perform UAT
+
+  ┌─ UAT issues → fix on feat/x, git tag v1.2.3-rc2, repeat ─┐
+  └───────────────────────────────────────────────────────────┘
+
+      │  UAT sign-off
+      ▼  PR approved, merged to master (rebase, linear history)
+      │
+      ▼  git tag v1.2.3 (on master)
+         promote-release.yml: retags :rc → :v1.2.3 (no rebuild)
+      │
+      ▼  PRODUCTION ← CD daemon, CD_IMAGE_TAG=v1.2.3
+         operator updates .env, daemon deploys
 ```
 
-**Test bed** — ephemeral, runs inside GitHub Actions on every PR commit. No persistent
-infrastructure. The `ci-pr.yml` workflow runs `pytest` and validates both Docker builds.
-Merging to master is blocked until this job passes (enforced via GitHub branch protection).
+**Test bed** — persistent, agent-managed. Agent triggers `build-on-demand.yml` via
+`gh workflow run`, waits on the run ID, deploys `:sha-<hash>` directly. No daemon.
 
-**Staging** — persistent host. The CD daemon is configured with `CD_IMAGE_TAG=latest`.
-Every merge to master triggers a new image push, which the daemon detects within one poll
-cycle and deploys automatically. Used for human smoke-testing before a release is tagged.
+**Staging** — persistent, CD daemon, `CD_IMAGE_TAG=rc`. Receives RC builds automatically
+when a `v*-rc*` tag is pushed to the feature branch. Used for user and agent UAT.
 
-**Production** — persistent host. The CD daemon is configured with a pinned semver tag
-(e.g. `CD_IMAGE_TAG=v1.2.3`). Promotion to production is a two-step human action:
-(1) push a `v*` git tag; (2) update `CD_IMAGE_TAG` in the production environment's config
-to the new semver (or restart the daemon with the new tag). The daemon then detects the new
-digest for that tag and deploys.
+**Production** — persistent, CD daemon, `CD_IMAGE_TAG=v1.2.3`. Receives releases only
+after UAT sign-off. `CD_IMAGE_TAG` is updated manually by the operator per release.
+
+### 5. RC-based promotion with bit-identical production image
+
+**Trigger for staging deploy:** a `v*-rc*` tag pushed to the feature branch (not a merge to
+master). This is the key structural change from the original design.
+
+**Staging tracks `:rc` (mutable).** Every new RC tag updates `:rc` in GHCR. The staging
+daemon auto-deploys on digest change. Multiple RC iterations are expected during UAT; each
+one advances `:rc` to the latest tested build.
+
+**Release promotion without rebuild (`promote-release.yml`):** when a `v*` (non-rc) tag is
+pushed on master after merge, the workflow pulls `:rc` by digest and pushes that same digest
+under `:v1.2.3`. It does not invoke `docker build`. This guarantees that production receives
+the exact image bits that were UAT-approved on staging.
+
+**Why retag instead of rebuild:** rebuilding from the same source could theoretically produce
+a different image (base layer updates, pip dependency resolution). Retagging the `:rc` digest
+eliminates this risk entirely.
+
+**Note on commit SHAs and fast-forward:** GitHub's rebase merge creates new commit SHAs even
+for identical code. The image identity guarantee is not provided by commit SHA matching — it
+is provided by operating on GHCR image digests in `promote-release.yml`.
+
+### 6. Image tagging strategy (`:latest` removed)
+
+| Tag | When pushed | Mutable | Tracked by |
+|---|---|---|---|
+| `:sha-<hash>` | Every `build-on-demand.yml` run | No | Agent (test bed) |
+| `:v1.2.3-rc1` | RC tag push on any branch | No | Audit trail |
+| `:rc` | RC tag push (always latest RC) | Yes | Staging CD daemon |
+| `:v1.2.3` | Release retag on master tag | No | Production CD daemon |
+
+`:latest` is not used. All promotion tags have unambiguous semantics and a clear owner.
 
 ## Alternatives Considered
 
 ### Jenkins
 
-Rejected. See decision 1 above. No capability gap justifies the operational overhead.
+Rejected. No capability gap justifies the operational overhead.
+
+### CD daemon on test bed
+
+Rejected. The test bed is for iterative agent testing. A polling daemon cannot deploy on
+demand or handle the rapid broken/fixed cycle that pre-UAT development involves.
+
+### Merge to master before UAT (original design)
+
+Rejected. In the original design, every master merge triggered an image build and auto-
+deployed to staging. This meant unverified code could reach staging and potentially
+production before any human had validated the behaviour. The RC-based flow inverts this:
+staging only receives explicitly tagged, deliberately promoted builds.
+
+### Staging tracks `:staging` (explicit promote step)
+
+Considered as an alternative to staging tracking `:rc`. With `:staging`, a human or agent
+would run `promote-staging.yml` to move a specific SHA to staging. Rejected because:
+- RC tagging already serves as the explicit promotion action
+- An additional promote step between test bed and staging adds friction without benefit
+- Agents will iterate through multiple RCs; automating the staging deploy on RC tag is
+  the right default
+
+### Rebuild at release time instead of retag
+
+Rejected. Rebuilding from the same source could produce a different image (base layer
+updates, non-deterministic pip resolution). Retagging the `:rc` digest guarantees
+production receives exactly what was tested.
 
 ### Watchtower (third-party pull-based daemon)
 
-Considered as a replacement for `src/cd/`. Watchtower is a mature open-source container that
-monitors registries and redeploys. It would eliminate the custom daemon code but remove the
-built-in rollback-on-failure logic, the Slack/Discord notification integration, and the
-per-environment configurability that the current daemon provides. Not adopted; the existing
-daemon is retained.
+Considered as a replacement for `src/cd/`. Loses the built-in rollback-on-failure logic,
+the Slack/Discord notification integration, and per-environment configurability. Not adopted.
 
 ### Push-based SSH deploy from GitHub Actions
 
-Rejected. See decision 2 above. Requires inbound SSH access from GitHub runner IPs.
+Rejected. Requires inbound SSH access from GitHub runner IPs. Firewall constraint is real.
 
 ### Kubernetes with image-update automation (Flux/ArgoCD)
 
-Not applicable. The project runs on a single host with docker compose. Kubernetes
-infrastructure would be disproportionate overhead.
+Not applicable. Single-host docker compose deployment.
 
 ## Consequences
 
 Positive:
 
-- PRs are gated on tests; broken code cannot reach master.
-- Staging always reflects the latest merged state within minutes.
-- Production is promoted deliberately via a version tag; rollbacks are one tag-push away.
-- No new infrastructure to operate (no Jenkins server, no Kubernetes cluster).
-- The existing CD daemon and publish workflows are reused with minimal changes.
+- `master` is always clean — it only receives UAT-approved code.
+- The production image is bit-identical to the image that ran on staging during UAT.
+- Staging gets RC builds automatically on tag push — no extra promotion step needed.
+- Test bed is fast and flexible — agent deploys any SHA in seconds, no polling lag.
+- Multiple RC iterations are first-class — each new tag advances staging automatically.
+- Linear history on master makes git log clean and bisectable.
 
 Tradeoffs:
 
-- Staging deploys have up to 5 min lag from merge to live (polling interval).
-- Production promotion requires two manual steps (git tag + env config update). This is
-  intentional — a human must decide when staging is ready for production.
-- The CD daemon process must itself be monitored; if it exits silently, deployments stall.
+- Operators must push two tags per release: the RC tag (on branch) and the release tag
+  (on master after merge). This is intentional — each is a deliberate human action.
+- GitHub's rebase merge does not guarantee commit SHA identity. Image identity is
+  guaranteed instead via digest-based retagging.
+- Staging always reflects the latest RC. If rc2 is pushed before rc1 UAT is complete,
+  staging moves to rc2. Document this as expected behaviour; avoid pushing new RCs while
+  UAT is actively in progress on the previous RC.
+- The CD daemon has polling lag (≤5 min staging, ≤10 min production). Acceptable because
+  both have explicit human promotion gates.
 
 ## Implementation Notes
 
-- Add branch protection rule on `master`: require `CI — PR Tests / pytest` and
-  `CI — PR Tests / Docker build check` status checks to pass before merge.
-- Staging compose stack should set `restart: unless-stopped` on the CD daemon service.
-- Production `CD_IMAGE_TAG` should be pinned to a semver string, never `latest`.
-- When the webhook receiver improvement is implemented, record it in a new ADR or as an
-  amendment to this one.
+- `build-rc.yml` triggers on `v*-rc*` tags on any branch — not just master.
+- `promote-release.yml` triggers on `v*` non-rc tags on `master` only — prevents accidental
+  release promotion from feature branches.
+- `publish-master.yml` master-push trigger should be removed; master pushes no longer build
+  images. Only tag-triggered builds remain.
+- `promote-staging.yml` is not needed — staging promotion is automatic via `:rc` tag.
+- Branch protection on master: rebase-only, require up-to-date, require CI checks.
+- Production `CD_IMAGE_TAG` must always be a semver string, never `:rc`.
+- Implement `build-rc.yml` and `promote-release.yml` after this ADR is signed off.

--- a/docs/decisions/0005-cicd-pipeline-design.md
+++ b/docs/decisions/0005-cicd-pipeline-design.md
@@ -11,14 +11,13 @@ Actions publish workflows (push-triggered, master/tag only) and a custom CD daem
 (`src/cd/`) that polls GHCR for digest changes and redeploys via docker compose. There was
 no PR-time test gate and no written policy for how code flows between environments.
 
-Five design questions needed resolution:
+Four design questions needed resolution:
 
 1. Should Jenkins be adopted alongside or instead of GitHub Actions?
 2. Is the CD daemon (pull-based CD) the right deployment model for all environments?
 3. What are the formal trigger points and promotion rules for the three environments?
-4. How should the test bed be managed given that its primary operator is an LLM agent?
-5. How do we ensure master only receives UAT-approved code, and that the image deployed
-   to production is bit-identical to the image that was tested on staging?
+4. How should the test bed be managed given that its primary operator is an LLM agent, not
+   a human release engineer?
 
 ## Decision
 
@@ -28,6 +27,9 @@ Jenkins is not adopted. The existing GitHub Actions workflows already handle ima
 and publishing. Jenkins would add an additional server to operate, a separate secret store,
 plugin lifecycle management, and network access requirements between Jenkins and GHCR — with
 no capability gain over what GitHub Actions provides for this project.
+
+If the team later requires on-premises build agents that cannot reach GitHub, self-hosted
+GitHub Actions runners satisfy that requirement without Jenkins.
 
 The master orchestrator's `gh` CLI is the bridge between the LLM agent and GitHub Actions
 workflows — no separate CI server is needed for agent-triggered builds.
@@ -39,179 +41,168 @@ The CD daemon is retained for staging and production but is **not used on the te
 **Why pull-based fits staging and production:**
 
 - The deployment host may be behind NAT or a firewall. Pull-based requires only outbound
-  connections to GHCR; no inbound SSH port or GitHub runner IP allowlist is needed.
+  connections from the host to GHCR; no inbound SSH port or GitHub runner IP allowlist is
+  needed.
 - The daemon provides rollback-on-failure: if a health check fails after deploy it
   re-pulls and redeploys the previous digest automatically.
 - The daemon is already implemented, tested, and in use.
 
-**Why the test bed is agent-managed:**
+**Why the test bed is agent-managed instead:**
 
-The test bed's purpose is pre-UAT development testing by LLM agents. Agents need to deploy
-arbitrary builds on demand, iterate rapidly, and control the exact deploy lifecycle. A
-passive polling daemon cannot do this. The agent already controls container lifecycle via
-the Podman socket the master orchestrator holds.
+The test bed's purpose is pre-UAT development testing and troubleshooting by LLM agents.
+Agents need to:
+- Deploy arbitrary builds (feature branches, specific SHAs) on demand
+- Iterate rapidly between broken and working states
+- Control the exact deploy lifecycle without waiting for a polling cycle
 
-### 3. No merge to master before UAT sign-off
+A passive polling daemon is the wrong model for this. The agent already controls container
+lifecycle via the Podman socket that the master orchestrator holds. Agent-direct deployment
+is simpler, faster, and more aligned with how agents work.
 
-Code is built and tested from the feature branch. `master` only receives commits after UAT
-is complete. This is enforced by:
+**Known limitations and mitigations for the CD daemon (staging/production):**
 
-- Building release candidate images from RC tags on the feature branch (not from master)
-- Requiring the PR to be approved (UAT sign-off) before it can be merged
-- Enforcing linear history on master (rebase-only merges, no merge commits)
-- Requiring branches to be up to date before merging
+- *Polling lag* — up to 5 min on staging, up to 10 min on production. Acceptable given that
+  both environments have explicit human promotion gates; nobody is watching a clock.
+- *Silent daemon failure* — if the daemon process dies, deployments stop without alerting.
+  Compose files must set `restart: unless-stopped` on the daemon service.
 
-Master is a stable, always-releasable pointer. It receives new commits through fast-forward-
-equivalent rebase merges only after the code has been UAT-approved on staging.
+**Rejected alternative — push-based SSH deploy from GHA:**
 
-### 4. Three-environment promotion path
+After image push a GHA job would SSH into the deployment host and run
+`docker compose pull && docker compose up -d`. Requires an SSH key stored in GHA secrets
+and an inbound firewall rule for GitHub runner IP ranges. Not adopted; firewall constraint
+is real.
+
+### 3. Three-environment promotion path
 
 ```
-feat/x branch
+feature branch
       │
-      │  agent: build-on-demand.yml → :sha-<hash> → test bed
-      │  agent: creates PR, runs ci-pr.yml gate
+      │  agent triggers build-on-demand.yml (workflow_dispatch)
+      │  waits on run ID via: gh run watch <run-id>
+      ▼
+  GHA builds both images from branch ref
+  pushes :sha-<hash> only (dead-end tag, cannot enter staging)
       │
-      ▼  git tag v1.2.3-rc1 (on branch)
-         build-rc.yml: builds both images
-         pushes :v1.2.3-rc1 (immutable) + :rc (mutable)
+      ▼
+  TEST BED  ← agent-managed, no daemon
+  agent deploys, tests, iterates
       │
-      ▼  STAGING ← CD daemon, CD_IMAGE_TAG=rc
-         auto-deploys on new :rc digest
-         user + agent perform UAT
-
-  ┌─ UAT issues → fix on feat/x, git tag v1.2.3-rc2, repeat ─┐
-  └───────────────────────────────────────────────────────────┘
-
-      │  UAT sign-off
-      ▼  PR approved, merged to master (rebase, linear history)
+      │  PR merged to master
+      ▼
+  GHA publish-master.yml builds from master, pushes :sha-<hash>
       │
-      ▼  git tag v1.2.3 (on master)
-         promote-release.yml: retags :rc → :v1.2.3 (no rebuild)
+      │  agent or human triggers promote-staging.yml (workflow_dispatch)
+      │  retags :sha-<hash> → :staging in GHCR (no rebuild)
+      ▼
+  STAGING  ← CD daemon, CD_IMAGE_TAG=staging
+  user + agent UAT
       │
-      ▼  PRODUCTION ← CD daemon, CD_IMAGE_TAG=v1.2.3
-         operator updates .env, daemon deploys
+      │  human: git tag v1.2.3 && git push --tags
+      ▼
+  GHA publish-master.yml (tag trigger) builds, pushes :v1.2.3
+      │
+      ▼
+  PRODUCTION  ← CD daemon, CD_IMAGE_TAG=v1.2.3
 ```
 
-**Test bed** — persistent, agent-managed. Agent triggers `build-on-demand.yml` via
-`gh workflow run`, waits on the run ID, deploys `:sha-<hash>` directly. No daemon.
+**Test bed** — persistent host, agent-managed. The agent triggers `build-on-demand.yml`
+via `gh workflow run`, waits synchronously on the run ID, then deploys the resulting
+`:sha-<hash>` image directly. Used for testing feature branches before they merge to master.
+No CD daemon runs here.
 
-**Staging** — persistent, CD daemon, `CD_IMAGE_TAG=rc`. Receives RC builds automatically
-when a `v*-rc*` tag is pushed to the feature branch. Used for user and agent UAT.
+**Staging** — persistent host, CD daemon, `CD_IMAGE_TAG=staging`. Receives builds that
+agents have validated on the test bed. Promotion from test bed to staging is an explicit
+action: running `promote-staging.yml` which retags an approved SHA as `:staging`. Used for
+user and agent UAT, and issue reproduction in a stable-enough environment.
 
-**Production** — persistent, CD daemon, `CD_IMAGE_TAG=v1.2.3`. Receives releases only
-after UAT sign-off. `CD_IMAGE_TAG` is updated manually by the operator per release.
+**Production** — persistent host, CD daemon, `CD_IMAGE_TAG=v1.2.3`. Promotion is a
+two-step human action: (1) push a `v*` git tag; (2) update `CD_IMAGE_TAG` in the production
+environment's config. Receives only human-approved release builds.
 
-### 5. RC-based promotion with bit-identical production image
+### 4. On-demand branch builds via workflow_dispatch
 
-**Trigger for staging deploy:** a `v*-rc*` tag pushed to the feature branch (not a merge to
-master). This is the key structural change from the original design.
+The agent triggers builds of arbitrary branches using `gh workflow run` against a new
+`build-on-demand.yml` workflow. The agent waits on the run ID synchronously rather than
+relying on webhook notifications.
 
-**Staging tracks `:rc` (mutable).** Every new RC tag updates `:rc` in GHCR. The staging
-daemon auto-deploys on digest change. Multiple RC iterations are expected during UAT; each
-one advances `:rc` to the latest tested build.
+This pattern keeps unverified branch code isolated from the promotion chain. A branch image
+can only enter staging via an explicit `promote-staging.yml` run — there is no automatic
+path from a branch build into staging or production.
 
-**Release promotion without rebuild (`promote-release.yml`):** when a `v*` (non-rc) tag is
-pushed on master after merge, the workflow pulls `:rc` by digest and pushes that same digest
-under `:v1.2.3`. It does not invoke `docker build`. This guarantees that production receives
-the exact image bits that were UAT-approved on staging.
+### 5. Image tagging strategy (`:latest` removed)
 
-**Why retag instead of rebuild:** rebuilding from the same source could theoretically produce
-a different image (base layer updates, pip dependency resolution). Retagging the `:rc` digest
-eliminates this risk entirely.
+| Tag | When pushed | Used by |
+|---|---|---|
+| `:sha-<hash>` | Every build (branch, master push, tag push) | Agent deploys to test bed explicitly |
+| `:staging` | When `promote-staging.yml` runs | Staging CD daemon |
+| `:v1.2.3` | When `v1.2.3` git tag is pushed | Production CD daemon |
 
-**Note on commit SHAs and fast-forward:** GitHub's rebase merge creates new commit SHAs even
-for identical code. The image identity guarantee is not provided by commit SHA matching — it
-is provided by operating on GHCR image digests in `promote-release.yml`.
-
-### 6. Image tagging strategy (`:latest` removed)
-
-| Tag | When pushed | Mutable | Tracked by |
-|---|---|---|---|
-| `:sha-<hash>` | Every `build-on-demand.yml` run | No | Agent (test bed) |
-| `:v1.2.3-rc1` | RC tag push on any branch | No | Audit trail |
-| `:rc` | RC tag push (always latest RC) | Yes | Staging CD daemon |
-| `:v1.2.3` | Release retag on master tag | No | Production CD daemon |
-
-`:latest` is not used. All promotion tags have unambiguous semantics and a clear owner.
+`:latest` is not used. It was ambiguous — "latest what?" — and created risk of accidental
+promotion. Every tag now has unambiguous semantics and a clear owner.
 
 ## Alternatives Considered
 
 ### Jenkins
 
-Rejected. No capability gap justifies the operational overhead.
+Rejected. See decision 1 above. No capability gap justifies the operational overhead.
 
 ### CD daemon on test bed
 
-Rejected. The test bed is for iterative agent testing. A polling daemon cannot deploy on
-demand or handle the rapid broken/fixed cycle that pre-UAT development involves.
-
-### Merge to master before UAT (original design)
-
-Rejected. In the original design, every master merge triggered an image build and auto-
-deployed to staging. This meant unverified code could reach staging and potentially
-production before any human had validated the behaviour. The RC-based flow inverts this:
-staging only receives explicitly tagged, deliberately promoted builds.
-
-### Staging tracks `:staging` (explicit promote step)
-
-Considered as an alternative to staging tracking `:rc`. With `:staging`, a human or agent
-would run `promote-staging.yml` to move a specific SHA to staging. Rejected because:
-- RC tagging already serves as the explicit promotion action
-- An additional promote step between test bed and staging adds friction without benefit
-- Agents will iterate through multiple RCs; automating the staging deploy on RC tag is
-  the right default
-
-### Rebuild at release time instead of retag
-
-Rejected. Rebuilding from the same source could produce a different image (base layer
-updates, non-deterministic pip resolution). Retagging the `:rc` digest guarantees
-production receives exactly what was tested.
+Rejected. The test bed is designed for agent-driven iterative testing. A polling daemon
+cannot deploy on demand, cannot choose which SHA to deploy, and cannot handle the rapid
+broken/fixed cycle that pre-UAT development involves. Agent-direct deployment is the right
+model for this environment.
 
 ### Watchtower (third-party pull-based daemon)
 
-Considered as a replacement for `src/cd/`. Loses the built-in rollback-on-failure logic,
-the Slack/Discord notification integration, and per-environment configurability. Not adopted.
+Considered as a replacement for `src/cd/`. Watchtower is a mature open-source container
+that monitors registries and redeploys. It would eliminate the custom daemon code but
+remove the built-in rollback-on-failure logic, the Slack/Discord notification integration,
+and the per-environment configurability. Not adopted; the existing daemon is retained.
 
 ### Push-based SSH deploy from GitHub Actions
 
-Rejected. Requires inbound SSH access from GitHub runner IPs. Firewall constraint is real.
+Rejected. See decision 2 above. Requires inbound SSH access from GitHub runner IPs.
+
+### Webhook notification from build-on-demand to agent
+
+Considered for `build-on-demand.yml`: post a Slack/Discord message when the build
+completes so the agent knows without polling. Rejected in favour of `gh run watch <run-id>`:
+synchronous polling on the run ID is simpler, doesn't require webhook URL configuration,
+and is already available via the `gh` CLI the agent holds.
 
 ### Kubernetes with image-update automation (Flux/ArgoCD)
 
-Not applicable. Single-host docker compose deployment.
+Not applicable. The project runs on a single host with docker compose. Kubernetes
+infrastructure would be disproportionate overhead.
 
 ## Consequences
 
 Positive:
 
-- `master` is always clean — it only receives UAT-approved code.
-- The production image is bit-identical to the image that ran on staging during UAT.
-- Staging gets RC builds automatically on tag push — no extra promotion step needed.
+- PRs are gated on tests; broken code cannot reach master.
 - Test bed is fast and flexible — agent deploys any SHA in seconds, no polling lag.
-- Multiple RC iterations are first-class — each new tag advances staging automatically.
-- Linear history on master makes git log clean and bisectable.
+- Staging only receives builds the agent has explicitly approved.
+- Production only receives human-tagged releases.
+- No new infrastructure to operate (no Jenkins server, no Kubernetes cluster).
+- `:latest` removal eliminates the ambiguity of what "latest" means across environments.
 
 Tradeoffs:
 
-- Operators must push two tags per release: the RC tag (on branch) and the release tag
-  (on master after merge). This is intentional — each is a deliberate human action.
-- GitHub's rebase merge does not guarantee commit SHA identity. Image identity is
-  guaranteed instead via digest-based retagging.
-- Staging always reflects the latest RC. If rc2 is pushed before rc1 UAT is complete,
-  staging moves to rc2. Document this as expected behaviour; avoid pushing new RCs while
-  UAT is actively in progress on the previous RC.
-- The CD daemon has polling lag (≤5 min staging, ≤10 min production). Acceptable because
-  both have explicit human promotion gates.
+- Staging and production deploys have polling lag (up to 5 and 10 min respectively).
+  This is acceptable because both have explicit promotion gates — speed is not the concern.
+- Agent must wait on `gh run watch` during on-demand builds (~minutes). The agent is
+  blocked during this time.
+- Two new GHA workflows are required (`build-on-demand.yml`, `promote-staging.yml`).
+  `publish-master.yml` needs a minor update to stop pushing `:latest`.
 
 ## Implementation Notes
 
-- `build-rc.yml` triggers on `v*-rc*` tags on any branch — not just master.
-- `promote-release.yml` triggers on `v*` non-rc tags on `master` only — prevents accidental
-  release promotion from feature branches.
-- `publish-master.yml` master-push trigger should be removed; master pushes no longer build
-  images. Only tag-triggered builds remain.
-- `promote-staging.yml` is not needed — staging promotion is automatic via `:rc` tag.
-- Branch protection on master: rebase-only, require up-to-date, require CI checks.
-- Production `CD_IMAGE_TAG` must always be a semver string, never `:rc`.
-- Implement `build-rc.yml` and `promote-release.yml` after this ADR is signed off.
+- Add branch protection rule on `master`: require `CI — PR Tests / pytest` and
+  `CI — PR Tests / Docker build check` status checks before merge.
+- Staging and production compose stacks must set `restart: unless-stopped` on the daemon.
+- Production `CD_IMAGE_TAG` must always be a semver string, never `:staging` or `:latest`.
+- `build-on-demand.yml` must push `:sha-<hash>` only — no promotion tags.
+- `promote-staging.yml` retags an existing image in GHCR — it does not rebuild.
+- Implement `build-on-demand.yml` and `promote-staging.yml` after this ADR is signed off.

--- a/docs/decisions/0005-cicd-pipeline-design.md
+++ b/docs/decisions/0005-cicd-pipeline-design.md
@@ -1,0 +1,148 @@
+# 0005 CI/CD Pipeline Design
+
+- Status: accepted
+- Date: 2026-05-04
+
+## Context
+
+The project deploys two Docker images (master orchestrator and agent-minimal worker) to three
+environments: test bed, staging, and production. Before this ADR the repository had two GitHub
+Actions publish workflows (push-triggered, master/tag only) and a custom CD daemon
+(`src/cd/`) that polls GHCR for digest changes and redeploys via docker compose. There was
+no PR-time test gate and no written policy for how code flows between environments.
+
+Three design questions needed resolution:
+
+1. Should Jenkins be adopted alongside or instead of GitHub Actions?
+2. Is the CD daemon (pull-based CD) the right deployment model, or should GitHub Actions
+   push-deploy directly to hosts?
+3. What are the formal trigger points and promotion rules for the three environments?
+
+## Decision
+
+### 1. GitHub Actions only — no Jenkins
+
+Jenkins is not adopted. The existing GitHub Actions workflows already handle image building
+and publishing. Jenkins would add an additional server to operate, a separate secret store,
+plugin lifecycle management, and network access requirements between Jenkins and GHCR — with
+no capability gain over what GitHub Actions provides for this project.
+
+If the team later requires on-premises build agents that cannot reach GitHub, self-hosted
+GitHub Actions runners satisfy that requirement without Jenkins.
+
+### 2. Retain the pull-based CD daemon
+
+The CD daemon (`src/cd/`) follows the pull-based deployment pattern: it runs on the
+deployment host, polls GHCR for digest changes, and invokes docker compose to redeploy. This
+is retained as the deployment mechanism for both staging and production.
+
+**Why pull-based fits this project:**
+
+- The deployment host may be behind NAT or a firewall. Pull-based requires only outbound
+  connections from the host to GHCR; no inbound SSH port or GitHub runner IP allowlist is
+  needed.
+- The daemon provides rollback-on-failure built in: if a health check fails after deploy it
+  re-pulls and redeploys the previous digest automatically.
+- The daemon is already implemented, tested, and in use.
+
+**Known limitations and mitigations:**
+
+- *Polling lag* — the default poll interval is 300 s (5 min). A future improvement is to
+  add a webhook receiver endpoint to the daemon so the GitHub Actions publish workflow can
+  trigger an immediate check via HTTP POST rather than waiting for the next poll cycle.
+- *Silent daemon failure* — if the daemon process dies, deployments stop without alerting.
+  The compose file should set `restart: unless-stopped` on the daemon service, and Slack/
+  Discord webhook notifications should be monitored.
+
+**Rejected alternative — push-based SSH deploy from GHA:**
+
+After image push a GHA job would SSH into the deployment host and run
+`docker compose pull && docker compose up -d`. This is simpler operationally and makes
+deploy history visible in GitHub, but requires an SSH key stored in GHA secrets and an
+inbound firewall rule for GitHub runner IP ranges. Given that this project already has the
+daemon and the firewall constraint is real, push-based is not adopted at this time.
+
+### 3. Three-environment promotion path
+
+```
+PR branch  ──► CI jobs (pytest + docker build) ──► merge gate
+                                                         │
+                                                   merge to master
+                                                         │
+                                              build + push :latest + :sha-<hash>
+                                                         │
+                                                      STAGING
+                                             (daemon tracks :latest)
+                                                         │
+                                              human decision: tag release
+                                                         │
+                                                git tag v1.2.3 + push
+                                                         │
+                                              build + push :v1.2.3
+                                                         │
+                                                    PRODUCTION
+                                             (daemon tracks :v1.2.3)
+```
+
+**Test bed** — ephemeral, runs inside GitHub Actions on every PR commit. No persistent
+infrastructure. The `ci-pr.yml` workflow runs `pytest` and validates both Docker builds.
+Merging to master is blocked until this job passes (enforced via GitHub branch protection).
+
+**Staging** — persistent host. The CD daemon is configured with `CD_IMAGE_TAG=latest`.
+Every merge to master triggers a new image push, which the daemon detects within one poll
+cycle and deploys automatically. Used for human smoke-testing before a release is tagged.
+
+**Production** — persistent host. The CD daemon is configured with a pinned semver tag
+(e.g. `CD_IMAGE_TAG=v1.2.3`). Promotion to production is a two-step human action:
+(1) push a `v*` git tag; (2) update `CD_IMAGE_TAG` in the production environment's config
+to the new semver (or restart the daemon with the new tag). The daemon then detects the new
+digest for that tag and deploys.
+
+## Alternatives Considered
+
+### Jenkins
+
+Rejected. See decision 1 above. No capability gap justifies the operational overhead.
+
+### Watchtower (third-party pull-based daemon)
+
+Considered as a replacement for `src/cd/`. Watchtower is a mature open-source container that
+monitors registries and redeploys. It would eliminate the custom daemon code but remove the
+built-in rollback-on-failure logic, the Slack/Discord notification integration, and the
+per-environment configurability that the current daemon provides. Not adopted; the existing
+daemon is retained.
+
+### Push-based SSH deploy from GitHub Actions
+
+Rejected. See decision 2 above. Requires inbound SSH access from GitHub runner IPs.
+
+### Kubernetes with image-update automation (Flux/ArgoCD)
+
+Not applicable. The project runs on a single host with docker compose. Kubernetes
+infrastructure would be disproportionate overhead.
+
+## Consequences
+
+Positive:
+
+- PRs are gated on tests; broken code cannot reach master.
+- Staging always reflects the latest merged state within minutes.
+- Production is promoted deliberately via a version tag; rollbacks are one tag-push away.
+- No new infrastructure to operate (no Jenkins server, no Kubernetes cluster).
+- The existing CD daemon and publish workflows are reused with minimal changes.
+
+Tradeoffs:
+
+- Staging deploys have up to 5 min lag from merge to live (polling interval).
+- Production promotion requires two manual steps (git tag + env config update). This is
+  intentional — a human must decide when staging is ready for production.
+- The CD daemon process must itself be monitored; if it exits silently, deployments stall.
+
+## Implementation Notes
+
+- Add branch protection rule on `master`: require `CI — PR Tests / pytest` and
+  `CI — PR Tests / Docker build check` status checks to pass before merge.
+- Staging compose stack should set `restart: unless-stopped` on the CD daemon service.
+- Production `CD_IMAGE_TAG` should be pinned to a semver string, never `latest`.
+- When the webhook receiver improvement is implemented, record it in a new ADR or as an
+  amendment to this one.

--- a/docs/design/cicd-pipeline.md
+++ b/docs/design/cicd-pipeline.md
@@ -1,0 +1,270 @@
+# CI/CD Pipeline Design
+
+**Status:** Accepted — see ADR 0005  
+**Date:** 2026-05-04
+
+---
+
+## Context
+
+This document describes the end-to-end CI/CD pipeline for the codex-slack project: what
+triggers it, what it builds, how images are promoted across environments, and why the CD
+daemon pattern was chosen over alternatives.
+
+The project produces two Docker images:
+
+| Image | Purpose |
+|---|---|
+| `ghcr.io/<org>/codex-slack-master` | Master orchestrator + single-session bot |
+| `ghcr.io/<org>/codex-slack-agent-minimal` | Lean agent worker spawned by master |
+
+Both images are deployed to three environments: test bed (ephemeral, CI), staging
+(persistent, `latest`), and production (persistent, pinned semver).
+
+---
+
+## What is a GitHub Actions runner?
+
+A GitHub Actions **runner** is the machine that executes a workflow job. GitHub provides
+hosted runners — ephemeral virtual machines (Ubuntu, Windows, macOS) that GitHub spins up
+fresh for each job and discards when the job finishes. `runs-on: ubuntu-latest` in a
+workflow file requests one of these.
+
+Hosted runners have:
+- ~7 GB RAM, 2 vCPUs, ~14 GB SSD (for Ubuntu)
+- Docker, Python, Node.js, and most common tools pre-installed
+- No persistence between runs — every job starts from a clean slate
+- Network access to the internet (GHCR, PyPI, etc.)
+
+You can also run **self-hosted runners** on your own machines (useful if builds need access
+to internal networks, GPUs, or large caches). For this project, GitHub-hosted runners are
+sufficient.
+
+---
+
+## Pipeline overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Developer pushes commits to a PR branch                         │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │  ci-pr.yml          │  ← GitHub Actions (GHA runner)
+                    │  1. pytest          │
+                    │  2. docker build    │
+                    │     (no push)       │
+                    └──────────┬──────────┘
+                               │ all jobs green?
+                    ┌──────────▼──────────┐
+                    │  PR can be merged   │  ← branch protection gate
+                    └──────────┬──────────┘
+                               │ human merges to master
+          ┌────────────────────▼────────────────────┐
+          │  publish-master.yml                      │  ← GHA runner
+          │  publish-agent-minimal.yml               │
+          │  Build both images                       │
+          │  Push :latest + :sha-<hash> to GHCR      │
+          └────────────────────┬────────────────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │  STAGING            │  ← persistent host
+                    │  CD daemon polls    │
+                    │  GHCR every 5 min   │
+                    │  Detects new digest │
+                    │  docker compose up  │
+                    └──────────┬──────────┘
+                               │ human smoke-tests staging
+                               │ decides it's ready
+                    ┌──────────▼──────────┐
+                    │  git tag v1.2.3     │  ← human action
+                    │  git push --tags    │
+                    └──────────┬──────────┘
+                               │
+          ┌────────────────────▼────────────────────┐
+          │  publish-master.yml (tag trigger)        │  ← GHA runner
+          │  publish-agent-minimal.yml               │
+          │  Build both images                       │
+          │  Push :v1.2.3 + :sha-<hash> to GHCR      │
+          └────────────────────┬────────────────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │  PRODUCTION         │  ← persistent host
+                    │  CD daemon config:  │
+                    │  CD_IMAGE_TAG=v1.2.3│
+                    │  Detects new digest │
+                    │  docker compose up  │
+                    └─────────────────────┘
+```
+
+---
+
+## Trigger rules
+
+| Git event | Workflow triggered | Effect |
+|---|---|---|
+| Commit pushed to a PR branch | `ci-pr.yml` | Run pytest + docker build (no push) |
+| Merge to `master` | `publish-master.yml`, `publish-agent-minimal.yml` | Build + push `:latest` + `:sha-<hash>` |
+| Push `v*` tag | `publish-master.yml`, `publish-agent-minimal.yml` | Build + push `:v1.2.3` + `:sha-<hash>` |
+| Manual trigger | Any of the above via workflow_dispatch | On-demand build/publish |
+
+Path filters ensure workflows only run when relevant files change (src/, requirements.txt,
+Dockerfiles, etc.) — unrelated file changes (docs, config) do not trigger image builds.
+
+---
+
+## Environments
+
+### Test bed (ephemeral, CI)
+
+- **Where:** inside the GitHub Actions runner VM — no persistent host
+- **Lifetime:** exists only for the duration of one workflow job
+- **Trigger:** every commit pushed to a PR branch
+- **What runs:**
+  - `pytest --tb=short -q` against the full test suite
+  - `docker build` for both images (master and agent-minimal), no push
+  - smoke test of the agent-minimal runtime contract (`codex`, `claude`, `gh`, `--help`)
+- **Gate:** PR cannot be merged to master until these jobs pass (GitHub branch protection)
+
+### Staging (persistent, tracks `:latest`)
+
+- **Where:** a persistent host (VM or bare metal)
+- **CD config:** `CD_IMAGE_TAG=latest`
+- **Promotion trigger:** automatic — every merge to master produces a new `:latest` image;
+  the CD daemon detects the digest change within one poll cycle (≤5 min) and redeploys
+- **Purpose:** always reflects the latest merged state; used for human verification before
+  a release is tagged
+
+### Production (persistent, tracks semver)
+
+- **Where:** a persistent host (VM or bare metal), separate from staging
+- **CD config:** `CD_IMAGE_TAG=v1.2.3` (pinned to a specific release)
+- **Promotion trigger:** human pushes a `v*` tag to git; the GHA publish workflow builds and
+  pushes the semver-tagged image; the operator then updates `CD_IMAGE_TAG` in the
+  production host's environment and restarts the daemon (or the daemon is already configured
+  for the new tag)
+- **Purpose:** stable, intentionally promoted releases only
+
+---
+
+## The CD daemon — design and trade-offs
+
+### What it does
+
+`src/cd/` is a Python process running on the deployment host. Every N seconds (default 300)
+it:
+
+1. Pulls `<image>:<tag>` from GHCR and reads the repo-digest
+2. Compares the digest to the last deployed digest stored in a JSON state file
+3. If changed: runs `docker compose up --force-recreate` with the new image
+4. Waits `health_check_delay_seconds`, then checks the container is still running
+5. If the health check fails and `CD_ROLLBACK_ON_FAILURE=true`: re-deploys the previous
+   digest and re-checks health
+6. Sends deploy/rollback/failure notifications to a Slack or Discord webhook
+
+### Why pull-based is appropriate here
+
+The pull pattern (daemon on the host, no inbound connections required) suits this project
+because:
+
+- **Firewall / NAT friendliness.** The deployment host makes only outbound HTTPS requests
+  to GHCR. No inbound SSH port needs to be opened, and no GitHub runner IP allowlist is
+  needed.
+- **Rollback is built-in.** If a new image is unhealthy the daemon automatically re-deploys
+  the previous known-good digest without human intervention.
+- **Notification is built-in.** Deploy, rollback, and failure events are sent to the same
+  Slack/Discord channels the team already monitors.
+
+### Limitations and planned improvements
+
+| Limitation | Current state | Planned mitigation |
+|---|---|---|
+| Polling lag | ≤5 min between image push and deploy | Add a webhook receiver endpoint to the daemon; GHA POSTs to it after push to trigger an immediate check |
+| Silent daemon failure | If the daemon exits, deployments stop | Set `restart: unless-stopped` on the daemon compose service; monitor webhook silence as an alert signal |
+| No deploy history in GitHub | Deploys are invisible to GitHub UI | Webhook notifications to Slack/Discord provide the audit trail |
+
+### What if you removed the CD daemon?
+
+Two alternatives, in order of simplicity:
+
+**Option A — Push-based SSH deploy from GitHub Actions (simpler)**
+
+Add a `deploy` job to each publish workflow. After the image is pushed, the job SSHes into
+the deployment host and runs:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Pros: instant deploy (no polling), deploy history visible in GitHub workflow runs, no extra
+process to operate.  
+Cons: requires storing an SSH private key in GitHub Secrets and opening an inbound SSH rule
+for GitHub runner IPs. If the host is behind NAT or a strict firewall, this is not viable.
+
+**Option B — Watchtower (drop-in open-source daemon)**
+
+Replace `src/cd/` with the `containrrr/watchtower` container. It does the same poll-detect-
+redeploy loop and is battle-tested. You lose the built-in rollback-on-failure logic and the
+Slack/Discord notification integration, but you also stop maintaining custom daemon code.
+
+For this project the current daemon is retained because the firewall constraint is real,
+the rollback logic is valuable, and the daemon is already implemented.
+
+---
+
+## Should we add Jenkins?
+
+No. Jenkins is not adopted.
+
+GitHub Actions covers 100% of this project's CI/CD needs:
+- Hosted runners are free for public repos and cheap for private ones
+- Secrets, caches, and artifact storage are built in
+- The existing publish workflows already use GHA and work correctly
+
+Jenkins would require:
+- A Jenkins server to provision, maintain, patch, and back up
+- A separate secret store to manage
+- Plugin version management (plugins regularly break across Jenkins upgrades)
+- Network configuration so Jenkins can reach GHCR and deployment hosts
+
+The only scenario where Jenkins makes sense is if builds require on-premises agents with
+access to internal resources that GitHub-hosted runners cannot reach. In that case,
+**self-hosted GitHub Actions runners** (not Jenkins) are the preferred solution — they run
+your code on your hardware while keeping the same workflow YAML and GitHub secrets
+integration.
+
+---
+
+## Branch protection setup (required)
+
+To enforce the PR test gate, configure the following in GitHub → Settings → Branches → `master`:
+
+- **Require status checks to pass before merging**: enabled
+  - Required checks: `pytest`, `Docker build check`
+- **Require branches to be up to date before merging**: enabled
+- **Do not allow bypassing the above settings**: enabled (for all users including admins)
+
+---
+
+## Image tagging strategy
+
+| Tag | When pushed | Who tracks it |
+|---|---|---|
+| `:latest` | Every merge to `master` | Staging CD daemon |
+| `:sha-<7-char-hash>` | Every build (master push or tag push) | Nobody automatically — used for pinned rollback references |
+| `:v1.2.3` | When `v1.2.3` tag is pushed | Production CD daemon |
+
+Production should **never** be configured with `CD_IMAGE_TAG=latest`. Always pin to a
+semver tag. This ensures production only changes when a human pushes a release tag.
+
+---
+
+## Rollback procedure
+
+**Staging:** push a revert commit to master → CI passes → new `:latest` is built → daemon
+deploys it automatically.
+
+**Production:** push the previous working `v*` tag (or a new patch tag pointing to the last
+known-good commit) → new image is built → update `CD_IMAGE_TAG` in production config and
+restart daemon. Alternatively, if the daemon's rollback-on-failure triggered automatically,
+no action is needed.

--- a/docs/design/cicd-pipeline.md
+++ b/docs/design/cicd-pipeline.md
@@ -8,8 +8,8 @@
 ## Context
 
 This document describes the end-to-end CI/CD pipeline for the codex-slack project: what
-triggers it, what it builds, how images are promoted across environments, and why the CD
-daemon pattern was chosen over alternatives.
+triggers it, what it builds, how images are promoted across environments, and the rationale
+for each design choice.
 
 The project produces two Docker images:
 
@@ -18,8 +18,19 @@ The project produces two Docker images:
 | `ghcr.io/<org>/codex-slack-master` | Master orchestrator + single-session bot |
 | `ghcr.io/<org>/codex-slack-agent-minimal` | Lean agent worker spawned by master |
 
-Both images are deployed to three environments: test bed (ephemeral, CI), staging
-(persistent, `latest`), and production (persistent, pinned semver).
+Both images are deployed to three persistent environments with distinct purposes and
+different deployment models:
+
+| Environment | Purpose | Managed by |
+|---|---|---|
+| **Test bed** | Agent development testing and pre-UAT troubleshooting | LLM agent (direct) |
+| **Staging** | User and agent UAT; issue reproduction | CD daemon (tracks `:rc`) |
+| **Production** | Stable working environment for real users | CD daemon (tracks `:v1.2.3`) |
+
+**Core invariant:** code is never merged to `master` before UAT sign-off. The feature
+branch is built, tested on staging, and UAT-approved before the PR is merged. The image
+deployed to production is the exact same image (same bits) that ran on staging during UAT
+— guaranteed by retagging rather than rebuilding.
 
 ---
 
@@ -45,226 +56,241 @@ sufficient.
 ## Pipeline overview
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│  Developer pushes commits to a PR branch                         │
-└──────────────────────────────┬───────────────────────────────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │  ci-pr.yml          │  ← GitHub Actions (GHA runner)
-                    │  1. pytest          │
-                    │  2. docker build    │
-                    │     (no push)       │
-                    └──────────┬──────────┘
-                               │ all jobs green?
-                    ┌──────────▼──────────┐
-                    │  PR can be merged   │  ← branch protection gate
-                    └──────────┬──────────┘
-                               │ human merges to master
-          ┌────────────────────▼────────────────────┐
-          │  publish-master.yml                      │  ← GHA runner
-          │  publish-agent-minimal.yml               │
-          │  Build both images                       │
-          │  Push :latest + :sha-<hash> to GHCR      │
-          └────────────────────┬────────────────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │  STAGING            │  ← persistent host
-                    │  CD daemon polls    │
-                    │  GHCR every 5 min   │
-                    │  Detects new digest │
-                    │  docker compose up  │
-                    └──────────┬──────────┘
-                               │ human smoke-tests staging
-                               │ decides it's ready
-                    ┌──────────▼──────────┐
-                    │  git tag v1.2.3     │  ← human action
-                    │  git push --tags    │
-                    └──────────┬──────────┘
-                               │
-          ┌────────────────────▼────────────────────┐
-          │  publish-master.yml (tag trigger)        │  ← GHA runner
-          │  publish-agent-minimal.yml               │
-          │  Build both images                       │
-          │  Push :v1.2.3 + :sha-<hash> to GHCR      │
-          └────────────────────┬────────────────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │  PRODUCTION         │  ← persistent host
-                    │  CD daemon config:  │
-                    │  CD_IMAGE_TAG=v1.2.3│
-                    │  Detects new digest │
-                    │  docker compose up  │
-                    └─────────────────────┘
+feat/x branch (never merged until UAT sign-off)
+      │
+      │  1. Agent develops on feature branch
+      │
+      ▼  2. Agent: gh workflow run build-on-demand.yml --ref feat/x
+         GHA builds both images from feat/x, pushes :sha-<hash>
+         Agent waits on run ID, deploys to test bed, iterates
+      │
+      ▼  3. Agent creates PR: feat/x → master
+         GHA ci-pr.yml: pytest + docker build gate
+      │
+      ▼  4. Agent or human: git tag v1.2.3-rc1 && git push --tags
+         (tag is on the BRANCH, not master)
+      │
+      ▼  5. GHA build-rc.yml triggers on v*-rc* tag
+         builds both images from v1.2.3-rc1 commit
+         pushes :v1.2.3-rc1 (immutable) + :rc (mutable, latest RC)
+      │
+      ▼  6. STAGING  ← CD daemon, CD_IMAGE_TAG=rc
+         detects new :rc digest, deploys automatically
+         notifies: "RC v1.2.3-rc1 deployed to staging"
+      │
+      ▼  7. User performs UAT on staging
+
+  ┌── issues found ──────────────────────────────────────────────────┐
+  │   back to step 1                                                 │
+  │   agent fixes on feat/x, commits                                │
+  │   git tag v1.2.3-rc2 && git push --tags                        │
+  │   repeat from step 5 (new :rc deployed to staging)              │
+  └──────────────────────────────────────────────────────────────────┘
+
+      │  8. UAT sign-off
+      │
+      ▼  9. PR approved, merged to master
+         Linear history only (rebase merge, branch must be up to date)
+         master receives the exact tested commits
+      │
+      ▼  10. Human: git tag v1.2.3 && git push --tags (on master)
+          GHA promote-release.yml triggers on v* (non-rc) tags on master
+          retags :rc → :v1.2.3 in GHCR  ← no rebuild
+          same image bits that ran on staging during UAT
+      │
+      ▼  11. Operator updates production .env: CD_IMAGE_TAG=v1.2.3
+          PRODUCTION  ← CD daemon, CD_IMAGE_TAG=v1.2.3
+          detects new :v1.2.3 digest, deploys
 ```
 
 ---
 
 ## Trigger rules
 
-| Git event | Workflow triggered | Effect |
+| Trigger | Workflow | What it does |
 |---|---|---|
-| Commit pushed to a PR branch | `ci-pr.yml` | Run pytest + docker build (no push) |
-| Merge to `master` | `publish-master.yml`, `publish-agent-minimal.yml` | Build + push `:latest` + `:sha-<hash>` |
-| Push `v*` tag | `publish-master.yml`, `publish-agent-minimal.yml` | Build + push `:v1.2.3` + `:sha-<hash>` |
-| Manual trigger | Any of the above via workflow_dispatch | On-demand build/publish |
+| Commit pushed to any PR branch | `ci-pr.yml` | Run pytest + docker build (no push) — merge gate |
+| Agent/human triggers manually | `build-on-demand.yml` | Build from any ref, push `:sha-<hash>` only |
+| `v*-rc*` tag pushed (any branch) | `build-rc.yml` | Build RC images, push `:v1.2.3-rc1` + `:rc` |
+| `v*` non-rc tag pushed on `master` | `promote-release.yml` | Retag `:rc` → `:v1.2.3` in GHCR (no rebuild) |
 
-Path filters ensure workflows only run when relevant files change (src/, requirements.txt,
-Dockerfiles, etc.) — unrelated file changes (docs, config) do not trigger image builds.
+**What no longer triggers a build:** pushing to `master`. Master is a stable pointer;
+images are built from feature branch RC tags, not from master merges.
 
 ---
 
 ## Environments
 
-### Test bed (ephemeral, CI)
+### Test bed (persistent, agent-managed)
 
-- **Where:** inside the GitHub Actions runner VM — no persistent host
-- **Lifetime:** exists only for the duration of one workflow job
-- **Trigger:** every commit pushed to a PR branch
-- **What runs:**
-  - `pytest --tb=short -q` against the full test suite
-  - `docker build` for both images (master and agent-minimal), no push
-  - smoke test of the agent-minimal runtime contract (`codex`, `claude`, `gh`, `--help`)
-- **Gate:** PR cannot be merged to master until these jobs pass (GitHub branch protection)
+- **Where:** persistent host — co-located with the master orchestrator is sufficient
+- **Purpose:** agent development testing and pre-UAT troubleshooting. May run broken or
+  experimental builds; never exposed to end users
+- **Managed by:** LLM agent directly via the Podman socket the master orchestrator holds
+- **What deploys:** any `:sha-<hash>` from a feature branch build (`build-on-demand.yml`)
+- **No CD daemon** — the agent controls deploy lifecycle directly and handles rollback
+  by redeploying a previous SHA explicitly
 
-### Staging (persistent, tracks `:latest`)
+**Agent deploy workflow:**
 
-- **Where:** a persistent host (VM or bare metal)
-- **CD config:** `CD_IMAGE_TAG=latest`
-- **Promotion trigger:** automatic — every merge to master produces a new `:latest` image;
-  the CD daemon detects the digest change within one poll cycle (≤5 min) and redeploys
-- **Purpose:** always reflects the latest merged state; used for human verification before
-  a release is tagged
+```bash
+# 1. Trigger build of the feature branch
+gh workflow run build-on-demand.yml \
+  --ref feat/new-auth \
+  --field label=feat-new-auth
 
-### Production (persistent, tracks semver)
+# 2. Wait synchronously on the run ID
+gh run watch <run-id>
 
-- **Where:** a persistent host (VM or bare metal), separate from staging
-- **CD config:** `CD_IMAGE_TAG=v1.2.3` (pinned to a specific release)
-- **Promotion trigger:** human pushes a `v*` tag to git; the GHA publish workflow builds and
-  pushes the semver-tagged image; the operator then updates `CD_IMAGE_TAG` in the
-  production host's environment and restarts the daemon (or the daemon is already configured
-  for the new tag)
-- **Purpose:** stable, intentionally promoted releases only
+# 3. Deploy the SHA to test bed
+# (agent uses compose + the sha-tagged image)
+
+# 4. Test, iterate. When solid: create the PR and push an RC tag.
+```
+
+### Staging (persistent, CD daemon, `:rc`)
+
+- **Where:** persistent host, separate from test bed and production
+- **Purpose:** UAT by users and agents. Staging uses real (or staging-specific) Slack/
+  Discord credentials so users can exercise real flows without risk to production
+- **CD config:** `CD_IMAGE_TAG=rc`
+- **Promotion trigger:** pushing a `v*-rc*` tag on the feature branch. GHA `build-rc.yml`
+  builds the image and updates `:rc` in GHCR. The daemon detects the digest change and
+  redeploys automatically, then notifies via Slack/Discord
+- **Multiple RC iterations:** each new RC tag (rc1, rc2, …) moves `:rc` to the new image.
+  Staging always reflects the latest RC. This is intentional — if rc2 is pushed while rc1
+  UAT is ongoing, staging updates to rc2
+- **Rollback:** re-push a previous RC tag (e.g., push a new `v1.2.3-rc3` pointing to the
+  rc1 commit) to move `:rc` back
+
+### Production (persistent, CD daemon, `:v1.2.3`)
+
+- **Where:** persistent host, separate from staging
+- **Purpose:** stable working environment for real users. Receives only human-approved,
+  UAT-signed-off release builds
+- **CD config:** `CD_IMAGE_TAG=v1.2.3` (pinned, updated per release)
+- **Promotion trigger:** two manual steps by a human operator
+  1. Push release tag on master: `git tag v1.2.3 && git push --tags`
+  2. Update `CD_IMAGE_TAG` in production `.env` to `v1.2.3` and restart the daemon
+- **Image guarantee:** `promote-release.yml` retags `:rc` → `:v1.2.3` without rebuilding.
+  The production image is bit-identical to the image that ran on staging during UAT
+- **Invariant:** `CD_IMAGE_TAG` must always be a semver string — never `:rc`, never
+  `:latest`, never a raw SHA
 
 ---
 
 ## The CD daemon — design and trade-offs
 
-### What it does
-
-`src/cd/` is a Python process running on the deployment host. Every N seconds (default 300)
-it:
+`src/cd/` is a Python process running on the deployment host. Every N seconds it:
 
 1. Pulls `<image>:<tag>` from GHCR and reads the repo-digest
-2. Compares the digest to the last deployed digest stored in a JSON state file
+2. Compares to the last deployed digest in a JSON state file
 3. If changed: runs `docker compose up --force-recreate` with the new image
 4. Waits `health_check_delay_seconds`, then checks the container is still running
-5. If the health check fails and `CD_ROLLBACK_ON_FAILURE=true`: re-deploys the previous
-   digest and re-checks health
+5. If unhealthy and `CD_ROLLBACK_ON_FAILURE=true`: re-deploys the previous digest
 6. Sends deploy/rollback/failure notifications to a Slack or Discord webhook
 
-### Why pull-based is appropriate here
+The daemon runs on **staging and production only**. The test bed is agent-managed with no
+daemon.
 
-The pull pattern (daemon on the host, no inbound connections required) suits this project
-because:
+### Why pull-based (no inbound connections needed)
 
-- **Firewall / NAT friendliness.** The deployment host makes only outbound HTTPS requests
-  to GHCR. No inbound SSH port needs to be opened, and no GitHub runner IP allowlist is
-  needed.
-- **Rollback is built-in.** If a new image is unhealthy the daemon automatically re-deploys
-  the previous known-good digest without human intervention.
-- **Notification is built-in.** Deploy, rollback, and failure events are sent to the same
-  Slack/Discord channels the team already monitors.
+The deployment host makes only outbound HTTPS requests to GHCR. No inbound SSH port and
+no GitHub runner IP allowlist are required. Works behind NAT or strict firewalls.
 
-### Limitations and planned improvements
+### CD daemon config per environment
 
-| Limitation | Current state | Planned mitigation |
+| Setting | Staging | Production |
 |---|---|---|
-| Polling lag | ≤5 min between image push and deploy | Add a webhook receiver endpoint to the daemon; GHA POSTs to it after push to trigger an immediate check |
-| Silent daemon failure | If the daemon exits, deployments stop | Set `restart: unless-stopped` on the daemon compose service; monitor webhook silence as an alert signal |
-| No deploy history in GitHub | Deploys are invisible to GitHub UI | Webhook notifications to Slack/Discord provide the audit trail |
+| `CD_IMAGE_TAG` | `rc` | `v1.2.3` |
+| `CD_POLL_INTERVAL_SECONDS` | `300` | `600` |
+| `CD_ROLLBACK_ON_FAILURE` | `true` | `true` |
+| `CD_HEALTH_CHECK_DELAY_SECONDS` | `30` | `60` |
+| Notification channel | `#staging-deploys` | `#prod-alerts` |
 
-### What if you removed the CD daemon?
+### Limitations and mitigations
 
-Two alternatives, in order of simplicity:
-
-**Option A — Push-based SSH deploy from GitHub Actions (simpler)**
-
-Add a `deploy` job to each publish workflow. After the image is pushed, the job SSHes into
-the deployment host and runs:
-
-```bash
-docker compose pull && docker compose up -d
-```
-
-Pros: instant deploy (no polling), deploy history visible in GitHub workflow runs, no extra
-process to operate.  
-Cons: requires storing an SSH private key in GitHub Secrets and opening an inbound SSH rule
-for GitHub runner IPs. If the host is behind NAT or a strict firewall, this is not viable.
-
-**Option B — Watchtower (drop-in open-source daemon)**
-
-Replace `src/cd/` with the `containrrr/watchtower` container. It does the same poll-detect-
-redeploy loop and is battle-tested. You lose the built-in rollback-on-failure logic and the
-Slack/Discord notification integration, but you also stop maintaining custom daemon code.
-
-For this project the current daemon is retained because the firewall constraint is real,
-the rollback logic is valuable, and the daemon is already implemented.
-
----
-
-## Should we add Jenkins?
-
-No. Jenkins is not adopted.
-
-GitHub Actions covers 100% of this project's CI/CD needs:
-- Hosted runners are free for public repos and cheap for private ones
-- Secrets, caches, and artifact storage are built in
-- The existing publish workflows already use GHA and work correctly
-
-Jenkins would require:
-- A Jenkins server to provision, maintain, patch, and back up
-- A separate secret store to manage
-- Plugin version management (plugins regularly break across Jenkins upgrades)
-- Network configuration so Jenkins can reach GHCR and deployment hosts
-
-The only scenario where Jenkins makes sense is if builds require on-premises agents with
-access to internal resources that GitHub-hosted runners cannot reach. In that case,
-**self-hosted GitHub Actions runners** (not Jenkins) are the preferred solution — they run
-your code on your hardware while keeping the same workflow YAML and GitHub secrets
-integration.
-
----
-
-## Branch protection setup (required)
-
-To enforce the PR test gate, configure the following in GitHub → Settings → Branches → `master`:
-
-- **Require status checks to pass before merging**: enabled
-  - Required checks: `pytest`, `Docker build check`
-- **Require branches to be up to date before merging**: enabled
-- **Do not allow bypassing the above settings**: enabled (for all users including admins)
+| Limitation | Mitigation |
+|---|---|
+| Polling lag (≤5 min staging, ≤10 min production) | Acceptable — both envs have explicit promotion gates |
+| Silent daemon failure stops deployments | `restart: unless-stopped` on daemon compose service |
+| No deploy history in GitHub UI | Slack/Discord webhook notifications are the audit trail |
 
 ---
 
 ## Image tagging strategy
 
-| Tag | When pushed | Who tracks it |
-|---|---|---|
-| `:latest` | Every merge to `master` | Staging CD daemon |
-| `:sha-<7-char-hash>` | Every build (master push or tag push) | Nobody automatically — used for pinned rollback references |
-| `:v1.2.3` | When `v1.2.3` tag is pushed | Production CD daemon |
+| Tag | When pushed | Mutable | Tracked by |
+|---|---|---|---|
+| `:sha-<7-char-hash>` | Every `build-on-demand.yml` run | No | Agent (explicit deploy to test bed) |
+| `:v1.2.3-rc1` | RC tag push on any branch | No | Audit trail only |
+| `:rc` | RC tag push (always latest RC) | Yes | Staging CD daemon |
+| `:v1.2.3` | Release `promote-release.yml` (retag, no rebuild) | No | Production CD daemon |
 
-Production should **never** be configured with `CD_IMAGE_TAG=latest`. Always pin to a
-semver tag. This ensures production only changes when a human pushes a release tag.
+**No `:latest` tag.** Every tag has unambiguous semantics and a clear owner.
+
+**Bit-identical guarantee:** `:v1.2.3` in GHCR is always the same image digest as the
+`:rc` image that was deployed to staging and UAT-approved. `promote-release.yml` pulls `:rc`
+by digest and pushes that digest under the release tag — it does not invoke `docker build`.
 
 ---
 
-## Rollback procedure
+## Linear history enforcement on master
 
-**Staging:** push a revert commit to master → CI passes → new `:latest` is built → daemon
-deploys it automatically.
+The goal: code on `master` is always code that has been UAT-approved. No unreviewed merge
+commits.
 
-**Production:** push the previous working `v*` tag (or a new patch tag pointing to the last
-known-good commit) → new image is built → update `CD_IMAGE_TAG` in production config and
-restart daemon. Alternatively, if the daemon's rollback-on-failure triggered automatically,
-no action is needed.
+**GitHub repository settings (Settings → General → Pull Requests):**
+- Disable **Allow merge commits**
+- Disable **Allow squash merging**
+- Enable **Allow rebase merging** only
+
+**Branch protection on `master` (Settings → Branches):**
+- Require status checks: `pytest`, `Docker build check`
+- **Require branches to be up to date before merging**
+- Require linear history
+- Do not allow bypassing (including admins)
+
+With rebase-only merging and "up to date" enforcement, the feature branch must include all
+of master's commits before it can merge. The PR commits land on master as a linear sequence
+with no merge commit.
+
+**Note on commit SHAs:** GitHub's rebase merge replays commits, producing new SHAs even
+when code is identical. The image guarantee is not provided by commit SHA matching — it is
+provided by the `:rc` → `:v1.2.3` retag in `promote-release.yml`, which operates on image
+digests, not commit SHAs.
+
+---
+
+## GHA workflows summary
+
+| Workflow | Trigger | Builds? | Pushes tags |
+|---|---|---|---|
+| `ci-pr.yml` | PR commit to `master` | Yes (no push) | None |
+| `build-on-demand.yml` | `workflow_dispatch` (agent/human) | Yes | `:sha-<hash>` |
+| `build-rc.yml` | `v*-rc*` tag push (any branch) | Yes | `:v1.2.3-rc1`, `:rc` |
+| `promote-release.yml` | `v*` non-rc tag push on `master` | No (retag only) | `:v1.2.3` |
+
+---
+
+## Should we add Jenkins?
+
+No. See ADR 0005. GitHub Actions covers all CI/CD needs. The master orchestrator's `gh`
+CLI is the bridge between the LLM agent and GHA workflows — no separate CI server is
+required.
+
+---
+
+## Rollback procedures
+
+**Test bed:** agent redeploys a previous `:sha-<hash>` explicitly.
+
+**Staging:** push a new RC tag pointing to the last known-good commit
+(e.g., `v1.2.3-rc3` pointing to the rc1 commit). GHA rebuilds and updates `:rc`; daemon
+redeploys. Daemon's built-in rollback also handles transient deploy failures automatically.
+
+**Production:** push a new patch release tag pointing to the previous known-good commit
+(e.g., `v1.2.4` → same commit as `v1.2.2`). `promote-release.yml` retags `:rc`
+(which should be the last RC for that commit) → `:v1.2.4`. Operator updates
+`CD_IMAGE_TAG=v1.2.4` and restarts the daemon. Daemon's built-in rollback handles
+transient failures automatically.

--- a/docs/design/cicd-pipeline.md
+++ b/docs/design/cicd-pipeline.md
@@ -23,14 +23,9 @@ different deployment models:
 
 | Environment | Purpose | Managed by |
 |---|---|---|
-| **Test bed** | Agent development testing and pre-UAT troubleshooting | LLM agent (direct) |
-| **Staging** | User and agent UAT; issue reproduction | CD daemon (tracks `:rc`) |
-| **Production** | Stable working environment for real users | CD daemon (tracks `:v1.2.3`) |
-
-**Core invariant:** code is never merged to `master` before UAT sign-off. The feature
-branch is built, tested on staging, and UAT-approved before the PR is merged. The image
-deployed to production is the exact same image (same bits) that ran on staging during UAT
-— guaranteed by retagging rather than rebuilding.
+| **Test bed** | Agent development testing and pre-UAT troubleshooting | LLM agent |
+| **Staging** | User and agent UAT; issue reproduction | CD daemon |
+| **Production** | Stable working environment for real users | CD daemon |
 
 ---
 
@@ -56,51 +51,49 @@ sufficient.
 ## Pipeline overview
 
 ```
-feat/x branch (never merged until UAT sign-off)
+feature branch
       │
-      │  1. Agent develops on feature branch
+      │  agent triggers: gh workflow run build-on-demand.yml \
+      │                    --ref feat/x --field label=feat-x
+      ▼
+  GHA: build-on-demand.yml
+  builds both images from feat/x
+  pushes :sha-<hash> to GHCR
+  (agent waits on run ID, no notification needed)
       │
-      ▼  2. Agent: gh workflow run build-on-demand.yml --ref feat/x
-         GHA builds both images from feat/x, pushes :sha-<hash>
-         Agent waits on run ID, deploys to test bed, iterates
+      ▼
+  TEST BED  ← persistent host, agent-managed, no daemon
+  agent deploys :sha-<hash>, tests, iterates
+  agent: "this build is solid, merge the PR"
       │
-      ▼  3. Agent creates PR: feat/x → master
-         GHA ci-pr.yml: pytest + docker build gate
+      │  PR merged to master
+      ▼
+  GHA: publish-master.yml  (existing, triggered by master push)
+  builds from master HEAD
+  pushes :sha-<hash> to GHCR
       │
-      ▼  4. Agent or human: git tag v1.2.3-rc1 && git push --tags
-         (tag is on the BRANCH, not master)
+      │  agent or human triggers:
+      │  gh workflow run promote-staging.yml \
+      │    --field sha=<hash>
+      ▼
+  GHA: promote-staging.yml
+  retags :sha-<hash> → :staging in GHCR
+  (no build — same image bits, new tag)
       │
-      ▼  5. GHA build-rc.yml triggers on v*-rc* tag
-         builds both images from v1.2.3-rc1 commit
-         pushes :v1.2.3-rc1 (immutable) + :rc (mutable, latest RC)
+      ▼
+  STAGING  ← persistent host, CD daemon, CD_IMAGE_TAG=staging
+  daemon detects new :staging digest, deploys
+  user + agent perform UAT
       │
-      ▼  6. STAGING  ← CD daemon, CD_IMAGE_TAG=rc
-         detects new :rc digest, deploys automatically
-         notifies: "RC v1.2.3-rc1 deployed to staging"
+      │  human: git tag v1.2.3 && git push --tags
+      ▼
+  GHA: publish-master.yml  (tag trigger)
+  builds from tagged commit
+  pushes :v1.2.3 + :sha-<hash> to GHCR
       │
-      ▼  7. User performs UAT on staging
-
-  ┌── issues found ──────────────────────────────────────────────────┐
-  │   back to step 1                                                 │
-  │   agent fixes on feat/x, commits                                │
-  │   git tag v1.2.3-rc2 && git push --tags                        │
-  │   repeat from step 5 (new :rc deployed to staging)              │
-  └──────────────────────────────────────────────────────────────────┘
-
-      │  8. UAT sign-off
-      │
-      ▼  9. PR approved, merged to master
-         Linear history only (rebase merge, branch must be up to date)
-         master receives the exact tested commits
-      │
-      ▼  10. Human: git tag v1.2.3 && git push --tags (on master)
-          GHA promote-release.yml triggers on v* (non-rc) tags on master
-          retags :rc → :v1.2.3 in GHCR  ← no rebuild
-          same image bits that ran on staging during UAT
-      │
-      ▼  11. Operator updates production .env: CD_IMAGE_TAG=v1.2.3
-          PRODUCTION  ← CD daemon, CD_IMAGE_TAG=v1.2.3
-          detects new :v1.2.3 digest, deploys
+      ▼
+  PRODUCTION  ← persistent host, CD daemon, CD_IMAGE_TAG=v1.2.3
+  daemon detects new :v1.2.3 digest, deploys
 ```
 
 ---
@@ -109,13 +102,15 @@ feat/x branch (never merged until UAT sign-off)
 
 | Trigger | Workflow | What it does |
 |---|---|---|
-| Commit pushed to any PR branch | `ci-pr.yml` | Run pytest + docker build (no push) — merge gate |
-| Agent/human triggers manually | `build-on-demand.yml` | Build from any ref, push `:sha-<hash>` only |
-| `v*-rc*` tag pushed (any branch) | `build-rc.yml` | Build RC images, push `:v1.2.3-rc1` + `:rc` |
-| `v*` non-rc tag pushed on `master` | `promote-release.yml` | Retag `:rc` → `:v1.2.3` in GHCR (no rebuild) |
+| Commit pushed to a PR branch | `ci-pr.yml` | Run pytest + docker build validation (no push) |
+| Agent/human triggers manually | `build-on-demand.yml` | Build both images from any ref, push `:sha-<hash>` |
+| Merge to `master` | `publish-master.yml`, `publish-agent-minimal.yml` | Build from master, push `:sha-<hash>` |
+| Agent/human triggers manually | `promote-staging.yml` | Retag a `:sha-<hash>` → `:staging` in GHCR |
+| Push `v*` tag | `publish-master.yml`, `publish-agent-minimal.yml` | Build from tag, push `:v1.2.3` + `:sha-<hash>` |
 
-**What no longer triggers a build:** pushing to `master`. Master is a stable pointer;
-images are built from feature branch RC tags, not from master merges.
+Path filters on `ci-pr.yml` and the publish workflows ensure they only fire when relevant
+files change (`src/`, `requirements.txt`, `Dockerfile*`). Docs and config changes do not
+trigger image builds.
 
 ---
 
@@ -123,59 +118,63 @@ images are built from feature branch RC tags, not from master merges.
 
 ### Test bed (persistent, agent-managed)
 
-- **Where:** persistent host — co-located with the master orchestrator is sufficient
-- **Purpose:** agent development testing and pre-UAT troubleshooting. May run broken or
-  experimental builds; never exposed to end users
-- **Managed by:** LLM agent directly via the Podman socket the master orchestrator holds
-- **What deploys:** any `:sha-<hash>` from a feature branch build (`build-on-demand.yml`)
-- **No CD daemon** — the agent controls deploy lifecycle directly and handles rollback
-  by redeploying a previous SHA explicitly
+- **Where:** persistent host — the same host running the master orchestrator is sufficient
+- **Purpose:** agent development testing and pre-UAT troubleshooting before any build
+  touches staging or production
+- **Managed by:** LLM agent directly — the agent issues deploy commands via the Podman
+  socket it already controls; no CD daemon runs here
+- **What the agent deploys:** any `:sha-<hash>` image — from a feature branch build
+  (triggered via `build-on-demand.yml`) or from a master merge build
+- **Intentionally unstable:** the test bed may run broken or experimental builds; it is
+  never shown to end users
 
-**Agent deploy workflow:**
+**Agent workflow for test bed deployment:**
 
-```bash
-# 1. Trigger build of the feature branch
+```
+# 1. Trigger a build of the feature branch
 gh workflow run build-on-demand.yml \
   --ref feat/new-auth \
   --field label=feat-new-auth
 
-# 2. Wait synchronously on the run ID
+# 2. Wait for the build to finish (synchronous, uses run ID)
 gh run watch <run-id>
 
-# 3. Deploy the SHA to test bed
-# (agent uses compose + the sha-tagged image)
+# 3. Deploy the built image to test bed
+docker compose -f docker-compose.testbed.yml up -d --force-recreate \
+  codex-slack-master  # with MASTER_RUNTIME_IMAGE=ghcr.io/.../master:sha-<hash>
 
-# 4. Test, iterate. When solid: create the PR and push an RC tag.
+# 4. Test, iterate. If broken, the agent reports and fixes on the branch.
+# 5. When solid: "this build is ready, merge the PR"
 ```
 
-### Staging (persistent, CD daemon, `:rc`)
+No CD daemon is needed because the agent controls the deploy lifecycle directly. The agent
+also handles rollback explicitly — it simply redeploys the previous SHA if a new one is
+broken.
 
-- **Where:** persistent host, separate from test bed and production
-- **Purpose:** UAT by users and agents. Staging uses real (or staging-specific) Slack/
-  Discord credentials so users can exercise real flows without risk to production
-- **CD config:** `CD_IMAGE_TAG=rc`
-- **Promotion trigger:** pushing a `v*-rc*` tag on the feature branch. GHA `build-rc.yml`
-  builds the image and updates `:rc` in GHCR. The daemon detects the digest change and
-  redeploys automatically, then notifies via Slack/Discord
-- **Multiple RC iterations:** each new RC tag (rc1, rc2, …) moves `:rc` to the new image.
-  Staging always reflects the latest RC. This is intentional — if rc2 is pushed while rc1
-  UAT is ongoing, staging updates to rc2
-- **Rollback:** re-push a previous RC tag (e.g., push a new `v1.2.3-rc3` pointing to the
-  rc1 commit) to move `:rc` back
+### Staging (persistent, CD daemon, `:staging`)
+
+- **Where:** persistent host, separate from test bed/production
+- **Purpose:** user and agent UAT in a stable-enough environment. Staging uses the same
+  Slack/Discord workspace or a dedicated staging workspace so users can reproduce issues and
+  validate flows without risk to production
+- **CD config:** `CD_IMAGE_TAG=staging`
+- **Promotion trigger:** explicit human or agent action — run `promote-staging.yml`
+  `workflow_dispatch`, which retags the approved `:sha-<hash>` as `:staging` in GHCR; the
+  daemon detects the new digest and deploys automatically
+- **Rollback:** daemon rolls back automatically on health-check failure; manual rollback is
+  done by re-promoting a known-good SHA
 
 ### Production (persistent, CD daemon, `:v1.2.3`)
 
 - **Where:** persistent host, separate from staging
-- **Purpose:** stable working environment for real users. Receives only human-approved,
-  UAT-signed-off release builds
-- **CD config:** `CD_IMAGE_TAG=v1.2.3` (pinned, updated per release)
-- **Promotion trigger:** two manual steps by a human operator
-  1. Push release tag on master: `git tag v1.2.3 && git push --tags`
-  2. Update `CD_IMAGE_TAG` in production `.env` to `v1.2.3` and restart the daemon
-- **Image guarantee:** `promote-release.yml` retags `:rc` → `:v1.2.3` without rebuilding.
-  The production image is bit-identical to the image that ran on staging during UAT
-- **Invariant:** `CD_IMAGE_TAG` must always be a semver string — never `:rc`, never
-  `:latest`, never a raw SHA
+- **Purpose:** stable working environment for real users; only receives human-approved
+  release builds
+- **CD config:** `CD_IMAGE_TAG=v1.2.3` (a specific semver tag, updated per release)
+- **Promotion trigger:** human pushes a `v*` git tag; GHA builds and pushes `:v1.2.3`;
+  operator updates `CD_IMAGE_TAG` in the production `.env` and restarts the daemon (or the
+  daemon is pre-configured for the new tag)
+- **Invariant:** production `CD_IMAGE_TAG` must always be a semver string; never `:staging`,
+  never `:latest`, never a SHA directly
 
 ---
 
@@ -190,107 +189,99 @@ gh run watch <run-id>
 5. If unhealthy and `CD_ROLLBACK_ON_FAILURE=true`: re-deploys the previous digest
 6. Sends deploy/rollback/failure notifications to a Slack or Discord webhook
 
-The daemon runs on **staging and production only**. The test bed is agent-managed with no
-daemon.
+The daemon is used on **staging and production only**. The test bed does not run a daemon —
+the agent manages the test bed directly.
 
 ### Why pull-based (no inbound connections needed)
 
-The deployment host makes only outbound HTTPS requests to GHCR. No inbound SSH port and
-no GitHub runner IP allowlist are required. Works behind NAT or strict firewalls.
+- The deployment host makes only outbound HTTPS requests to GHCR
+- No inbound SSH port, no GitHub runner IP allowlist required
+- Works behind NAT or strict firewalls
 
-### CD daemon config per environment
+### CD daemon config differences per environment
 
 | Setting | Staging | Production |
 |---|---|---|
-| `CD_IMAGE_TAG` | `rc` | `v1.2.3` |
+| `CD_IMAGE_TAG` | `staging` | `v1.2.3` |
 | `CD_POLL_INTERVAL_SECONDS` | `300` | `600` |
 | `CD_ROLLBACK_ON_FAILURE` | `true` | `true` |
 | `CD_HEALTH_CHECK_DELAY_SECONDS` | `30` | `60` |
 | Notification channel | `#staging-deploys` | `#prod-alerts` |
 
+Production uses a longer poll interval because production deploys are deliberate — nobody
+is watching a clock. Staging uses 5 minutes as a reasonable balance between feedback speed
+and GHCR polling load.
+
 ### Limitations and mitigations
 
-| Limitation | Mitigation |
-|---|---|
-| Polling lag (≤5 min staging, ≤10 min production) | Acceptable — both envs have explicit promotion gates |
-| Silent daemon failure stops deployments | `restart: unless-stopped` on daemon compose service |
-| No deploy history in GitHub UI | Slack/Discord webhook notifications are the audit trail |
+| Limitation | Current state | Mitigation |
+|---|---|---|
+| Polling lag | ≤5 min (staging), ≤10 min (production) | Acceptable given explicit promotion gates |
+| Silent daemon failure | If daemon exits, deployments stall | `restart: unless-stopped` on daemon compose service; monitor webhook silence |
+| No deploy history in GitHub UI | Deploys invisible to GitHub | Slack/Discord webhook notifications are the audit trail |
 
 ---
 
 ## Image tagging strategy
 
-| Tag | When pushed | Mutable | Tracked by |
-|---|---|---|---|
-| `:sha-<7-char-hash>` | Every `build-on-demand.yml` run | No | Agent (explicit deploy to test bed) |
-| `:v1.2.3-rc1` | RC tag push on any branch | No | Audit trail only |
-| `:rc` | RC tag push (always latest RC) | Yes | Staging CD daemon |
-| `:v1.2.3` | Release `promote-release.yml` (retag, no rebuild) | No | Production CD daemon |
+| Tag | When pushed | Tracks who |
+|---|---|---|
+| `:sha-<7-char-hash>` | Every build (branch, master, or tag trigger) | Nobody automatically — deployed explicitly by agent or promote workflow |
+| `:staging` | When `promote-staging.yml` is run | Staging CD daemon |
+| `:v1.2.3` | When `v1.2.3` git tag is pushed | Production CD daemon |
 
-**No `:latest` tag.** Every tag has unambiguous semantics and a clear owner.
+**No `:latest` tag.** Removing `:latest` eliminates the ambiguity of "what is latest" and
+forces every promotion to be an explicit, traceable action. Each environment tracks a tag
+with clear semantics:
 
-**Bit-identical guarantee:** `:v1.2.3` in GHCR is always the same image digest as the
-`:rc` image that was deployed to staging and UAT-approved. `promote-release.yml` pulls `:rc`
-by digest and pushes that digest under the release tag — it does not invoke `docker build`.
-
----
-
-## Linear history enforcement on master
-
-The goal: code on `master` is always code that has been UAT-approved. No unreviewed merge
-commits.
-
-**GitHub repository settings (Settings → General → Pull Requests):**
-- Disable **Allow merge commits**
-- Disable **Allow squash merging**
-- Enable **Allow rebase merging** only
-
-**Branch protection on `master` (Settings → Branches):**
-- Require status checks: `pytest`, `Docker build check`
-- **Require branches to be up to date before merging**
-- Require linear history
-- Do not allow bypassing (including admins)
-
-With rebase-only merging and "up to date" enforcement, the feature branch must include all
-of master's commits before it can merge. The PR commits land on master as a linear sequence
-with no merge commit.
-
-**Note on commit SHAs:** GitHub's rebase merge replays commits, producing new SHAs even
-when code is identical. The image guarantee is not provided by commit SHA matching — it is
-provided by the `:rc` → `:v1.2.3` retag in `promote-release.yml`, which operates on image
-digests, not commit SHAs.
+- `:sha-<hash>` — immutable, identifies exact code, used by agent on test bed
+- `:staging` — mutable, always points to the last promoted build, used by staging daemon
+- `:v1.2.3` — immutable semver, used by production daemon
 
 ---
 
-## GHA workflows summary
+## Agent-triggered on-demand builds
 
-| Workflow | Trigger | Builds? | Pushes tags |
-|---|---|---|---|
-| `ci-pr.yml` | PR commit to `master` | Yes (no push) | None |
-| `build-on-demand.yml` | `workflow_dispatch` (agent/human) | Yes | `:sha-<hash>` |
-| `build-rc.yml` | `v*-rc*` tag push (any branch) | Yes | `:v1.2.3-rc1`, `:rc` |
-| `promote-release.yml` | `v*` non-rc tag push on `master` | No (retag only) | `:v1.2.3` |
+The agent triggers builds of arbitrary branches using `gh workflow run` against the
+`build-on-demand.yml` workflow. This workflow:
+
+- Accepts a `ref` (branch, tag, or SHA) and an optional `label`
+- Builds both images (`master` and `agent-minimal`) from that ref
+- Pushes only `:sha-<hash>` — never `:staging`, never a semver
+- The agent waits on the run ID synchronously with `gh run watch <run-id>`
+
+This pattern keeps unverified branch code entirely isolated from the promotion chain.
+A branch image can only enter staging if a human or agent explicitly runs `promote-staging.yml`
+with a SHA — and that SHA must come from a build that passed CI.
 
 ---
 
 ## Should we add Jenkins?
 
-No. See ADR 0005. GitHub Actions covers all CI/CD needs. The master orchestrator's `gh`
-CLI is the bridge between the LLM agent and GHA workflows — no separate CI server is
-required.
+No. See ADR 0005. GitHub Actions covers all CI/CD needs. The master orchestrator's `gh` CLI
+is the bridge between the agent and GHA — no separate CI server is required.
+
+---
+
+## Branch protection setup (required)
+
+Configure in GitHub → Settings → Branches → `master`:
+
+- **Require status checks to pass before merging**: enabled
+  - Required checks: `pytest`, `Docker build check`
+- **Require branches to be up to date before merging**: enabled
+- **Do not allow bypassing the above settings**: enabled (including admins)
 
 ---
 
 ## Rollback procedures
 
-**Test bed:** agent redeploys a previous `:sha-<hash>` explicitly.
+**Test bed:** agent redeploys the previous `:sha-<hash>` explicitly.
 
-**Staging:** push a new RC tag pointing to the last known-good commit
-(e.g., `v1.2.3-rc3` pointing to the rc1 commit). GHA rebuilds and updates `:rc`; daemon
-redeploys. Daemon's built-in rollback also handles transient deploy failures automatically.
+**Staging:** re-run `promote-staging.yml` with the last known-good SHA to push a new
+`:staging` digest; daemon redeploys automatically. If the daemon's built-in rollback
+triggered, no action needed.
 
-**Production:** push a new patch release tag pointing to the previous known-good commit
-(e.g., `v1.2.4` → same commit as `v1.2.2`). `promote-release.yml` retags `:rc`
-(which should be the last RC for that commit) → `:v1.2.4`. Operator updates
-`CD_IMAGE_TAG=v1.2.4` and restarts the daemon. Daemon's built-in rollback handles
-transient failures automatically.
+**Production:** push a new `v*` tag pointing to the last known-good commit (e.g. `v1.2.4`
+pointing to same commit as `v1.2.2`); update `CD_IMAGE_TAG` in production env and restart
+daemon. Daemon's built-in rollback handles transient failures automatically.


### PR DESCRIPTION
## Summary

- Designs and implements a three-environment CI/CD pipeline (test bed → staging → production) where **no code merges to master before UAT sign-off**
- Test bed is agent-managed (direct deploys via Podman socket, no CD daemon)
- Staging auto-deploys on every RC tag push via a mutable `:rc` image tag
- Production receives releases via digest-based retag (bit-identical to UAT-tested image)
- Replaces ad-hoc `publish-*` auto-triggers with purpose-built, explicitly-scoped workflows

## Workflows added

| Workflow | Trigger | Purpose |
|---|---|---|
| `ci-pr.yml` | PR commit | pytest + docker build gate — merge blocker |
| `build-on-demand.yml` | `workflow_dispatch` | Agent builds any branch ref for test bed; pushes `:sha-<hash>` |
| `build-rc.yml` | `v*-rc*` tag on any branch | RC build → `:v1.2.3-rc1` + `:rc`; staging daemon auto-deploys |
| `promote-release.yml` | `v*` tag on master | Retags `:rc` → `:v1.2.3` by digest; no rebuild; digest match verified |

## Workflows updated

- `publish-master.yml` — removed master-push and tag auto-triggers; `workflow_dispatch` only
- `publish-agent-minimal.yml` — same

## Documentation

- `docs/decisions/0005-cicd-pipeline-design.md` — ADR covering all five design decisions (no Jenkins, agent-managed test bed, no master merge before UAT, RC-based promotion, removed `:latest`)
- `docs/design/cicd-pipeline.md` — full design doc with pipeline diagram, environment definitions, CD daemon config per env, image tagging strategy, linear history enforcement, rollback procedures
- `AGENTS.md` — CI/CD section added; agents directed to `docs/design/cicd-pipeline.md` before triggering builds or pushing tags

## Test plan

- [ ] Push a `v*-rc*` tag on a feature branch → `build-rc.yml` fires, `:rc` updated, staging daemon redeploys
- [ ] Open a PR → `ci-pr.yml` runs pytest and docker build; merge is blocked until green
- [ ] Run `gh workflow run build-on-demand.yml --ref <branch>` → image pushed with `:sha-<hash>`
- [ ] Merge PR (rebase only), push `v*` tag on master → `promote-release.yml` retags, digest match passes
- [ ] Confirm `publish-master.yml` and `publish-agent-minimal.yml` no longer fire on master push

## Branch protection (manual step after merge)

Enable on `master` / `release/v3`:
- Require status checks: `pytest`, `Docker build check`
- Require linear history (rebase-only, no merge commits)
- Require branches to be up to date before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)