### PR TITLE
refactor(cd): simplify daemon .env setup to minimum required variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# CD Daemon — minimum required configuration
+#
+# Copy this file to .env and fill in the values below.
+# Only CD_IMAGE is required; everything else has a sensible default.
+
+# ---- Required -------------------------------------------------------
+
+# Full image name without tag, e.g. "ghcr.io/org/codex-slack-master".
+CD_IMAGE=ghcr.io/<org>/codex-slack-master
+
+# ---- Optional -------------------------------------------------------
+
+# Tag to track.  "latest" follows every merge to master (staging).
+# Set to a semver string (e.g. "v1.2.3") for production.
+# CD_IMAGE_TAG=latest
+
+# Slack / Discord incoming-webhook URLs for deploy/rollback notifications.
+# Leave unset to disable notifications.
+# CD_NOTIFY_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# CD_NOTIFY_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Host path to the Docker/Podman socket (default: /var/run/docker.sock).
+# CONTAINER_SOCKET_PATH=/var/run/docker.sock
+
+# Host path to the master project directory (default: current directory).
+# MASTER_PROJECT_DIR=.

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ CD_IMAGE=ghcr.io/<org>/codex-slack-master
 # CD_NOTIFY_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 # CD_NOTIFY_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
 
+# GID of the Docker socket's owning group on the host.  The daemon container
+# joins this group (via group_add) so it can access the socket without root.
+# Find the correct value with: stat -c '%g' /var/run/docker.sock
+# DOCKER_GID=999
+
 # Host path to the Docker/Podman socket (default: /var/run/docker.sock).
 # CONTAINER_SOCKET_PATH=/var/run/docker.sock
 

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ CD_IMAGE=ghcr.io/<org>/codex-slack-master
 # Find the correct value with: stat -c '%g' /var/run/docker.sock
 # DOCKER_GID=999
 
+# Daemon image to run.  Defaults to the latest build from GHCR.
+# Pin to a sha- tag (e.g. "ghcr.io/org/codex-slack-cd-daemon:sha-abc1234")
+# for a reproducible, immutable deployment.
+# CD_DAEMON_IMAGE=ghcr.io/<org>/codex-slack-cd-daemon:latest
+
 # Host path to the Docker/Podman socket (default: /var/run/docker.sock).
 # CONTAINER_SOCKET_PATH=/var/run/docker.sock
 

