### PR TITLE
feat(frontend): support pasting images from clipboard in chat

### DIFF
--- a/docs/design/paste-image-support.md
+++ b/docs/design/paste-image-support.md
@@ -1,0 +1,163 @@
+# Design: Paste Image Support in Chat Textarea
+
+**Status:** draft
+**Author:** architect
+**Date:** 2026-05-05
+**Related issue:** #126
+**Related design:** [attachment-management.md](./attachment-management.md)
+
+## Context
+
+Users frequently capture screenshots or copy images from another tool (browser, design app, terminal) and want to share them with an agent. Today they have to save the image to disk first, then click the file picker (📎) and select the file. That extra round-trip is friction for what should be a one-keystroke action.
+
+The chat input lives in `frontend/src/views/TopicChat.vue`. The component already has a working file-attachment pipeline:
+
+- `selectedFiles` ref holds pending `File` objects
+- The 📎 button opens a hidden `<input type="file" multiple>` that pushes selected files into `selectedFiles`
+- `sendMessage()` builds a `FormData`, appends every file as `files`, and POSTs to `/api/workspaces/:wsId/topics/:topicId/messages`
+- The backend (per `attachment-management.md`) already accepts and stores image attachments and renders them inline in chat bubbles
+
+The only missing piece is a path from the OS clipboard into `selectedFiles`. The browser exposes this via `ClipboardEvent.clipboardData.items` on `paste` events fired against an editable element — the existing textarea is already a valid paste target.
+
+## Goals
+
+- Pasting an image (Cmd/Ctrl+V) into the chat textarea adds it to `selectedFiles` so it ships on the next send, identically to a file-picker selection.
+- Multiple images in a single paste event are all captured.
+- Pasted images get a deterministic, sortable filename: `pasted-image-{ISO-timestamp}.{ext}` where `ext` is derived from the MIME type.
+- Default browser paste behavior (inserting a binary blob or filename text into the textarea) is suppressed when at least one image was captured.
+- Pasting plain text continues to work unchanged.
+
+## Non-goals
+
+- No clipboard image preview thumbnail in the file-chip strip beyond the existing filename chip — the existing chip UI is reused as-is.
+- No drag-and-drop support (separate feature).
+- No client-side image resizing, compression, or format conversion.
+- No HEIC/AVIF or video-frame handling — restricted to whatever MIME types the browser surfaces under `image/*`.
+- No backend changes. The upload contract is unchanged.
+- No paste support outside the chat textarea (e.g. into the message list).
+
+## Design
+
+### Surface change
+
+Add one event binding on the existing `<textarea>` in `TopicChat.vue`:
+
+```html
+<textarea
+  v-model="text"
+  placeholder="Type a message…"
+  rows="3"
+  :disabled="sending"
+  @keydown.enter.exact.prevent="sendMessage"
+  @paste="onPaste"
+/>
+```
+
+### Handler
+
+A new function `onPaste(evt)` in `<script setup>`:
+
+```js
+function onPaste(evt) {
+  const items = evt.clipboardData?.items
+  if (!items || !items.length) return
+
+  const pastedImages = []
+  for (const item of items) {
+    if (item.kind !== 'file') continue
+    if (!item.type || !item.type.startsWith('image/')) continue
+    const file = item.getAsFile()
+    if (!file) continue
+    pastedImages.push(renamePastedImage(file))
+  }
+
+  if (pastedImages.length === 0) return  // no images — let default paste run for text
+  evt.preventDefault()
+  selectedFiles.value = [...selectedFiles.value, ...pastedImages]
+}
+
+function renamePastedImage(file) {
+  const ext = mimeToExt(file.type) || 'png'
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')  // safe for filenames
+  const name = `pasted-image-${ts}.${ext}`
+  return new File([file], name, { type: file.type, lastModified: file.lastModified })
+}
+
+function mimeToExt(mime) {
+  switch (mime) {
+    case 'image/png':  return 'png'
+    case 'image/jpeg': return 'jpg'
+    case 'image/gif':  return 'gif'
+    case 'image/webp': return 'webp'
+    case 'image/bmp':  return 'bmp'
+    case 'image/svg+xml': return 'svg'
+    default:
+      // image/foo → foo; otherwise fall back to png
+      const m = /^image\/([a-z0-9.+-]+)$/i.exec(mime)
+      return m ? m[1].split('+')[0] : 'png'
+  }
+}
+```
+
+Notes:
+
+- `item.kind === 'file'` filters out the duplicate `text/plain` items that browsers sometimes include alongside an image (e.g. the source URL).
+- `getAsFile()` can return `null` for some items; we skip those defensively.
+- We rebuild the `File` with our own filename because the browser-supplied name is typically `image.png` for every paste, which would collide and is not informative.
+- Replacing `:` and `.` in the timestamp keeps the filename safe on Windows and avoids confusing extension parsing on the server.
+- We only call `preventDefault()` if at least one image was actually captured, so plain-text pastes (and mixed pastes that the user might still want as text) behave normally. In practice browsers do not deliver a useful text payload alongside a screenshot, so this is conservative.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Textarea
+  participant onPaste
+  participant selectedFiles
+  participant sendMessage
+  participant Backend
+
+  User->>Textarea: Cmd/Ctrl+V (image in clipboard)
+  Textarea->>onPaste: ClipboardEvent
+  onPaste->>onPaste: filter items by image/*
+  onPaste->>onPaste: rename to pasted-image-{ts}.{ext}
+  onPaste->>selectedFiles: append File[]
+  onPaste->>Textarea: preventDefault()
+  Note over Textarea: chip strip renders new file
+  User->>sendMessage: click Send
+  sendMessage->>Backend: multipart POST (text + files)
+```
+
+No state lives outside Vue refs; nothing async happens inside the handler; nothing needs unmounting.
+
+## Alternatives considered
+
+1. **Listen for `paste` on `document` / `window`.** Rejected — global listeners fire in contexts where the user is pasting elsewhere (e.g. into the URL bar, into the message detail panes), and risk swallowing pastes meant for other inputs. Scoping to the textarea is simpler and matches user intent.
+
+2. **Convert pasted images to base64 data URLs and embed them in the message text.** Rejected — bypasses the attachment pipeline that the backend, agents, and chat-bubble rendering already support; bloats the message body; and breaks the existing `attachment-management.md` contract.
+
+3. **Show a thumbnail preview in the chip strip for pasted images.** Deferred. The current chip UI shows filenames only and is consistent for both file-picker and paste paths. A thumbnail row is a separate UX improvement that should apply to both paths.
+
+4. **Auto-send on paste.** Rejected — users typically paste an image *and then* type context. Auto-send would surprise users and prevent them from pasting multiple images into one message.
+
+5. **Use `navigator.clipboard.read()` instead of the `ClipboardEvent`.** Rejected — requires async permission prompts on some browsers, has worse cross-browser support, and is unnecessary when the `paste` event already gives us synchronous access to clipboard data inside a user gesture.
+
+## Open Questions
+
+- [ ] Do we want a one-line toast or aria-live announcement when an image is captured ("1 image attached"), for accessibility? Default plan: no — the chip appearing in the strip is visible feedback, and screen-reader users will hear the textarea content unchanged because we suppress default paste. Owner: tester to flag during UAT if it feels off.
+- [ ] Should we cap the size of a pasted image to surface a friendlier error than the backend's? Default plan: no — defer to whatever limit the backend enforces today; revisit if UAT shows confusing failure modes.
+
+## Implementation Plan
+
+Single PR on `topic/support-paste-images-3646392`:
+
+1. Add `onPaste`, `renamePastedImage`, `mimeToExt` to `TopicChat.vue` `<script setup>`.
+2. Wire `@paste="onPaste"` on the textarea.
+3. Tests (authored by `tester` in parallel):
+   - Unit: `mimeToExt` mapping (png/jpeg/gif/webp/svg/unknown → png).
+   - Component: simulated `ClipboardEvent` with one `image/png` item appends one renamed file to `selectedFiles` and calls `preventDefault`.
+   - Component: simulated event with two image items appends both.
+   - Component: simulated event with only `text/plain` does not call `preventDefault` and does not touch `selectedFiles`.
+   - UAT (manual): screenshot → paste into textarea on Chrome, Firefox, Safari → chip appears → Send → image renders in the bubble.
+4. No backend, schema, or API changes.

--- a/docs/design/paste-image-support.md
+++ b/docs/design/paste-image-support.md
@@ -1,6 +1,6 @@
 # Design: Paste Image Support in Chat Textarea
 
-**Status:** draft
+**Status:** accepted
 **Author:** architect
 **Date:** 2026-05-05
 **Related issue:** #126

--- a/docs/knowledge-base/lessons-learned.md
+++ b/docs/knowledge-base/lessons-learned.md
@@ -90,6 +90,18 @@ Append-only log. Each entry: date, summary, root cause, fix applied, prevention.
 
 ---
 
+## 2026-05-05 — Vendor MIME subtype dots produce multi-dot extensions in filename generation
+
+*Summary:* When generating filenames for clipboard-pasted images, vendor MIME types such as `image/vnd.microsoft.icon` contain dots in the subtype. A naive regex that includes `.` in its character class (e.g. `[a-z0-9.+-]+`) extracts the entire subtype including dots, producing malformed extensions like `.vnd.microsoft.icon` instead of falling back to a safe default.
+
+*Root cause:* The `mimeToExt` fallback regex in the paste-image handler originally used `[a-z0-9.+-]+` for the subtype portion, which allowed dot characters through and incorporated them directly into the generated filename extension.
+
+*Fix applied:* Removed `.` from the regex character class, changing it to `[a-z0-9+-]+`. Subtypes containing dots no longer match, causing the function to fall back to `'png'` as the safe default extension.
+
+*Prevention:* When extracting file extensions from MIME type subtypes, restrict the character class to `[a-z0-9+-]` (no dots). Vendor MIME types with dotted subtypes should not produce dotted extensions — always fall back to a sensible default for unrecognised subtypes.
+
+---
+
 ## 2026-03-24 — docs/knowledge-base directory initialised
 
 *Summary:* The project `CLAUDE.md` references [`docs/knowledge-base/lessons-learned.md`](lessons-learned.md) and [`docs/knowledge-base/faq.md`](faq.md) as required knowledge-persistence targets, but neither file nor the directory existed.

--- a/docs/manuals/user-manual.md
+++ b/docs/manuals/user-manual.md
@@ -50,6 +50,12 @@ The topic gets its own git worktree at `/workspace/worktrees/<topic-id>` inside 
 4. A thinking spinner appears while the agent is processing.
 5. The agent's response appears in the thread when complete.
 
+### Attach images by pasting from the clipboard
+
+While the message input box is focused, press Ctrl+V (or Cmd+V on Mac) to paste an image directly from your clipboard. The image appears as an attachment chip alongside the text input, identical to a file selected via the file picker. You can paste multiple images in a single paste action; each becomes a separate chip. Plain-text clipboard content is unaffected and pastes into the text field as normal.
+
+Pasted images are uploaded with your message when you submit. Filenames are generated automatically in the form `pasted-image-{timestamp}.{ext}`.
+
 ### Session persistence
 
 Each agent maintains a separate LLM session per topic. The first message in a topic starts a new session. Subsequent messages in the same topic resume the session automatically. If a session expires on the server side, the agent retries the prompt with a fresh session transparently.

--- a/docs/test-plans/paste-image-support.md
+++ b/docs/test-plans/paste-image-support.md
@@ -1,0 +1,278 @@
+# Test Plan: Clipboard Paste Image Support
+
+- **Feature design:** [docs/design/paste-image-support.md](../design/paste-image-support.md)
+- **Date:** 2026-05-05
+- **Components under test:** `frontend/src/views/TopicChat.vue` — `onPaste`, `renamePastedImage`, `mimeToExt`
+- **Test file:** `frontend/src/views/__tests__/TopicChat.paste.test.js`
+
+---
+
+## 1. Scope
+
+### In scope
+
+- The `@paste` event handler (`onPaste`) attached to the chat textarea in `TopicChat.vue`.
+- Helper functions `renamePastedImage` and `mimeToExt` as exercised through the handler.
+- Filename generation: format, timestamp encoding, extension derivation from MIME type.
+- `selectedFiles` ref population: correct number of entries, correct File objects.
+- `preventDefault()` call semantics: called only when at least one image was captured.
+- Defensive handling of null returns from `getAsFile()`.
+- Non-image clipboard content (text-only, PDF) being left untouched.
+- Multiple images pasted in a single event.
+- End-to-end visibility of pasted images in the chip strip and their inclusion in a send.
+
+### Out of scope
+
+- Backend attachment upload and download (tested in `tests/master/test_attachments.py`).
+- Message send with files (tested in `tests/master/test_messages.py`).
+- File picker (`<input type="file">`) path — pre-existing feature.
+- Image thumbnail preview — explicitly deferred per design doc (Non-goals).
+- Drag-and-drop — separate feature.
+- Client-side image size limits — deferred per design doc (Open Questions).
+- Cross-browser clipboard API compatibility (Chrome, Firefox, Safari) — UAT only.
+- Accessibility / aria-live announcement for captured images — flagged as open question in design.
+
+---
+
+## 2. Test Environment Prerequisites
+
+### Automated tests
+
+- Node.js >= 18, npm available.
+- `frontend/` dependencies installed (`npm install`), including `vitest`, `@vue/test-utils`, and `jsdom`.
+- Run with: `cd frontend && npm test -- --run`
+
+### UAT (human)
+
+- A running deployment reachable at the UI URL (local `docker compose up` or testbed).
+- A browser with clipboard access (Chrome, Firefox, or Safari).
+- A screenshot utility or an image on the system clipboard (e.g. Cmd+Shift+4 on macOS, Win+Shift+S on Windows, or `xclip`/`gnome-screenshot` on Linux).
+
+---
+
+## 3. Test Cases
+
+### TC-1: Single image paste — automated
+
+**What:** Paste a single `image/png` clipboard item into the textarea.
+
+**How (automated):** Dispatch a synthetic `ClipboardEvent` containing one item with `kind='file'`, `type='image/png'`, and a non-null `File`. Assert that `selectedFiles` gains exactly one entry (visible as one chip in the DOM).
+
+**Expected:** One file chip appears. The chip filename matches `pasted-image-*.png`.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-1.
+
+---
+
+### TC-2: Multiple images paste — automated
+
+**What:** Paste two image items in a single clipboard event.
+
+**How (automated):** Dispatch a synthetic event with one `image/png` and one `image/jpeg` item. Assert two chips appear.
+
+**Expected:** `selectedFiles` has 2 entries. Both chips are visible.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-2.
+
+---
+
+### TC-3: Text-only paste — no interference — automated
+
+**What:** Paste plain text; the handler must not intercept it.
+
+**How (automated):** Dispatch a synthetic event with one item of `kind='string'`, `type='text/plain'`. Assert no chips appear and `preventDefault` was not called.
+
+**Expected:** `selectedFiles` unchanged (empty). `preventDefault` not called, allowing normal browser text-insert behavior.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-3.
+
+---
+
+### TC-4: Non-image file in clipboard — automated
+
+**What:** Paste an `application/pdf` file; it must not be added to `selectedFiles`.
+
+**How (automated):** Dispatch a synthetic event with `kind='file'`, `type='application/pdf'`. Assert no chips appear and `preventDefault` was not called.
+
+**Expected:** `selectedFiles` unchanged. `preventDefault` not called.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-4.
+
+---
+
+### TC-5: Filename format — no colons, timestamped — automated
+
+**What:** Verify the generated filename is safe for all filesystems and follows the documented pattern.
+
+**How (automated):** Paste one `image/png` item. Read the chip text. Assert the name matches the regex `^pasted-image-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png$` and contains no `:` characters.
+
+**Expected:** Filename like `pasted-image-2026-05-05T08-30-00-000Z.png` — colons replaced with dashes throughout.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-5.
+
+---
+
+### TC-6: `getAsFile()` returns null — gracefully skipped — automated
+
+**What:** Defensive behavior when the clipboard item exists but `getAsFile()` returns null.
+
+**How (automated):** Dispatch a synthetic event with `kind='file'`, `type='image/png'`, but `getAsFile` returning `null`. Assert no crash, no chips, and `preventDefault` not called (no images were captured).
+
+**Expected:** Handler exits cleanly. `selectedFiles` unchanged.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-6.
+
+---
+
+### TC-7: `preventDefault` called on successful image capture — automated
+
+**What:** Confirm `preventDefault` is called exactly once when an image is captured, suppressing the browser's default binary-paste behavior.
+
+**How (automated):** Spy on `event.preventDefault`. Paste one valid image. Assert the spy was called exactly once.
+
+**Expected:** `preventDefault` called once.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-7.
+
+---
+
+### TC-8: MIME-to-extension mapping — automated
+
+**What:** Verify `mimeToExt` produces the correct extension for each known MIME type.
+
+**How (automated):** For each of `image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/bmp`, `image/svg+xml` — paste one item and assert the chip filename ends with the expected extension (`png`, `jpg`, `gif`, `webp`, `bmp`, `svg`).
+
+**Expected:**
+
+| MIME type        | Extension |
+|------------------|-----------|
+| `image/png`      | `png`     |
+| `image/jpeg`     | `jpg`     |
+| `image/gif`      | `gif`     |
+| `image/webp`     | `webp`    |
+| `image/bmp`      | `bmp`     |
+| `image/svg+xml`  | `svg`     |
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-8.
+
+---
+
+### TC-9: Mixed clipboard (image + text string) — automated
+
+**What:** When the clipboard contains both a text item and an image item, the image is captured and the text item is silently ignored.
+
+**How (automated):** Dispatch an event with one `kind='string'` text item and one `kind='file'` image item. Assert exactly one chip appears.
+
+**Expected:** One chip for the image. Text item ignored.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-9.
+
+---
+
+### TC-10: Empty clipboard items list — automated
+
+**What:** Handler is robust when `clipboardData.items` is empty.
+
+**How (automated):** Dispatch a synthetic event with zero items. Assert no crash and no chips.
+
+**Expected:** Handler returns early with no side effects.
+
+**Status:** automated — covered in `TopicChat.paste.test.js` TC-10.
+
+---
+
+### TC-11: Real browser paste — Chrome — needs-human
+
+**What:** Verify the feature works end-to-end in Chrome with the real clipboard API.
+
+**Steps:**
+1. Open the app in Chrome and navigate to any topic chat.
+2. Take a screenshot (Cmd+Shift+4 on macOS / Win+Shift+S on Windows / `gnome-screenshot -c` on Linux) so an image is on the system clipboard.
+3. Click inside the chat textarea.
+4. Press Cmd+V (macOS) or Ctrl+V (Windows/Linux).
+5. Observe the file chip strip above the textarea.
+6. Type any message text and click Send.
+7. Observe the sent message in the chat.
+
+**Expected:** A chip labeled `pasted-image-<timestamp>.png` (or relevant extension) appears in the chip strip after paste. After sending, the message bubble contains the attached image rendered inline.
+
+**Status:** needs-human.
+
+---
+
+### TC-12: Real browser paste — Firefox — needs-human
+
+**What:** Same as TC-11 in Firefox.
+
+**Steps:** Same as TC-11, using Firefox.
+
+**Expected:** Same as TC-11.
+
+**Status:** needs-human.
+
+---
+
+### TC-13: Paste multiple images simultaneously — needs-human
+
+**What:** Verify multiple images can be pasted in one event (e.g. copying multiple items from a file manager or a design tool that places multiple images on the clipboard).
+
+**Steps:**
+1. Find a tool or workflow that places multiple images on the clipboard simultaneously (e.g. copy two files in Finder on macOS, or use a browser extension to copy multiple images).
+2. Paste into the textarea.
+3. Observe the chip strip.
+
+**Expected:** Multiple chips appear, one per pasted image. All are included in the next send.
+
+**Note:** Most OS/browser combinations only surface one image per Ctrl+V even when multiple files are selected. This test is best effort — if only one image lands, that is an OS-level constraint, not a bug.
+
+**Status:** needs-human.
+
+---
+
+### TC-14: Plain text paste is unaffected — needs-human
+
+**What:** Confirm that pasting plain text (e.g. from another document) still inserts text into the textarea normally and does not add any chips.
+
+**Steps:**
+1. Copy any text to clipboard (e.g. Cmd+C on a paragraph of text in a browser).
+2. Click the chat textarea.
+3. Press Cmd+V / Ctrl+V.
+
+**Expected:** Text is inserted into the textarea at the cursor position. No file chip appears. No console errors.
+
+**Status:** needs-human.
+
+---
+
+### TC-15: Textarea disabled during send — needs-human
+
+**What:** Paste should not cause crashes or state corruption when the textarea is disabled (i.e. a send is in flight).
+
+**Steps:**
+1. Paste an image into the textarea (chip appears).
+2. Type a message and begin sending (click Send and immediately try to paste again while the spinner is active, if timing allows).
+
+**Expected:** Either the paste during send is ignored or it is buffered; no crash; no duplicate chips in a broken state.
+
+**Note:** This is a timing-dependent test; best-effort manual verification.
+
+**Status:** needs-human.
+
+---
+
+## 4. Non-Functional Requirements
+
+| Requirement | Verification method |
+|-------------|---------------------|
+| No synchronous blocking: handler completes in < 5 ms for a typical screenshot | Browser DevTools Performance panel (needs-human) |
+| Filename safe on Windows (no `:` or `*` characters) | Covered by TC-5 (automated regex assertion) |
+| No memory leaks from repeated paste operations | Browser DevTools Memory snapshot after 20 paste cycles (needs-human, low priority) |
+
+---
+
+## 5. Pass / Fail Criteria
+
+- All 10 automated test cases must be green (`npm test -- --run` exits 0) before the PR is merged.
+- TC-11 and TC-12 (real browser, single image) are blocking UAT sign-off items.
+- TC-13, TC-14, TC-15 are non-blocking but should be attempted and reported.
+- No regressions in pre-existing test suites (`tests/master/test_attachments.py`, `tests/master/test_messages.py`).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "highlight.js": "^11.11.1",
@@ -15,7 +16,10 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.0",
-    "vite": "^5.0.0"
+    "@vitejs/plugin-vue": "^5.2.4",
+    "@vue/test-utils": "^2.4.10",
+    "jsdom": "^29.1.1",
+    "vite": "^5.0.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -112,6 +112,7 @@
           rows="3"
           :disabled="sending"
           @keydown.enter.exact.prevent="sendMessage"
+          @paste="onPaste"
         />
         <button type="submit" :disabled="sending || !text.trim()">
           {{ sending ? 'Sending…' : 'Send' }}
@@ -203,6 +204,46 @@ function onFilesSelected(evt) {
 
 function removeFile(index) {
   selectedFiles.value = selectedFiles.value.filter((_, i) => i !== index)
+}
+
+function mimeToExt(mime) {
+  switch (mime) {
+    case 'image/png':     return 'png'
+    case 'image/jpeg':    return 'jpg'
+    case 'image/gif':     return 'gif'
+    case 'image/webp':    return 'webp'
+    case 'image/bmp':     return 'bmp'
+    case 'image/svg+xml': return 'svg'
+    default: {
+      const m = /^image\/([a-z0-9.+-]+)$/i.exec(mime)
+      return m ? m[1].split('+')[0] : 'png'
+    }
+  }
+}
+
+function renamePastedImage(file) {
+  const ext = mimeToExt(file.type) || 'png'
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const name = `pasted-image-${ts}.${ext}`
+  return new File([file], name, { type: file.type, lastModified: file.lastModified })
+}
+
+function onPaste(evt) {
+  const items = evt.clipboardData?.items
+  if (!items || !items.length) return
+
+  const pastedImages = []
+  for (const item of items) {
+    if (item.kind !== 'file') continue
+    if (!item.type || !item.type.startsWith('image/')) continue
+    const file = item.getAsFile()
+    if (!file) continue
+    pastedImages.push(renamePastedImage(file))
+  }
+
+  if (pastedImages.length === 0) return
+  evt.preventDefault()
+  selectedFiles.value = [...selectedFiles.value, ...pastedImages]
 }
 
 function formatSize(bytes) {

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -215,8 +215,10 @@ function mimeToExt(mime) {
     case 'image/bmp':     return 'bmp'
     case 'image/svg+xml': return 'svg'
     default: {
-      const m = /^image\/([a-z0-9.+-]+)$/i.exec(mime)
-      return m ? m[1].split('+')[0] : 'png'
+      const m = /^image\/([a-z0-9+-]+)$/i.exec(mime)
+      if (!m) return 'png'
+      const ext = m[1].split('+')[0].replace(/[^a-z0-9]/gi, '')
+      return ext || 'png'
     }
   }
 }
@@ -229,6 +231,7 @@ function renamePastedImage(file) {
 }
 
 function onPaste(evt) {
+  if (sending.value) return
   const items = evt.clipboardData?.items
   if (!items || !items.length) return
 

--- a/frontend/src/views/__tests__/TopicChat.paste.test.js
+++ b/frontend/src/views/__tests__/TopicChat.paste.test.js
@@ -233,11 +233,13 @@ describe('TopicChat paste handler', () => {
 
     // kind=file, type=image/png, but getAsFile returns null
     const event = makePasteEvent([{ kind: 'file', type: 'image/png', file: null }])
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
 
     expect(() => textarea.dispatchEvent(event)).not.toThrow()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.findAll('.file-chip')).toHaveLength(0)
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
   })
 
   // -------------------------------------------------------------------------
@@ -284,6 +286,38 @@ describe('TopicChat paste handler', () => {
       const lastName = chips[chips.length - 1].text().replace('×', '').trim()
       expect(lastName).toMatch(new RegExp(`\\.${ext}$`))
     }
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-8b: mimeToExt fallback — unknown and vendor MIME types
+  // -------------------------------------------------------------------------
+  it('maps image/tiff to tiff and vendor MIME types with dots to png fallback', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    // image/tiff — matches regex, produces 'tiff'
+    const tiffFile = new File([new Uint8Array([0])], 'img.tiff', { type: 'image/tiff' })
+    const tiffEvent = makePasteEvent([{ kind: 'file', type: 'image/tiff', file: tiffFile }])
+    textarea.dispatchEvent(tiffEvent)
+    await wrapper.vm.$nextTick()
+    let chips = wrapper.findAll('.file-chip')
+    expect(chips[chips.length - 1].text().replace('×', '').trim()).toMatch(/\.tiff$/)
+
+    // image/vnd.microsoft.icon — dot in subtype, regex rejects it, falls back to 'png'
+    const icoFile = new File([new Uint8Array([0])], 'img.ico', { type: 'image/vnd.microsoft.icon' })
+    const icoEvent = makePasteEvent([{ kind: 'file', type: 'image/vnd.microsoft.icon', file: icoFile }])
+    textarea.dispatchEvent(icoEvent)
+    await wrapper.vm.$nextTick()
+    chips = wrapper.findAll('.file-chip')
+    expect(chips[chips.length - 1].text().replace('×', '').trim()).toMatch(/\.png$/)
+
+    // image/ with empty subtype — regex rejects it, falls back to 'png'
+    const emptyFile = new File([new Uint8Array([0])], 'img', { type: 'image/' })
+    const emptyEvent = makePasteEvent([{ kind: 'file', type: 'image/', file: emptyFile }])
+    textarea.dispatchEvent(emptyEvent)
+    await wrapper.vm.$nextTick()
+    chips = wrapper.findAll('.file-chip')
+    expect(chips[chips.length - 1].text().replace('×', '').trim()).toMatch(/\.png$/)
   })
 
   // -------------------------------------------------------------------------

--- a/frontend/src/views/__tests__/TopicChat.paste.test.js
+++ b/frontend/src/views/__tests__/TopicChat.paste.test.js
@@ -1,0 +1,322 @@
+/**
+ * Unit tests for the clipboard paste image handler in TopicChat.vue.
+ *
+ * Strategy: mount TopicChat with the minimum set of stubs/mocks needed to
+ * keep vue-router and the network layer quiet, then dispatch synthetic
+ * ClipboardEvents on the textarea and assert on the component's internal
+ * state (selectedFiles) and on whether preventDefault was invoked.
+ *
+ * Because the paste logic (onPaste / renamePastedImage / mimeToExt) lives
+ * entirely inside <script setup> and is not exported, we drive it through
+ * the real DOM event path that Vue wires up via @paste="onPaste".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import TopicChat from '../TopicChat.vue'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal router that satisfies useRoute() inside TopicChat.
+ * The component reads route.params.wsId and route.params.topicId on setup.
+ */
+function makeRouter() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/workspaces/:wsId/topics/:topicId',
+        component: TopicChat,
+      },
+    ],
+  })
+  return router
+}
+
+/**
+ * Construct a synthetic ClipboardEvent whose clipboardData.items list is
+ * populated from the provided array of item descriptors.
+ *
+ * Each descriptor: { kind, type, file }
+ *   - kind: 'file' | 'string'
+ *   - type: MIME string
+ *   - file: File | null  (returned by getAsFile(); ignored when kind !== 'file')
+ */
+function makePasteEvent(itemDescriptors) {
+  const items = itemDescriptors.map(({ kind, type, file }) => ({
+    kind,
+    type,
+    getAsFile: () => file ?? null,
+  }))
+
+  // DataTransferItemList-like: iterable + length
+  const itemList = Object.assign(items, { length: items.length })
+
+  const clipboardData = { items: itemList }
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: clipboardData })
+  return event
+}
+
+/**
+ * Mount TopicChat at the route /workspaces/ws1/topics/t1 and wait for the
+ * router to be ready. Stubs MarkdownMessage to avoid needing the full
+ * render chain.  Mocks fetch to return empty data so onMounted doesn't throw.
+ */
+async function mountComponent() {
+  const router = makeRouter()
+  await router.push('/workspaces/ws1/topics/t1')
+  await router.isReady()
+
+  // Suppress network calls made in onMounted (load + connectWs).
+  // The component fetches topic (returns an object) and then messages (returns an array).
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ subject: 'Test', archived_at: null }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+    .mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    })
+  vi.stubGlobal('fetch', fetchMock)
+
+  // WebSocket mock must be a class (constructor) because the code does `new WebSocket(...)`.
+  class WsMock {
+    constructor() {
+      this.onmessage = null
+      this.onclose = null
+    }
+    close() {}
+  }
+  vi.stubGlobal('WebSocket', WsMock)
+
+  const wrapper = mount(TopicChat, {
+    global: {
+      plugins: [router],
+      stubs: { MarkdownMessage: true },
+    },
+  })
+
+  // Wait for onMounted async load to settle
+  await vi.waitFor(() => wrapper.find('textarea').exists(), { timeout: 1000 })
+
+  return wrapper
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('TopicChat paste handler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-1: Single image paste
+  // -------------------------------------------------------------------------
+  it('adds a single pasted image to selectedFiles with a timestamped filename', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const fakeFile = new File([new Uint8Array([1, 2, 3])], 'image.png', { type: 'image/png' })
+    const event = makePasteEvent([{ kind: 'file', type: 'image/png', file: fakeFile }])
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    // Find the file-chips rendered in the DOM — each chip displays the filename
+    const chips = wrapper.findAll('.file-chip')
+    expect(chips).toHaveLength(1)
+
+    const chipText = chips[0].text()
+    // Filename must start with 'pasted-image-' and end with '.png'
+    expect(chipText).toMatch(/pasted-image-.+\.png/)
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-2: Multiple images in one paste event
+  // -------------------------------------------------------------------------
+  it('adds all images when multiple image items are in the clipboard', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const file1 = new File([new Uint8Array([1])], 'a.png', { type: 'image/png' })
+    const file2 = new File([new Uint8Array([2])], 'b.jpeg', { type: 'image/jpeg' })
+
+    const event = makePasteEvent([
+      { kind: 'file', type: 'image/png', file: file1 },
+      { kind: 'file', type: 'image/jpeg', file: file2 },
+    ])
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    const chips = wrapper.findAll('.file-chip')
+    expect(chips).toHaveLength(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-3: Text-only paste — no interference
+  // -------------------------------------------------------------------------
+  it('does not add files and does not call preventDefault for a text-only paste', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const event = makePasteEvent([{ kind: 'string', type: 'text/plain', file: null }])
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('.file-chip')).toHaveLength(0)
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-4: Non-image file in clipboard (e.g. PDF)
+  // -------------------------------------------------------------------------
+  it('does not add a non-image file kind to selectedFiles', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const pdfFile = new File([new Uint8Array([0])], 'doc.pdf', { type: 'application/pdf' })
+    const event = makePasteEvent([{ kind: 'file', type: 'application/pdf', file: pdfFile }])
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('.file-chip')).toHaveLength(0)
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-5: Filename format — no colons, matches pattern
+  // -------------------------------------------------------------------------
+  it('generates a filename without colons that matches pasted-image-*.{ext}', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const fakeFile = new File([new Uint8Array([7])], 'screenshot.png', { type: 'image/png' })
+    const event = makePasteEvent([{ kind: 'file', type: 'image/png', file: fakeFile }])
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    const chips = wrapper.findAll('.file-chip')
+    expect(chips).toHaveLength(1)
+
+    const name = chips[0].text().replace('×', '').trim()
+    expect(name).not.toContain(':')
+    // Pattern: pasted-image-<ISO-timestamp-with-dashes>.<ext>
+    expect(name).toMatch(/^pasted-image-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png$/)
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-6: getAsFile() returns null — gracefully skipped, no crash
+  // -------------------------------------------------------------------------
+  it('skips an image item where getAsFile() returns null without crashing', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    // kind=file, type=image/png, but getAsFile returns null
+    const event = makePasteEvent([{ kind: 'file', type: 'image/png', file: null }])
+
+    expect(() => textarea.dispatchEvent(event)).not.toThrow()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('.file-chip')).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-7: preventDefault is called when at least one image is captured
+  // -------------------------------------------------------------------------
+  it('calls preventDefault when an image item is successfully captured', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const fakeFile = new File([new Uint8Array([1])], 'img.png', { type: 'image/png' })
+    const event = makePasteEvent([{ kind: 'file', type: 'image/png', file: fakeFile }])
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    expect(preventDefaultSpy).toHaveBeenCalledOnce()
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-8: mimeToExt mapping — various MIME types produce correct extensions
+  // -------------------------------------------------------------------------
+  it('assigns the correct file extension for known image MIME types', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const cases = [
+      { type: 'image/png', ext: 'png' },
+      { type: 'image/jpeg', ext: 'jpg' },
+      { type: 'image/gif', ext: 'gif' },
+      { type: 'image/webp', ext: 'webp' },
+      { type: 'image/bmp', ext: 'bmp' },
+      { type: 'image/svg+xml', ext: 'svg' },
+    ]
+
+    for (const { type, ext } of cases) {
+      const fakeFile = new File([new Uint8Array([0])], `img.${ext}`, { type })
+      const event = makePasteEvent([{ kind: 'file', type, file: fakeFile }])
+
+      textarea.dispatchEvent(event)
+      await wrapper.vm.$nextTick()
+
+      const chips = wrapper.findAll('.file-chip')
+      const lastName = chips[chips.length - 1].text().replace('×', '').trim()
+      expect(lastName).toMatch(new RegExp(`\\.${ext}$`))
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-9: Mixed clipboard — image + text — image captured, text not blocked
+  // -------------------------------------------------------------------------
+  it('captures images and ignores text items in a mixed clipboard event', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const fakeFile = new File([new Uint8Array([1])], 'screenshot.png', { type: 'image/png' })
+    const event = makePasteEvent([
+      { kind: 'string', type: 'text/plain', file: null },
+      { kind: 'file', type: 'image/png', file: fakeFile },
+    ])
+
+    textarea.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    // One image was captured
+    expect(wrapper.findAll('.file-chip')).toHaveLength(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // TC-10: Empty clipboard items list — no crash
+  // -------------------------------------------------------------------------
+  it('handles an event with no clipboard items without crashing', async () => {
+    const wrapper = await mountComponent()
+    const textarea = wrapper.find('textarea').element
+
+    const event = makePasteEvent([])
+    expect(() => textarea.dispatchEvent(event)).not.toThrow()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('.file-chip')).toHaveLength(0)
+  })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,4 +13,8 @@ export default defineConfig({
       '/ws': { target: 'ws://localhost:8080', ws: true },
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- Adds `@paste` handler to the chat textarea so images copied to clipboard (e.g. screenshots) are captured and queued as attachments — no file picker required
- Supports pasting multiple images in a single paste event; plain-text paste is unaffected
- Reuses the existing multipart upload pipeline end-to-end; no backend or API changes needed
- Adds Vitest test infrastructure to the frontend with 10 automated unit tests (all green)

## Test plan
- [ ] Run `cd frontend && npm test -- --run` — all 10 paste unit tests pass
- [ ] In a browser: copy a screenshot to clipboard, open a topic chat, press Ctrl+V in the textarea — a filename chip should appear
- [ ] Send the message — the image should render inline in the chat bubble
- [ ] Paste plain text — no chip appears, text lands in the textarea normally
- [ ] Copy two images and paste — two chips appear, both upload and render

Closes #126

🤖 Generated with repository automation