### PR TITLE
feat(topics): branch picker, base SHA display, and deduplicated branch names

### DIFF
--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -33,7 +33,7 @@
               @input="onBranchInput"
               @focus="branchDropdownOpen = true"
               @blur="scheduleBranchClose"
-              placeholder="Branch (optional)"
+              placeholder="Branch (required)"
               autocomplete="off"
               class="branch-input"
               :title="selectedBranch ? `Base branch: ${selectedBranch}` : 'Select a base branch'"
@@ -312,6 +312,10 @@ async function load() {
 }
 
 async function createTopic() {
+  if (!selectedBranch.value) {
+    createError.value = 'Please select a branch'
+    return
+  }
   creating.value = true
   createError.value = ''
   try {

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -68,7 +68,9 @@
           <span class="topic-row">
             <RouterLink :to="`/workspaces/${id}/topics/${t.id}`">{{ t.subject }}</RouterLink>
             <span class="muted small"> — branch: {{ t.branch_name }}</span>
-            <span v-if="t.repo_ref" class="repo-ref-badge">{{ t.repo_ref }}</span>
+            <span v-if="t.repo_ref" class="repo-ref-badge">
+              {{ t.repo_ref }}<template v-if="t.base_sha"> · {{ t.base_sha.substring(0, 7) }}</template>
+            </span>
           </span>
           <button v-if="!isArchived" class="remove-btn" @click="deleteTopic(t.id, t.subject)" title="Archive topic">Archive</button>
         </li>

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -25,6 +25,36 @@
       </div>
       <form v-if="!isArchived" @submit.prevent="createTopic" class="create-form">
         <input v-model="subject" placeholder="Topic subject" required />
+
+        <div class="branch-picker" ref="branchPickerEl">
+          <div class="branch-input-wrap">
+            <input
+              v-model="branchFilter"
+              @input="onBranchInput"
+              @focus="branchDropdownOpen = true"
+              @blur="scheduleBranchClose"
+              placeholder="Branch (optional)"
+              autocomplete="off"
+              class="branch-input"
+              :title="selectedBranch ? `Base branch: ${selectedBranch}` : 'Select a base branch'"
+            />
+            <button v-if="selectedBranch" type="button" class="branch-clear" @mousedown.prevent="clearBranch" title="Clear branch">×</button>
+            <span class="branch-caret" @mousedown.prevent="toggleBranchDropdown">▾</span>
+          </div>
+          <ul v-if="branchDropdownOpen" class="branch-dropdown">
+            <li v-if="branchesLoading" class="branch-hint">Loading…</li>
+            <li v-else-if="!filteredBranches.length" class="branch-hint">No branches found</li>
+            <template v-else>
+              <li
+                v-for="b in filteredBranches"
+                :key="b"
+                @mousedown.prevent="selectBranch(b)"
+                :class="{ 'branch-selected': b === selectedBranch }"
+              >{{ b }}</li>
+            </template>
+          </ul>
+        </div>
+
         <button type="submit" :disabled="creating">
           {{ creating ? 'Creating…' : 'New Topic' }}
         </button>
@@ -38,6 +68,7 @@
           <span class="topic-row">
             <RouterLink :to="`/workspaces/${id}/topics/${t.id}`">{{ t.subject }}</RouterLink>
             <span class="muted small"> — branch: {{ t.branch_name }}</span>
+            <span v-if="t.repo_ref" class="repo-ref-badge">{{ t.repo_ref }}</span>
           </span>
           <button v-if="!isArchived" class="remove-btn" @click="deleteTopic(t.id, t.subject)" title="Archive topic">Archive</button>
         </li>
@@ -149,6 +180,19 @@ const subject = ref('')
 const agentStatus = ref(null)
 let statusTimer = null
 
+const branches = ref([])
+const branchesLoading = ref(false)
+const branchFilter = ref('')
+const selectedBranch = ref('')
+const branchDropdownOpen = ref(false)
+let branchCloseTimer = null
+
+const filteredBranches = computed(() => {
+  const q = branchFilter.value.toLowerCase()
+  if (!q || q === selectedBranch.value.toLowerCase()) return branches.value
+  return branches.value.filter(b => b.toLowerCase().includes(q))
+})
+
 const refreshing = ref(false)
 const restarting = ref(false)
 const envPanel = ref(null)
@@ -216,6 +260,40 @@ async function fetchAgentStatus() {
   } catch { /* ignore */ }
 }
 
+async function fetchBranches() {
+  branchesLoading.value = true
+  try {
+    const r = await fetch(`/api/workspaces/${id}/branches`)
+    if (r.ok) branches.value = await r.json()
+  } catch { /* ignore */ } finally {
+    branchesLoading.value = false
+  }
+}
+
+function onBranchInput() {
+  if (branchFilter.value !== selectedBranch.value) selectedBranch.value = ''
+  branchDropdownOpen.value = true
+}
+
+function selectBranch(b) {
+  selectedBranch.value = b
+  branchFilter.value = b
+  branchDropdownOpen.value = false
+}
+
+function clearBranch() {
+  selectedBranch.value = ''
+  branchFilter.value = ''
+}
+
+function toggleBranchDropdown() {
+  branchDropdownOpen.value = !branchDropdownOpen.value
+}
+
+function scheduleBranchClose() {
+  branchCloseTimer = setTimeout(() => { branchDropdownOpen.value = false }, 150)
+}
+
 async function load() {
   loading.value = true
   try {
@@ -240,7 +318,10 @@ async function createTopic() {
     const r = await fetch(`/api/workspaces/${id}/topics`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ subject: subject.value }),
+      body: JSON.stringify({
+        subject: subject.value,
+        repo_ref: selectedBranch.value || null,
+      }),
     })
     if (!r.ok) {
       const err = await r.json()
@@ -248,6 +329,7 @@ async function createTopic() {
       return
     }
     subject.value = ''
+    clearBranch()
     await load()
   } finally {
     creating.value = false
@@ -327,6 +409,7 @@ async function deleteStaff(name) {
 onMounted(async () => {
   await load()
   if (!isArchived.value) {
+    fetchBranches()
     await fetchAgentStatus()
     statusTimer = setInterval(fetchAgentStatus, 10000)
   }
@@ -334,6 +417,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   if (statusTimer) clearInterval(statusTimer)
+  if (branchCloseTimer) clearTimeout(branchCloseTimer)
 })
 </script>
 
@@ -401,4 +485,19 @@ section { margin-bottom: 2rem; }
 .small { font-size: 0.82em; }
 .remove-btn { background: none; border: none; color: #94a3b8; cursor: pointer; font-size: 0.9em; padding: 0.15rem 0.4rem; border-radius: 3px; }
 .remove-btn:hover { background: #fee2e2; color: #dc2626; }
+
+.branch-picker { position: relative; min-width: 180px; flex: 1; max-width: 260px; }
+.branch-input-wrap { display: flex; align-items: center; border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; overflow: visible; }
+.branch-input { flex: 1; padding: 0.4rem 0.5rem; border: none; outline: none; font-size: 0.9em; background: transparent; min-width: 0; }
+.branch-clear { background: none; border: none; color: #94a3b8; cursor: pointer; font-size: 1em; padding: 0 0.3rem; line-height: 1; }
+.branch-clear:hover { color: #dc2626; }
+.branch-caret { padding: 0 0.4rem; color: #64748b; cursor: pointer; font-size: 0.75em; user-select: none; }
+.branch-caret:hover { color: #1e293b; }
+.branch-dropdown { position: absolute; top: calc(100% + 2px); left: 0; right: 0; background: #fff; border: 1px solid #cbd5e1; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,.1); max-height: 220px; overflow-y: auto; z-index: 100; list-style: none; padding: 0.25rem 0; margin: 0; }
+.branch-dropdown li { padding: 0.35rem 0.75rem; cursor: pointer; font-size: 0.88em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.branch-dropdown li:hover { background: #f1f5f9; }
+.branch-dropdown li.branch-selected { background: #eff6ff; color: #2563eb; font-weight: 500; }
+.branch-hint { color: #94a3b8; cursor: default !important; font-size: 0.85em; }
+.branch-hint:hover { background: none !important; }
+.repo-ref-badge { background: #dbeafe; color: #1d4ed8; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 500; margin-left: 0.25rem; }
 </style>

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -39,16 +39,26 @@ def _response_topic(workspace_id: str, topic_id: str) -> str:
     return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/response"
 
 
-def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str) -> None:
+def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str, repo_ref: str = "") -> None:
     if Path(worktree_path).exists():
         return
     Path(worktree_path).parent.mkdir(parents=True, exist_ok=True)
+    start_point = "HEAD"
+    if repo_ref:
+        try:
+            subprocess.run(
+                ["git", "-C", repo_dir, "fetch", "origin", repo_ref],
+                capture_output=True, text=True, check=True,
+            )
+            start_point = f"origin/{repo_ref}"
+        except subprocess.CalledProcessError:
+            LOGGER.warning("agent.worktree_fetch_failed repo_ref=%s — falling back to HEAD", repo_ref)
     try:
         subprocess.run(
-            ["git", "-C", repo_dir, "worktree", "add", worktree_path, "-b", branch],
+            ["git", "-C", repo_dir, "worktree", "add", worktree_path, "-b", branch, start_point],
             capture_output=True, text=True, check=True,
         )
-        LOGGER.info("agent.worktree_created path=%s branch=%s", worktree_path, branch)
+        LOGGER.info("agent.worktree_created path=%s branch=%s base=%s", worktree_path, branch, start_point)
     except subprocess.CalledProcessError:
         # Branch already exists — check out without -b
         subprocess.run(
@@ -168,6 +178,7 @@ def _process_prompt(
     agent_name = payload.get("agent_name", "claude")
     worktree = payload.get("worktree", "")
     branch = payload.get("branch", "")
+    repo_ref = payload.get("repo_ref", "")
     text = payload.get("text", "")
     session_id = payload.get("session_id")
     is_new_session = bool(payload.get("is_new_session", False))
@@ -188,9 +199,9 @@ def _process_prompt(
 
     try:
         if worktree and branch and repo_dir:
-            _ensure_worktree(repo_dir, worktree, branch)
+            _ensure_worktree(repo_dir, worktree, branch, repo_ref)
     except Exception:
-        LOGGER.exception("agent.worktree_create_failed worktree=%s branch=%s", worktree, branch)
+        LOGGER.exception("agent.worktree_create_failed worktree=%s branch=%s repo_ref=%s", worktree, branch, repo_ref)
 
     cwd = worktree if (worktree and Path(worktree).exists()) else repo_dir or "/"
 
@@ -212,18 +223,11 @@ def _process_prompt(
     if adapter == "codex":
         response_text, new_session_id, transcript = _run_codex(cwd, text)
     else:
-        # Claude sessions are scoped to the CWD (project directory).
-        # For workspace/global scope we use a stable shared directory so
-        # --resume works across different topic worktrees.
-        session_cwd = cwd
-        if session_scope == "workspace":
-            session_cwd = f"/workspace/sessions/{workspace_id}"
-            Path(session_cwd).mkdir(parents=True, exist_ok=True)
-        elif session_scope == "global":
-            session_cwd = "/workspace/sessions/global"
-            Path(session_cwd).mkdir(parents=True, exist_ok=True)
+        # Always run Claude in the topic worktree so the agent's pwd reflects
+        # the selected branch. Session continuity is maintained via --resume
+        # SESSION_ID which works from any CWD.
         response_text, new_session_id, transcript = _run_claude(
-            session_cwd, text, session_id, is_new_session, subagent, model, system_prompt
+            cwd, text, session_id, is_new_session, subagent, model, system_prompt
         )
 
     LOGGER.info("agent.llm_done topic_id=%s chars=%d", topic_id, len(response_text))

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -39,26 +39,16 @@ def _response_topic(workspace_id: str, topic_id: str) -> str:
     return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/response"
 
 
-def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str, repo_ref: str = "") -> None:
+def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str) -> None:
     if Path(worktree_path).exists():
         return
     Path(worktree_path).parent.mkdir(parents=True, exist_ok=True)
-    start_point = "HEAD"
-    if repo_ref:
-        try:
-            subprocess.run(
-                ["git", "-C", repo_dir, "fetch", "origin", repo_ref],
-                capture_output=True, text=True, check=True,
-            )
-            start_point = f"origin/{repo_ref}"
-        except subprocess.CalledProcessError:
-            LOGGER.warning("agent.worktree_fetch_failed repo_ref=%s — falling back to HEAD", repo_ref)
     try:
         subprocess.run(
-            ["git", "-C", repo_dir, "worktree", "add", worktree_path, "-b", branch, start_point],
+            ["git", "-C", repo_dir, "worktree", "add", worktree_path, "-b", branch],
             capture_output=True, text=True, check=True,
         )
-        LOGGER.info("agent.worktree_created path=%s branch=%s base=%s", worktree_path, branch, start_point)
+        LOGGER.info("agent.worktree_created path=%s branch=%s", worktree_path, branch)
     except subprocess.CalledProcessError:
         # Branch already exists — check out without -b
         subprocess.run(
@@ -178,7 +168,6 @@ def _process_prompt(
     agent_name = payload.get("agent_name", "claude")
     worktree = payload.get("worktree", "")
     branch = payload.get("branch", "")
-    repo_ref = payload.get("repo_ref", "")
     text = payload.get("text", "")
     session_id = payload.get("session_id")
     is_new_session = bool(payload.get("is_new_session", False))
@@ -199,9 +188,9 @@ def _process_prompt(
 
     try:
         if worktree and branch and repo_dir:
-            _ensure_worktree(repo_dir, worktree, branch, repo_ref)
+            _ensure_worktree(repo_dir, worktree, branch)
     except Exception:
-        LOGGER.exception("agent.worktree_create_failed worktree=%s branch=%s repo_ref=%s", worktree, branch, repo_ref)
+        LOGGER.exception("agent.worktree_create_failed worktree=%s branch=%s", worktree, branch)
 
     cwd = worktree if (worktree and Path(worktree).exists()) else repo_dir or "/"
 
@@ -223,11 +212,18 @@ def _process_prompt(
     if adapter == "codex":
         response_text, new_session_id, transcript = _run_codex(cwd, text)
     else:
-        # Always run Claude in the topic worktree so the agent's pwd reflects
-        # the selected branch. Session continuity is maintained via --resume
-        # SESSION_ID which works from any CWD.
+        # Claude sessions are scoped to the CWD (project directory).
+        # For workspace/global scope we use a stable shared directory so
+        # --resume works across different topic worktrees.
+        session_cwd = cwd
+        if session_scope == "workspace":
+            session_cwd = f"/workspace/sessions/{workspace_id}"
+            Path(session_cwd).mkdir(parents=True, exist_ok=True)
+        elif session_scope == "global":
+            session_cwd = "/workspace/sessions/global"
+            Path(session_cwd).mkdir(parents=True, exist_ok=True)
         response_text, new_session_id, transcript = _run_claude(
-            cwd, text, session_id, is_new_session, subagent, model, system_prompt
+            session_cwd, text, session_id, is_new_session, subagent, model, system_prompt
         )
 
     LOGGER.info("agent.llm_done topic_id=%s chars=%d", topic_id, len(response_text))

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -107,6 +107,7 @@ _MIGRATIONS = [
     "ALTER TABLE workspaces ADD COLUMN last_message_at TEXT",
     "ALTER TABLE messages ADD COLUMN usage_json TEXT",
     "ALTER TABLE topics ADD COLUMN repo_ref TEXT",
+    "ALTER TABLE topics ADD COLUMN base_sha TEXT",
 ]
 
 

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -106,6 +106,7 @@ _MIGRATIONS = [
     "ALTER TABLE workspaces ADD COLUMN last_refreshed_at TEXT",
     "ALTER TABLE workspaces ADD COLUMN last_message_at TEXT",
     "ALTER TABLE messages ADD COLUMN usage_json TEXT",
+    "ALTER TABLE topics ADD COLUMN repo_ref TEXT",
 ]
 
 

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -103,7 +103,7 @@ async def send_message(
         if ws_row is None:
             raise HTTPException(404, "workspace not found")
         topic = conn.execute(
-            "SELECT id, worktree_path, branch_name FROM topics"
+            "SELECT id, worktree_path, branch_name, repo_ref FROM topics"
             " WHERE id = ? AND workspace_id = ? AND archived_at IS NULL",
             (topic_id, workspace_id),
         ).fetchone()
@@ -175,6 +175,7 @@ async def send_message(
         "subagent": staff["agent"],
         "worktree": topic["worktree_path"],
         "branch": topic["branch_name"],
+        "repo_ref": topic["repo_ref"] or "",
         "session_id": session_uuid,
         "is_new_session": is_new_session,
         "session_scope": staff["session_scope"] or "topic",

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -39,6 +39,7 @@ def _workspace_exists_any(conn, workspace_id: str) -> bool:
 class TopicCreate(BaseModel):
     subject: str
     branch_name: str | None = None
+    repo_ref: str | None = None
 
 
 class TopicOut(BaseModel):
@@ -46,6 +47,7 @@ class TopicOut(BaseModel):
     workspace_id: str
     subject: str
     branch_name: str
+    repo_ref: str | None
     worktree_path: str
     created_at: str
     archived_at: str | None
@@ -57,6 +59,7 @@ def _row_to_topic(row) -> TopicOut:
         workspace_id=row["workspace_id"],
         subject=row["subject"],
         branch_name=row["branch_name"],
+        repo_ref=row["repo_ref"],
         worktree_path=row["worktree_path"],
         created_at=row["created_at"],
         archived_at=row["archived_at"],
@@ -71,12 +74,13 @@ def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> Topi
             raise HTTPException(status_code=404, detail="workspace not found")
         topic_id = str(uuid.uuid4())
         branch_name = (body.branch_name or _slugify(body.subject)).strip()
+        repo_ref = body.repo_ref.strip() if body.repo_ref else None
         worktree_path = f"/workspace/worktrees/{topic_id}"
         now = _now()
         conn.execute(
-            "INSERT INTO topics (id, workspace_id, subject, branch_name, worktree_path, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?)",
-            (topic_id, workspace_id, body.subject.strip(), branch_name, worktree_path, now),
+            "INSERT INTO topics (id, workspace_id, subject, branch_name, repo_ref, worktree_path, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (topic_id, workspace_id, body.subject.strip(), branch_name, repo_ref, worktree_path, now),
         )
         conn.commit()
         row = conn.execute(

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -119,7 +119,7 @@ def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> Topi
         if ws_row is None:
             raise HTTPException(status_code=404, detail="workspace not found")
         topic_id = str(uuid.uuid4())
-        branch_name = (body.branch_name or _slugify(body.subject)).strip()
+        branch_name = (body.branch_name or f"topic/{_slugify(body.subject)}-{topic_id[:7]}").strip()
         repo_ref = body.repo_ref.strip()
         worktree_path = f"/workspace/worktrees/{topic_id}"
         now = _now()

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
+import logging
 import re
+import urllib.request
 import uuid
 from datetime import datetime, timezone
+
+LOGGER = logging.getLogger(__name__)
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -36,6 +41,42 @@ def _workspace_exists_any(conn, workspace_id: str) -> bool:
     ).fetchone() is not None
 
 
+def _parse_github_repo(repo_url: str) -> tuple[str, str] | None:
+    url = repo_url.strip().rstrip("/")
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    return None
+
+
+def _fetch_ref_sha(repo_url: str, ref: str, token: str | None) -> str | None:
+    parsed = _parse_github_repo(repo_url)
+    if parsed is None:
+        return None
+    owner, repo = parsed
+    api_url = f"https://api.github.com/repos/{owner}/{repo}/commits/{ref}"
+    req = urllib.request.Request(
+        api_url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "codex-slack-master",
+        },
+    )
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+        return data.get("sha")
+    except Exception:
+        LOGGER.warning("topics.fetch_ref_sha_failed repo_url=%s ref=%s", repo_url, ref)
+        return None
+
+
 class TopicCreate(BaseModel):
     subject: str
     branch_name: str | None = None
@@ -48,6 +89,7 @@ class TopicOut(BaseModel):
     subject: str
     branch_name: str
     repo_ref: str | None
+    base_sha: str | None
     worktree_path: str
     created_at: str
     archived_at: str | None
@@ -60,6 +102,7 @@ def _row_to_topic(row) -> TopicOut:
         subject=row["subject"],
         branch_name=row["branch_name"],
         repo_ref=row["repo_ref"],
+        base_sha=row["base_sha"],
         worktree_path=row["worktree_path"],
         created_at=row["created_at"],
         archived_at=row["archived_at"],
@@ -70,7 +113,10 @@ def _row_to_topic(row) -> TopicOut:
 def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> TopicOut:
     conn = get_connection(request.app.state.db_path)
     try:
-        if not _workspace_exists(conn, workspace_id):
+        ws_row = conn.execute(
+            "SELECT repo_url FROM workspaces WHERE id = ? AND archived_at IS NULL", (workspace_id,)
+        ).fetchone()
+        if ws_row is None:
             raise HTTPException(status_code=404, detail="workspace not found")
         topic_id = str(uuid.uuid4())
         branch_name = (body.branch_name or _slugify(body.subject)).strip()
@@ -88,6 +134,17 @@ def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> Topi
         ).fetchone()
     finally:
         conn.close()
+
+    base_sha = _fetch_ref_sha(ws_row["repo_url"], repo_ref, request.app.state.settings.gh_token)
+    if base_sha:
+        conn2 = get_connection(request.app.state.db_path)
+        try:
+            conn2.execute("UPDATE topics SET base_sha = ? WHERE id = ?", (base_sha, topic_id))
+            conn2.commit()
+            row = conn2.execute("SELECT * FROM topics WHERE id = ?", (topic_id,)).fetchone()
+        finally:
+            conn2.close()
+
     return _row_to_topic(row)
 
 

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -39,7 +39,7 @@ def _workspace_exists_any(conn, workspace_id: str) -> bool:
 class TopicCreate(BaseModel):
     subject: str
     branch_name: str | None = None
-    repo_ref: str | None = None
+    repo_ref: str
 
 
 class TopicOut(BaseModel):
@@ -74,7 +74,7 @@ def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> Topi
             raise HTTPException(status_code=404, detail="workspace not found")
         topic_id = str(uuid.uuid4())
         branch_name = (body.branch_name or _slugify(body.subject)).strip()
-        repo_ref = body.repo_ref.strip() if body.repo_ref else None
+        repo_ref = body.repo_ref.strip()
         worktree_path = f"/workspace/worktrees/{topic_id}"
         now = _now()
         conn.execute(

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import logging
+import re
 import sqlite3
+import urllib.request
 import uuid
 from datetime import datetime, timezone
 
@@ -303,3 +306,63 @@ def get_agent_status(workspace_id: str, request: Request) -> dict:  # type: igno
     name = row["container_name"] or container_name(workspace_id)
     settings = request.app.state.settings
     return get_container_status(name=name, dry_run=settings.dry_run)
+
+
+def _parse_github_repo(repo_url: str) -> tuple[str, str] | None:
+    url = repo_url.strip().rstrip("/")
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    return None
+
+
+def _fetch_github_branches(owner: str, repo: str, token: str | None) -> list[str]:
+    branches: list[str] = []
+    page = 1
+    while page <= 5:
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/branches?per_page=100&page={page}"
+        req = urllib.request.Request(
+            api_url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "codex-slack-master",
+            },
+        )
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data: list[dict] = json.loads(resp.read().decode())
+        except Exception:
+            LOGGER.exception("workspaces.fetch_branches_failed owner=%s repo=%s page=%d", owner, repo, page)
+            break
+        if not data:
+            break
+        branches.extend(b["name"] for b in data)
+        if len(data) < 100:
+            break
+        page += 1
+    return sorted(branches)
+
+
+@router.get("/{workspace_id}/branches", response_model=list[str])
+def list_workspace_branches(workspace_id: str, request: Request) -> list[str]:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        row = conn.execute(
+            "SELECT repo_url FROM workspaces WHERE id = ?", (workspace_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        raise HTTPException(status_code=404, detail="workspace not found")
+    parsed = _parse_github_repo(row["repo_url"])
+    if parsed is None:
+        return []
+    owner, repo = parsed
+    settings = request.app.state.settings
+    return _fetch_github_branches(owner, repo, settings.gh_token)


### PR DESCRIPTION
## Summary

- Adds `GET /api/workspaces/{id}/branches` endpoint — fetches branches in real-time from GitHub API (paginates up to 500, supports HTTPS and SSH remote URLs, uses `GH_TOKEN` when set)
- Adds `repo_ref` (required) and `base_sha` fields to `TopicCreate` / `TopicOut` backed by new DB columns (auto-migrated on startup); `base_sha` is resolved at creation time via GitHub Commits API
- Branch selection is mandatory on topic creation — form blocks submit until a branch is chosen
- Topic branch names are now prefixed `topic/` and suffixed with the first 7 chars of the topic UUID (e.g. `topic/fix-auth-a1b2c3d`) to prevent git worktree failures when two topics share the same subject
- Adds a searchable branch combobox to the topic creation form: filter-as-you-type, click to select, × to clear; selected branch shown as a badge on existing topics with the resolved base commit SHA (short 7-char hash)

## Test plan

- [x] Open a workspace backed by a GitHub repo — branch list loads in the picker without blocking the page
- [x] Type a partial branch name — list filters in real-time
- [x] Attempt to submit topic without selecting a branch — form shows validation error and blocks submit
- [x] Select a branch, submit a new topic — topic appears with branch badge and 7-char base SHA
- [x] Create two topics with the same subject — both get unique `topic/<slug>-<uuid7>` branch names, both worktrees created successfully
- [ ] Workspace with a non-GitHub repo URL — picker shows "No branches found" gracefully
- [ ] Verify `GET /api/workspaces/{id}/branches` returns a sorted list via curl/browser
- [ ] Verify existing topics (before migration) still load with `repo_ref: null`, `base_sha: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)