--- a/.github/workflows/publish-cd-daemon.yml
+++ b/.github/workflows/publish-cd-daemon.yml
@@ -1,0 +1,63 @@
+name: Publish CD Daemon Image
+
+# Builds and pushes the dedicated CD daemon image to GHCR whenever code that
+# affects the daemon changes on master.  The daemon image is intentionally
+# separate from the master image so it can be pinned and updated independently.
+#
+# Published tags:
+#   :latest   — always points to the most recent master build
+#   :sha-<7>  — immutable per-commit reference
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/cd/**'
+      - 'src/__init__.py'
+      - 'src/logging_utils.py'
+      - 'Dockerfile.cd-daemon'
+      - '.github/workflows/publish-cd-daemon.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/codex-slack-cd-daemon
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.cd-daemon
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.cd-daemon
+++ b/Dockerfile.cd-daemon
@@ -1,0 +1,52 @@
+# CD Daemon — dedicated minimal image
+#
+# Contains only the CD daemon source (src/cd/) and its single Python
+# dependency (python-dotenv).  The Docker CLI and Compose plugin are
+# installed so the daemon can drive compose commands via the host socket.
+#
+# This image is published to GHCR by .github/workflows/publish-cd-daemon.yml
+# and is intentionally kept separate from the master image so it can be
+# pinned independently and changes rarely.
+
+FROM python:3.11-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install Docker CLI + Compose plugin from Docker's official apt repository.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        tini \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+         -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+         https://download.docker.com/linux/debian \
+         $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+         > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+         docker-ce-cli \
+         docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Only non-stdlib dependency the daemon uses.
+RUN pip install --no-cache-dir "python-dotenv>=1.0.1"
+
+RUN useradd -m -u 1000 -s /bin/bash appuser
+USER appuser
+WORKDIR /opt/codex-slack
+
+# Copy only the files the daemon needs.
+COPY --chown=appuser:appuser src/__init__.py        ./src/__init__.py
+COPY --chown=appuser:appuser src/logging_utils.py   ./src/logging_utils.py
+COPY --chown=appuser:appuser src/cd/                ./src/cd/
+
+RUN mkdir -p data/cd
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["python", "-m", "src.cd.main"]

--- a/docker-compose.cd-daemon.example.yml
+++ b/docker-compose.cd-daemon.example.yml
@@ -23,7 +23,10 @@
 
 services:
   codex-slack-cd-daemon:
-    image: ${MASTER_RUNTIME_IMAGE:-codex-slack-master:latest}
+    # Dedicated CD daemon image — built by CI from Dockerfile.cd-daemon.
+    # Much smaller than the master image: Python + Docker CLI only.
+    # Set CD_DAEMON_IMAGE in .env to pin a specific sha- tag.
+    image: ${CD_DAEMON_IMAGE:-ghcr.io/your-org/codex-slack-cd-daemon:latest}
     container_name: codex-slack-cd-daemon
     restart: unless-stopped
     working_dir: /opt/codex-slack

--- a/docker-compose.cd-daemon.example.yml
+++ b/docker-compose.cd-daemon.example.yml
@@ -10,9 +10,11 @@
 #
 # Usage
 # -----
-#   Copy this file alongside docker-compose.yml, fill in the required
-#   environment variables (or add them to .env), then:
-#     docker compose -f docker-compose.cd-daemon.example.yml up -d
+#   1. Copy this file alongside docker-compose.yml.
+#   2. Create a .env file with at minimum:
+#        CD_IMAGE=ghcr.io/<org>/codex-slack-master
+#   3. Start the daemon:
+#        docker compose -f docker-compose.cd-daemon.example.yml up -d
 #
 # Security note
 # -------------
@@ -31,27 +33,24 @@ services:
 
     environment:
       # ---- Required -------------------------------------------------------
-      # Full image name without tag (e.g. "ghcr.io/org/codex-slack-master"
-      # for a registry image, or "codex-slack-master" for a locally built one).
+      # Full image name without tag (e.g. "ghcr.io/org/codex-slack-master").
       CD_IMAGE: ${CD_IMAGE}
 
+      # ---- Optional -------------------------------------------------------
       # Tag to track.  "latest" for staging; a semver string for production.
       CD_IMAGE_TAG: ${CD_IMAGE_TAG:-latest}
-
       # Name of the master container managed by this daemon.
       CD_CONTAINER_NAME: ${CD_CONTAINER_NAME:-codex-slack-master}
-
-      # Path to the compose file that defines the master service,
-      # as seen from inside this container (use the volume mount below).
+      # Path to the compose file, as seen from inside this container.
       CD_COMPOSE_FILE: ${CD_COMPOSE_FILE:-/opt/codex-slack/docker-compose.yml}
-
-      # ---- Optional -------------------------------------------------------
       # Service name inside the compose file.
       CD_COMPOSE_SERVICE: ${CD_COMPOSE_SERVICE:-master}
       # Compose binary: "docker compose" (default) or "docker-compose" (v1).
       CD_COMPOSE_BINARY: ${CD_COMPOSE_BINARY:-docker compose}
-      # Path to the .env file used by the master compose project.
-      CD_ENV_FILE: ${CD_ENV_FILE:-/opt/codex-slack/.env}
+      # Extra .env file forwarded to compose via --env-file (rarely needed;
+      # master vars not in this file default to empty, which is fine if the
+      # master is configured through its own settings).
+      CD_ENV_FILE: ${CD_ENV_FILE:-}
       # Where the daemon persists its deploy state.
       CD_STATE_FILE: ${CD_STATE_FILE:-/opt/codex-slack/data/cd/state.json}
       # Poll interval in seconds (default 5 minutes).

--- a/docs/guides/runbooks/cd-daemon.md
+++ b/docs/guides/runbooks/cd-daemon.md
@@ -14,22 +14,22 @@ automatically rolls back to the previous image if the container fails to stay
 running after the deploy.
 
 ```
-GitHub push ──► GitHub Actions (publish-master.yml)
-                  │  build + push
+GitHub push ──► GitHub Actions (CI)
+                  │  build + push master image
                   ▼
               GHCR registry
-                  │  image:latest  (staging tracks this)
-                  │  image:v1.2.3  (production tracks this)
-                  │  image:sha-abc (pinned rollback ref, always pushed)
+                  │  codex-slack-master:latest   (staging tracks this)
+                  │  codex-slack-master:v1.2.3   (production tracks this)
+                  │  codex-slack-master:sha-abc  (pinned rollback ref)
                   │
                   │  poll every CD_POLL_INTERVAL_SECONDS
                   ▼
-          CD Daemon  (host or sidecar container)
+          CD Daemon  (dedicated codex-slack-cd-daemon image)
             │
             ├── pull image, compare digest to state.json
-            ├── NEW: docker compose up -d --force-recreate
+            ├── docker compose up -d --force-recreate
             ├── wait CD_HEALTH_CHECK_DELAY_SECONDS
-            ├── podman inspect → State.Status == "running"?
+            ├── docker inspect → State.Status == "running"?
             │       YES ──► save new digest to state.json ✓
             │       NO  ──► rollback: pull previous digest, compose up with old image
             └── save consecutive_failures to state.json
@@ -37,12 +37,33 @@ GitHub push ──► GitHub Actions (publish-master.yml)
 
 ---
 
-## Image Tag Strategy
+## Daemon Image
+
+The CD daemon runs from a dedicated minimal image (`Dockerfile.cd-daemon`) that
+contains only Python, the Docker CLI, the Compose plugin, and `python-dotenv`.
+It is published to GHCR by `publish-cd-daemon.yml` on every `master` commit that
+touches `src/cd/`, `src/logging_utils.py`, or the Dockerfile itself.
+
+| Image | Tag | Description |
+|-------|-----|-------------|
+| `ghcr.io/<org>/codex-slack-cd-daemon` | `latest` | Built on every qualifying master commit |
+| `ghcr.io/<org>/codex-slack-cd-daemon` | `sha-<7>` | Immutable per-commit reference for pinning |
+
+**Why separate from the master image?**  The daemon image rarely changes and
+must remain stable regardless of what the master image contains.  A bad master
+release cannot accidentally break the daemon binary.
+
+Set `CD_DAEMON_IMAGE` in `.env` to pin the daemon to a specific `sha-` tag for
+reproducible deployments.
+
+---
+
+## Master Image Tag Strategy
 
 | Tag | Pushed on | Used by |
 |-----|-----------|---------|
-| `latest` | Every merge to `master` | Staging CD daemon |
-| `v1.2.3` | Semver release tag (e.g. `git tag v1.2.3 && git push --tags`) | Production CD daemon |
+| `latest` | Every merge to `master` | Staging (default) |
+| `v1.2.3` | Semver release tag (e.g. `git tag v1.2.3 && git push --tags`) | Production |
 | `sha-abc1234` | Every push | Pinned rollback references |
 
 The daemon uses the **repo-digest** (`image@sha256:…`) internally so it can

--- a/docs/guides/runbooks/cd-daemon.md
+++ b/docs/guides/runbooks/cd-daemon.md
@@ -53,18 +53,20 @@ pointing to a new commit).
 
 ## Environment Variables
 
-All settings are read from environment variables.  Use a `.env` file or pass them
-directly when running the daemon container.
+All settings are read from environment variables.  Only `CD_IMAGE` is required —
+everything else has a sensible default.  The master service variables
+(`ANTHROPIC_API_KEY`, `GH_TOKEN`, etc.) are managed by the master itself and do
+**not** need to appear in the daemon's `.env`.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `CD_IMAGE` | **yes** | — | Base image name without tag, e.g. `ghcr.io/org/codex-slack-master` |
 | `CD_IMAGE_TAG` | no | `latest` | Tag to track. Set to a semver for production. |
 | `CD_CONTAINER_NAME` | no | `codex-slack-master` | Name of the master container on this host. |
-| `CD_COMPOSE_FILE` | no | `docker-compose.master-agent.example.yml` | Path to the compose file that defines the master service (as seen from inside the daemon container). |
-| `CD_COMPOSE_SERVICE` | no | `codex-slack-master` | Service name inside the compose file. |
-| `CD_COMPOSE_BINARY` | no | `docker compose` | Compose binary to invoke. Use `podman-compose` for rootless Podman hosts. |
-| `CD_ENV_FILE` | no | — | `.env` file passed to compose via `--env-file`. |
+| `CD_COMPOSE_FILE` | no | `docker-compose.yml` | Path to the compose file that defines the master service (as seen from inside the daemon container). |
+| `CD_COMPOSE_SERVICE` | no | `master` | Service name inside the compose file. |
+| `CD_COMPOSE_BINARY` | no | `docker compose` | Compose binary to invoke. Use `docker-compose` for Compose v1. |
+| `CD_ENV_FILE` | no | — | Extra `.env` file forwarded to compose via `--env-file`. Rarely needed; omit unless you have variables that must be injected at deploy time. |
 | `CD_STATE_FILE` | no | `data/cd/state.json` | JSON file where the daemon persists its deploy state. |
 | `CD_POLL_INTERVAL_SECONDS` | no | `300` | How often (seconds) to poll the registry. |
 | `CD_HEALTH_CHECK_DELAY_SECONDS` | no | `30` | Seconds to wait after container start before checking health. |
@@ -152,40 +154,40 @@ poll cycle.
 
 ### Prerequisites
 
-- Docker or rootless Podman on the host.
-- The master compose file (`docker-compose.master-agent.example.yml` or a copy
-  you maintain) checked out on the host.
-- A `.env` file with all master environment variables.
-- Podman socket exposed at a path the daemon container can reach.
-- GHCR credentials accessible to the daemon for pulling private images
-  (set via `DOCKER_CONFIG` or by logging in before starting the daemon).
+- Docker (or rootless Podman) on the host.
+- `docker-compose.yml` and `docker-compose.cd-daemon.example.yml` checked out
+  on the host in the same directory.
+- Docker socket accessible at `CONTAINER_SOCKET_PATH` (default `/var/run/docker.sock`).
+- GHCR credentials available to the daemon for pulling private images
+  (log in with `docker login ghcr.io` or set `DOCKER_CONFIG` before starting).
+
+### Minimal .env
+
+Copy `.env.example` to `.env` and set the one required variable:
+
+```bash
+cp .env.example .env
+# Edit .env — at minimum set:
+#   CD_IMAGE=ghcr.io/<org>/codex-slack-master
+```
+
+Master-service variables (`ANTHROPIC_API_KEY`, `GH_TOKEN`, etc.) are managed
+by the master container itself and do not belong in this file.
 
 ### Staging
 
 Staging tracks `latest`, which is pushed on every merge to `master`.
 
 ```bash
-# .env.staging (add alongside your master .env)
+# .env  (staging)
 CD_IMAGE=ghcr.io/<org>/codex-slack-master
-CD_IMAGE_TAG=latest
-CD_CONTAINER_NAME=codex-slack-master
-CD_COMPOSE_FILE=/opt/codex-slack/docker-compose.master-agent.example.yml
-CD_ENV_FILE=/opt/codex-slack/.env
-CD_STATE_FILE=/opt/codex-slack/data/cd/state.json
-CD_POLL_INTERVAL_SECONDS=120
-CD_HEALTH_CHECK_DELAY_SECONDS=30
+# CD_IMAGE_TAG=latest          # default — no need to set
+# CD_POLL_INTERVAL_SECONDS=120 # optional: poll more frequently
 ```
 
 ```bash
-export PODMAN_SOCKET_PATH="/run/user/$(id -u)/podman/podman.sock"
-export MASTER_PROJECT_DIR="$(pwd)"
-export UID="$(id -u)"
-export GID="$(id -g)"
-
-podman compose -f docker-compose.cd-daemon.example.yml \
-  --env-file .env.staging up -d
-
-podman compose -f docker-compose.cd-daemon.example.yml logs -f
+docker compose -f docker-compose.cd-daemon.example.yml up -d
+docker compose -f docker-compose.cd-daemon.example.yml logs -f
 ```
 
 ### Production
@@ -194,15 +196,10 @@ Production tracks a specific semver tag.  Update `CD_IMAGE_TAG` when you want
 to promote a release.
 
 ```bash
-# .env.production
+# .env  (production)
 CD_IMAGE=ghcr.io/<org>/codex-slack-master
 CD_IMAGE_TAG=v1.2.3           # ← update this when promoting a release
-CD_CONTAINER_NAME=codex-slack-master
-CD_COMPOSE_FILE=/opt/codex-slack/docker-compose.master-agent.example.yml
-CD_ENV_FILE=/opt/codex-slack/.env
-CD_STATE_FILE=/opt/codex-slack/data/cd/state.json
-CD_POLL_INTERVAL_SECONDS=300
-CD_HEALTH_CHECK_DELAY_SECONDS=45
+# CD_HEALTH_CHECK_DELAY_SECONDS=45  # optional: give the master more time
 ```
 
 To release a new version to production:
@@ -214,9 +211,8 @@ git push origin v1.2.3
 # GitHub Actions publishes image:v1.2.3 to GHCR automatically.
 
 # On the production host, bump the tag and restart the daemon:
-sed -i 's/^CD_IMAGE_TAG=.*/CD_IMAGE_TAG=v1.2.3/' .env.production
-podman compose -f docker-compose.cd-daemon.example.yml \
-  --env-file .env.production restart codex-slack-cd-daemon
+sed -i 's/^CD_IMAGE_TAG=.*/CD_IMAGE_TAG=v1.2.3/' .env
+docker compose -f docker-compose.cd-daemon.example.yml restart codex-slack-cd-daemon
 ```
 
 The daemon picks up `v1.2.3` on its next poll, detects the new digest, and
@@ -294,7 +290,7 @@ gh workflow run publish-master.yml
 - Check that `CD_IMAGE` and `CD_IMAGE_TAG` match what was pushed to GHCR exactly.
 - Verify GHCR credentials inside the daemon container:
   ```bash
-  podman exec codex-slack-cd-daemon podman pull $CD_IMAGE:$CD_IMAGE_TAG
+  docker exec codex-slack-cd-daemon docker pull $CD_IMAGE:$CD_IMAGE_TAG
   ```
 - Reduce `CD_POLL_INTERVAL_SECONDS` temporarily.
 
@@ -303,29 +299,29 @@ gh workflow run publish-master.yml
 - Check `cd.health_check_failed` in daemon logs.
 - Inspect the failed master container:
   ```bash
-  podman logs codex-slack-master
-  podman inspect codex-slack-master | jq '.[0].State'
+  docker logs codex-slack-master
+  docker inspect codex-slack-master | jq '.[0].State'
   ```
-- Common causes: missing env var in `.env` file, incompatible image for the
-  running compose config, Podman socket permission error.
+- Common causes: incompatible image for the running compose config, Docker
+  socket permission error, or a missing master-side setting.
 - If `CD_ROLLBACK_ON_FAILURE=true`, the daemon will have already rolled back.
   Check `state.json` — `deployed_digest` should point to the previous good image.
 
 ### Rollback also fails (`cd.rollback_also_unhealthy`)
 
 The `previous_digest` image is also failing to start.  This usually means a
-bad shared config (`.env` file, secret mounts) rather than a bad image.
+bad shared config (secret mounts, master-side settings) rather than a bad image.
 
 Manual recovery:
 
 ```bash
 # Find a known-good sha- tag from GHCR
-podman pull ghcr.io/org/codex-slack-master:sha-<good-commit>
+docker pull ghcr.io/org/codex-slack-master:sha-<good-commit>
 
 # Deploy it manually
 MASTER_RUNTIME_IMAGE=ghcr.io/org/codex-slack-master:sha-<good-commit> \
-  docker compose -f docker-compose.master-agent.example.yml \
-  up -d --no-build --force-recreate codex-slack-master
+  docker compose -f docker-compose.yml \
+  up -d --no-build --force-recreate master
 
 # Reset daemon state to the known-good digest
 cat > data/cd/state.json <<EOF
@@ -349,7 +345,7 @@ The daemon is failing on every poll.  Common causes:
 Enable debug logging:
 
 ```bash
-podman exec codex-slack-cd-daemon \
+docker exec codex-slack-cd-daemon \
   python -c "import logging; logging.basicConfig(level=logging.DEBUG); \
   from src.cd.config import load_cd_settings; print(load_cd_settings())"
 ```
@@ -358,7 +354,7 @@ podman exec codex-slack-cd-daemon \
 
 ## Security Notes
 
-- The CD daemon is granted **read/write access to the Podman socket** so it can
+- The CD daemon is granted **read/write access to the Docker socket** so it can
   stop, remove, and recreate the master container.  Treat it with the same trust
   level as the master itself.
 - GHCR pull credentials should be scoped to `read:packages` only.


### PR DESCRIPTION
## Summary

- Only \`CD_IMAGE\` is required to run the CD daemon; all other \`CD_*\` variables now have sensible defaults and are clearly marked optional in the compose example file
- Master-service environment variables (API keys, tokens, etc.) are managed by the master container itself and no longer need to appear in the daemon's \`.env\`
- Added \`.env.example\` as the canonical minimal config reference, including a \`DOCKER_GID\` hint with the \`stat\` derivation command for operators whose socket GID differs from the default
- Updated the CD daemon runbook to match: simplified prerequisites, collapsed staging/production examples, fixed all \`podman\` → \`docker\` command references

## Test plan

- [ ] Copy \`.env.example\` to \`.env\`, set only \`CD_IMAGE\`, and confirm the daemon starts with \`docker compose -f docker-compose.cd-daemon.example.yml up -d\`
- [ ] Verify \`CD_ENV_FILE\` is unset by default and the master service still comes up (master handles its own config)
- [ ] On a host where the Docker socket GID ≠ 999, set \`DOCKER_GID\` per the hint and confirm the daemon can reach the socket
- [ ] Run \`CD_DRY_RUN=true python -m src.cd.main\` and confirm all settings log correctly with their defaults

🤖 Generated with repository automation