### PR TITLE
feat(notifications): add Discord and Telegram agent-reply notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,20 @@ CD_IMAGE=ghcr.io/<org>/codex-slack-master
 
 # Host path to the master project directory (default: current directory).
 # MASTER_PROJECT_DIR=.
+
+# ---- Master: agent-reply notifications ----------------------------------
+
+# Externally reachable base URL of the web UI. Used to build deep links in
+# notifications. If unset, notifications are sent without a clickable URL.
+# MASTER_PUBLIC_URL=https://codex.example.com
+
+# Discord incoming-webhook URL. Leave unset to disable Discord notifications.
+# MASTER_NOTIFY_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Telegram bot token + chat/channel ID. Both must be set to enable Telegram.
+# MASTER_NOTIFY_TELEGRAM_BOT_TOKEN=
+# MASTER_NOTIFY_TELEGRAM_CHAT_ID=
+
+# Max characters of the agent reply shown as a preview (default: 200).
+# Set to 0 to omit the preview entirely.
+# MASTER_NOTIFY_PREVIEW_CHARS=200

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
 
 RUN useradd -m -u 1000 -s /bin/bash appuser \
-    && mkdir -p /workspace/home /home/appuser/.claude \
-    && chown -R appuser:appuser /workspace /home/appuser/.claude
+    && mkdir -p /workspace/home /home/appuser/.claude /opt/codex-slack/data/master \
+    && chown -R appuser:appuser /workspace /home/appuser/.claude /opt/codex-slack
 USER appuser
 WORKDIR /opt/codex-slack
-
-RUN mkdir -p data/master data/cd
 
 COPY --chown=appuser:appuser requirements.txt ./requirements.txt
 RUN python -m pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt

--- a/docs/decisions/0011-agent-message-notification.md
+++ b/docs/decisions/0011-agent-message-notification.md
@@ -1,0 +1,222 @@
+---
+title: "ADR-0011: Outbound notifications when agents reply"
+status: proposed
+date: 2026-05-05
+decision-makers: [maintainers]
+consulted: [architect, engineer]
+informed: [users]
+---
+
+## Context and Problem Statement
+
+Agents can take minutes to respond. The web UI is the canonical interface (per
+ADR-0006), but users do not keep a browser tab open while they wait. They
+have asked for a push notification on a chat platform of their choice (Discord,
+Telegram, WhatsApp) that links back to the topic in the web UI. See GitHub
+issue [#118](https://github.com/pandazxx/codex-slack/issues/118).
+
+This is **outbound-only**: the system pushes a "your agent replied" message to
+a chat channel; users still issue commands and read full replies in the web UI.
+It is not a return to the v2 model where chat platforms were the interface.
+
+## Decision Drivers
+
+- **Stay aligned with ADR-0006.** No inbound chat command handling. No
+  platform-specific message splitting, formatting, or rate-limit gymnastics in
+  the core. The notification payload is a fixed-shape "you have a reply" hint
+  with a deep link.
+- **Reuse existing patterns.** The CD daemon already implements webhook fan-out
+  in `src/cd/notify.py` (Slack + Discord, threaded, swallow-and-log on error,
+  dry-run aware). The agent-reply path should reuse that shape rather than
+  invent a new one.
+- **Single-user, self-hosted threat model.** Same posture as ADR-0009/0010 —
+  webhook URLs and bot tokens are stored alongside other operator settings.
+- **Minimum surface for v1.** Avoid a large new abstraction; ship one channel
+  pattern that demonstrably works and extend it when there is concrete demand.
+- **Don't block the agent reply path.** Notification delivery must not
+  introduce latency or failure modes for the existing MQTT → DB → WebSocket
+  fan-out.
+
+## Considered Options
+
+### Channel selection (which platforms ship in v1)
+
+1. **Discord webhook only.** Reuse the exact `_discord_payload` shape from CD.
+2. **Discord webhook + Telegram Bot API.** Two channels, both simple HTTPS
+   POSTs.
+3. **Discord + Telegram + WhatsApp Business API.**
+4. **Generic webhook only — let users plug in any service via a single
+   user-supplied URL and JSON template.**
+
+### Configuration storage
+
+A. **Global env vars only** (`MASTER_NOTIFY_*`), read once at process start.
+B. **Per-workspace rows in the existing `config` table** (ADR-0009/0010), with
+   global env vars as fallback.
+C. **Both: global env vars are the default; workspace `config` rows override
+   per-workspace via the merge already implemented in `runtime_config`.**
+
+### Public-URL discovery
+
+I. **New `MASTER_PUBLIC_URL` env var.** Operator sets the externally reachable
+   base URL once; master uses it verbatim to build deep links.
+II. **Reuse the existing `MASTER_URL` setting** (currently
+    `http://master:8080`, an in-cluster address).
+III. **Infer from the inbound HTTP `Host`/`X-Forwarded-*` headers** seen during
+     normal API traffic.
+
+### When to notify
+
+P. **On every agent `response` MQTT event** (final reply per topic).
+Q. **On every agent event including `status` transitions** (running → idle,
+   etc.).
+R. **Only on final reply, and only when no UI client is currently watching the
+   topic.**
+
+## Decision Outcome
+
+**Chosen:** **2 + C + I + P.**
+
+1. **Channels — Option 2 (Discord + Telegram).**
+   - **Discord** ships first; the payload shape matches `src/cd/notify.py`
+     (`{"content": "..."}`) so the existing helper can be lifted with minimal
+     change. Operators who already set up CD webhooks can reuse the same URL
+     shape.
+   - **Telegram** ships in the same slice. The Bot API is a single
+     `POST https://api.telegram.org/bot<TOKEN>/sendMessage` with JSON body
+     `{"chat_id": "...", "text": "..."}`. This is the cheapest second channel
+     to add and demonstrates the abstraction works for non-webhook providers.
+   - **WhatsApp is out of scope for v1.** The Cloud / Business API requires a
+     verified Meta business account, a registered phone number, template
+     pre-approval for proactive messages outside a 24-hour user-initiated
+     window, and review of message templates. This is materially more work
+     than the rest of the feature combined, and the user base for a self-hosted
+     dev tool is unlikely to maintain a Business API account. Documented as a
+     future option; not built.
+   - **Generic webhook is deferred.** It is a tempting catch-all but in
+     practice forces every operator to write their own JSON template, which is
+     more friction than picking a named provider.
+
+2. **Configuration — Option C (env-default + workspace override).** The
+   plumbing for this already exists:
+   - Global defaults read from env vars by `load_master_settings()` (e.g.
+     `MASTER_NOTIFY_DISCORD_WEBHOOK_URL`, `MASTER_NOTIFY_TELEGRAM_BOT_TOKEN`,
+     `MASTER_NOTIFY_TELEGRAM_CHAT_ID`).
+   - Per-workspace overrides via the existing `config` table (ADR-0009 §4) and
+     workspace UI surface (ADR-0010). The same keys can be set per-workspace
+     and they override the global default at notification time.
+   - At each agent reply, master resolves the effective config for that
+     workspace by reading `config` rows + env defaults via the merge already
+     implemented for `load_agent_env`. Workspace UI heuristic masking from
+     ADR-0010 already covers `*TOKEN*`, `*WEBHOOK*` will be added to the
+     substring list.
+   - Empty/None at every scope means "do not notify on this channel".
+
+3. **Public URL — Option I (`MASTER_PUBLIC_URL`).** The existing
+   `master_url` setting (`http://master:8080`) is the in-cluster address used
+   by agent containers to reach the API; it is not safe to use in a chat
+   message. A separate `MASTER_PUBLIC_URL` env var (no default; if unset,
+   notifications are sent without a clickable link, only the topic identifier
+   in plain text) keeps the two concerns separate. Header inference is
+   rejected: it is non-deterministic, depends on every request setting the
+   right headers, and the notification path runs from an MQTT callback that
+   has no inbound request context.
+
+4. **When to notify — Option P (every final reply).** The agent publishes
+   exactly one `response` per dispatch (see `src/agent/mqtt_loop.py:231` —
+   single `client.publish` to the response topic per turn). Status events
+   are not user-meaningful for notification purposes. "Only when no client is
+   watching" (Option R) is rejected for v1: it requires presence tracking on
+   the WebSocket hub and creates a confusing "sometimes silent" UX. Users who
+   do not want notifications can leave the channel unconfigured.
+
+### Alignment with ADR-0006
+
+ADR-0006 dropped Slack/Discord as **interfaces**. It explicitly leaves room
+for chat integration as "an external adapter (a separate service that bridges
+Slack/Discord events to `POST /api/workspaces/{id}/topics/{tid}/messages`)".
+
+This feature is **not** that adapter and does not contradict ADR-0006:
+
+- It is unidirectional (master → chat). No chat events come back into master.
+- There is no slash-command parsing, no thread tracking, no platform-specific
+  formatting beyond a one-line text template + URL.
+- The web UI remains the only way to read full replies and send new messages.
+- If a future adapter wants to consume agent replies and post them as proper
+  threaded messages, it can do so via the existing WebSocket / HTTP API; the
+  notification webhook is independent.
+
+The notification is best understood as a **pager-style heads-up**: "your agent
+replied — open the topic". It is intentionally minimal so it does not become a
+de facto chat UI.
+
+### Consequences
+
+- **Good**
+  - Users get out-of-band notifications without keeping a tab open.
+  - Reuses the existing `cd/notify.py` pattern and the ADR-0009/0010 config
+    machinery — minimal new code, no new tables, no new endpoints.
+  - Per-workspace override means a user can route different projects to
+    different channels (e.g. `#work` vs `#personal`).
+  - Notification failures cannot break the agent reply path (delivery is
+    fire-and-forget on a daemon thread with bounded timeout, errors logged
+    and swallowed — same shape as `cd/notify.py`).
+- **Bad / accepted tradeoffs**
+  - WhatsApp users are not served in v1.
+  - `MASTER_PUBLIC_URL` is a new operator-facing knob. If unset, the
+    notification still goes out but contains only the topic id — operators
+    who deploy behind a reverse proxy must set it explicitly.
+  - Notifications fire even when the user is actively reading the topic in
+    the browser. We accept the duplicate-buzz cost in v1 to avoid presence
+    tracking; can be revisited.
+  - Webhook URLs and bot tokens stored in plaintext (per ADR-0009 §E).
+
+### Confirmation
+
+- Unit tests in `tests/master/` for the channel adapters (Discord, Telegram)
+  and the config-resolution logic (env default → workspace override → none).
+- UAT case: configure a Discord webhook globally, send a message in any
+  workspace, observe a Discord message arriving with the topic deep link.
+  Marked `needs-human` since it requires a real Discord channel.
+- UAT case: configure a Telegram bot token + chat id at workspace scope, send
+  a message, observe Telegram delivery. `needs-human`.
+- UAT case: leave both channels unset, verify no notifications are sent and
+  no errors logged.
+- UAT case: set `MASTER_PUBLIC_URL` to an obviously-wrong URL, verify the
+  notification still arrives with that URL embedded (master does not validate
+  the URL, only uses it).
+
+## Pros and Cons of the Options
+
+### Channels
+
+| Option | Pro | Con |
+|---|---|---|
+| 1 — Discord only | Cheapest; one payload shape | Single-platform; misses Telegram users with no path forward |
+| 2 — Discord + Telegram (chosen) | Two-channel design forces a small, real abstraction; covers both webhook and bot-API styles | Slightly more code than Option 1 |
+| 3 — Discord + Telegram + WhatsApp | Maximum coverage | WhatsApp Business API onboarding dwarfs the rest of the feature |
+| 4 — Generic webhook | Maximum flexibility | Pushes JSON-template authoring onto every operator; poor first-time UX |
+
+### Configuration storage
+
+| Option | Pro | Con |
+|---|---|---|
+| A — Env only | Simplest; matches `cd/notify.py` exactly | No per-workspace routing; one channel for the whole instance |
+| B — Workspace `config` only | Consistent with ADR-0009 hierarchy | Forces every operator to set values per workspace even when one global set would do |
+| C — Env default + workspace override (chosen) | Reuses ADR-0009/0010 merge; sensible default with per-project escape hatch | Two places to look when debugging; mitigated by the merged-view UI ADR-0010 already provides |
+
+### Public-URL discovery
+
+| Option | Pro | Con |
+|---|---|---|
+| I — `MASTER_PUBLIC_URL` (chosen) | Explicit; works from non-HTTP contexts (MQTT callback) | One more env var to set behind a proxy |
+| II — Reuse `MASTER_URL` | No new config | Current value is in-cluster; would emit unreachable URLs |
+| III — Infer from headers | Zero config | Non-deterministic; unavailable from MQTT callback path |
+
+### When to notify
+
+| Option | Pro | Con |
+|---|---|---|
+| P — Every final reply (chosen) | Simple; matches user mental model ("agent finished, ping me") | Buzzes even when the user is watching |
+| Q — All status events | More info | Notification spam; status transitions are not user-meaningful |
+| R — Only when nobody is watching | Quietest | Requires WebSocket presence tracking; opaque "sometimes silent" UX |

--- a/docs/design/agent-message-notification.md
+++ b/docs/design/agent-message-notification.md
@@ -1,0 +1,426 @@
+# Design: Agent Message Notification
+
+**Status:** draft
+**Author:** architect
+**Date:** 2026-05-05
+**Related ADRs:** [ADR-0011](../decisions/0011-agent-message-notification.md), [ADR-0006](../decisions/0006-drop-slack-discord-integration.md), [ADR-0009](../decisions/0009-runtime-configuration-and-staff-system.md), [ADR-0010](../decisions/0010-workspace-env-var-overrides.md)
+**Issue:** [#118](https://github.com/pandazxx/codex-slack/issues/118)
+
+## Problem Statement
+
+Agent replies can take minutes. The web UI is the canonical interface but
+users do not keep tabs open while waiting. We need an out-of-band ping —
+"your agent replied" — that lands on a chat platform the user already
+watches and links back to the topic in the web UI.
+
+This is **outbound notification only**. It is not a return to chat-as-UI
+(see ADR-0006); it is a pager-style heads-up.
+
+## Goals
+
+- Deliver a one-line notification to **Discord** (webhook) and **Telegram**
+  (Bot API) when an agent emits a final reply on a topic.
+- Notification body contains: workspace name, topic subject, optional first
+  N characters of the reply as preview, and a deep link to the topic in the
+  web UI.
+- Configuration uses the **existing config layer** (ADR-0009 §4): global env
+  vars as defaults, per-workspace `config` rows as overrides.
+- Delivery is **fire-and-forget**: it must not delay or fail the existing
+  MQTT → SQLite → WebSocket reply path.
+- All errors are logged and swallowed; per-channel failures do not affect
+  delivery on the other channel.
+
+## Non-Goals
+
+- **WhatsApp.** Documented as a future extension (ADR-0011 — Business API
+  onboarding cost dwarfs the rest of the feature).
+- **Slack.** Out of scope to keep alignment with ADR-0006 unambiguous; the
+  same pattern would extend to Slack trivially if added later.
+- **Inbound chat events** (commands, replies posted in Discord/Telegram and
+  routed back to master). That is the "external adapter" path called out in
+  ADR-0006 and is a separate piece of work.
+- **Presence-aware notifications** ("only when nobody is watching the
+  topic"). Deferred — would require WebSocket presence tracking.
+- **Per-user preferences.** Notifications are per-workspace, not per-user;
+  the deployment is single-user (ADR-0009 §E threat model).
+- **Notification on agent `status` transitions** (running/idle). Only on
+  final agent `response`.
+- **Streaming chunks.** The agent publishes one `response` per dispatch
+  (`src/agent/mqtt_loop.py:231`); there are no chunks to coalesce.
+- **Retry on delivery failure.** Single attempt with timeout; matches
+  `cd/notify.py` posture.
+
+## Proposed Design
+
+### Where the hook fires
+
+Master subscribes to MQTT topic
+`codex-slack/workspace/+/topic/+/response` (`src/master/mqtt_client.py:16`).
+Each message lands in `_on_message()` (`src/master/mqtt_client.py:116`).
+
+Today the response branch (msg_type == `"response"`) does three things in
+order:
+
+1. Build the WebSocket message dict.
+2. `_save_agent_response(db_path, topic_id, payload)` — INSERT into
+   `messages`, UPDATE `sessions.llm_session_id`.
+3. `_record_agent_response(db_path, topic_id)` — UPDATE
+   `workspaces.last_responded_at`.
+4. `hub.broadcast_threadsafe(topic_id, message, loop)` — push to WebSocket
+   subscribers.
+
+We add **step 3a** between `_record_agent_response` and the broadcast: a
+single call into a new module `src/master/notify.py` that resolves the
+effective notification config for the workspace and dispatches to the
+configured channels on background threads.
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant MQTT
+    participant Master as Master.mqtt_client._on_message
+    participant DB as SQLite
+    participant N as Master.notify.notify_reply
+    participant WS as WebSocket Hub
+    participant Discord
+    participant Telegram
+
+    Agent->>MQTT: publish .../response
+    MQTT->>Master: _on_message
+    Master->>DB: _save_agent_response
+    Master->>DB: _record_agent_response
+    Master->>N: notify_reply(workspace_id, topic_id, payload)
+    par Fire-and-forget
+        N-->>Discord: POST webhook (daemon thread)
+        N-->>Telegram: POST sendMessage (daemon thread)
+    and
+        Master->>WS: broadcast_threadsafe
+    end
+```
+
+The notification dispatch must not block broadcast: `notify_reply` returns
+immediately after starting the daemon threads; the threads themselves use
+the same bounded `urlopen(timeout=10)` + 15s join shape as `cd/notify.py`.
+
+### Channels
+
+#### Discord
+
+Webhook delivery, identical shape to `src/cd/notify.py`:
+
+```http
+POST {webhook_url}
+Content-Type: application/json
+
+{"content": "Agent replied in {workspace_name} / {topic_subject}\n{preview}\n{topic_url}"}
+```
+
+#### Telegram
+
+Bot API delivery:
+
+```http
+POST https://api.telegram.org/bot{bot_token}/sendMessage
+Content-Type: application/json
+
+{
+  "chat_id": "{chat_id}",
+  "text": "Agent replied in {workspace_name} / {topic_subject}\n{preview}\n{topic_url}",
+  "disable_web_page_preview": true
+}
+```
+
+`chat_id` may be a numeric user/group id or a `@channelusername`. Master
+does not interpret it — it is forwarded to the API verbatim.
+
+#### Common adapter shape
+
+Both channels go through `post_webhook(url, payload)` (lifted from
+`src/cd/notify.py`). Each channel adapter is a small function that builds
+its provider-specific payload from a common `NotificationContent`:
+
+```python
+@dataclass(frozen=True)
+class NotificationContent:
+    workspace_name: str
+    topic_subject: str
+    topic_url: str | None     # None if MASTER_PUBLIC_URL unset
+    preview: str              # already trimmed, may be ""
+```
+
+```python
+def _discord_payload(c: NotificationContent) -> dict: ...
+def _telegram_payload(c: NotificationContent, chat_id: str) -> dict: ...
+```
+
+Adding a third channel later means: one new payload builder + one new
+config-resolution branch. No new tables, no new endpoints.
+
+### Configuration schema
+
+Two layers, merged at notification time per the rules in ADR-0009 §4 and
+the `runtime_config.load_agent_env` pattern:
+
+#### Layer 1 — global env (read once at master startup)
+
+| Env var | Type | Default | Notes |
+|---|---|---|---|
+| `MASTER_PUBLIC_URL` | string | unset | Externally reachable base URL of the web UI, e.g. `https://codex.example.com`. If unset, notifications omit the URL. **No default**: in-cluster `MASTER_URL` is wrong here. |
+| `MASTER_NOTIFY_DISCORD_WEBHOOK_URL` | string | unset | Discord channel webhook URL. Empty/unset disables Discord globally. |
+| `MASTER_NOTIFY_TELEGRAM_BOT_TOKEN` | string | unset | Telegram bot token. Required together with `_CHAT_ID`. |
+| `MASTER_NOTIFY_TELEGRAM_CHAT_ID` | string | unset | Telegram chat / channel id. |
+| `MASTER_NOTIFY_PREVIEW_CHARS` | int | `200` | Max characters of agent reply included as preview. `0` disables preview. |
+
+These are added to `MasterSettings` in `src/master/config.py` alongside the
+existing entries.
+
+#### Layer 2 — workspace `config` table (per ADR-0009 §4 / ADR-0010)
+
+The same keys (without the `MASTER_` prefix; matching how
+`runtime_config.load_agent_env` strips/treats them — confirm in
+implementation) can be set per-workspace:
+
+| Key in `config` table | Effect |
+|---|---|
+| `NOTIFY_DISCORD_WEBHOOK_URL` | Override or set Discord destination for this workspace. |
+| `NOTIFY_TELEGRAM_BOT_TOKEN` | Workspace-specific bot token. |
+| `NOTIFY_TELEGRAM_CHAT_ID` | Workspace-specific chat id. |
+| `NOTIFY_PREVIEW_CHARS` | Workspace-specific preview length. |
+| `NOTIFY_DISABLED` | If truthy, skip all notifications for this workspace regardless of global config. Lets a user mute one workspace without unsetting the global webhook. |
+
+Resolution at notification time:
+
+```python
+effective = {**global_env, **workspace_config_rows}  # workspace wins, per ADR-0009
+```
+
+For Telegram, both `BOT_TOKEN` and `CHAT_ID` must be present in the
+effective set, otherwise Telegram is skipped (logged at INFO).
+
+The workspace-config UI (ADR-0010 `WorkspaceEnvVarsPanel.vue`) already
+exposes a generic key-value editor and heuristic-masks `*TOKEN*`. We extend
+its `SECRET_KEY_SUBSTRINGS` constant with `WEBHOOK` so that
+`NOTIFY_DISCORD_WEBHOOK_URL` is masked by default.
+
+### Integration point — exact call site
+
+In `src/master/mqtt_client.py::_on_message`, after `_record_agent_response`
+and before the WebSocket broadcast:
+
+```python
+elif msg_type == "response":
+    message = {"type": "message", "sender": "agent", **payload}
+    if db_path:
+        _save_agent_response(db_path, topic_id, payload)
+        _record_agent_response(db_path, topic_id)
+        notify.notify_reply(                       # <-- new
+            db_path=db_path,
+            settings=userdata["settings"],         # <-- threaded through build_client
+            topic_id=topic_id,
+            payload=payload,
+        )
+```
+
+`notify_reply` is the only public symbol; everything else stays in
+`src/master/notify.py`. The function:
+
+1. Looks up `workspace_id`, `workspace_name`, `topic_subject` from SQLite
+   in one query joining `topics` and `workspaces` on `topic_id`. If the
+   join returns no row (deleted topic), log and return.
+2. Reads workspace `config` rows for the `NOTIFY_*` keys via the existing
+   helper used by `load_agent_env`. Merges with `settings.notify_*`
+   fields.
+3. If `NOTIFY_DISABLED` is truthy in the merged set, log
+   `master.notify.skipped reason=disabled` and return.
+4. Builds a `NotificationContent` (preview trimmed to
+   `NOTIFY_PREVIEW_CHARS`).
+5. For each channel with sufficient config: spawn a daemon thread running
+   `post_webhook(url, payload)`. **Do not join.** The thread itself has a
+   10s urlopen timeout; if master shuts down before delivery, the message
+   is dropped (acceptable per the fire-and-forget contract).
+
+`build_client()` (`src/master/mqtt_client.py:147`) gains a `settings`
+parameter so `_on_message` can read notification config without re-loading
+env vars. The caller in `src/master/main.py` already has
+`MasterSettings` in scope.
+
+### URL construction
+
+Frontend route is `/workspaces/{wsId}/topics/{topicId}` (verified in
+`frontend/src/views/TopicChat.vue` and `frontend/src/main.js`).
+
+```python
+def build_topic_url(public_url: str | None, workspace_id: str, topic_id: str) -> str | None:
+    if not public_url:
+        return None
+    base = public_url.rstrip("/")
+    return f"{base}/workspaces/{workspace_id}/topics/{topic_id}"
+```
+
+If `MASTER_PUBLIC_URL` is unset, `build_topic_url` returns `None` and the
+notification body omits the URL line; the workspace and topic identifiers
+are still included so the user can navigate manually. This degrades
+gracefully for first-run installs without a public URL.
+
+### Notification content
+
+Rendered as a single string for both providers:
+
+```
+Agent replied in {workspace_name} / {topic_subject}
+
+{preview}
+
+{topic_url}
+```
+
+Where:
+
+- **`preview`** is the agent's `last_response` truncated to
+  `NOTIFY_PREVIEW_CHARS` characters (default 200), with trailing `…` if
+  truncation occurred. If `NOTIFY_PREVIEW_CHARS` is `0`, the line is
+  omitted entirely (and the leading blank line collapsed). If
+  `last_response` is empty (transcript-only reply), the line is omitted.
+- **`topic_url`** is omitted if `MASTER_PUBLIC_URL` is unset.
+- Markdown / HTML escaping: **none in v1**. Discord renders the content as
+  plain markdown by default; Telegram renders as plain text by default
+  (we do not pass `parse_mode`, so `_`, `*`, `[` are inert). This avoids
+  accidental injection of formatting from agent output.
+
+### Failure modes
+
+| Condition | Behaviour |
+|---|---|
+| No channels configured (global or workspace) | `notify_reply` is a no-op. Logged once at DEBUG. |
+| Webhook URL invalid / 4xx / 5xx | `post_webhook` logs `master.notify.failed url=… status=…` and returns. Other channel still attempted. |
+| Webhook URL hangs | 10s `urlopen` timeout hits, logged as `URLError`. |
+| `MASTER_PUBLIC_URL` unset | URL line omitted; notification still sent. |
+| Workspace deleted between agent dispatch and reply | DB lookup returns no row; log and skip notification. |
+| Master shutting down with notifications in flight | Threads are daemons; messages may be dropped. Acceptable. |
+| `dry_run` mode (`MASTER_DRY_RUN=true`) | Log `master.notify.dry_run message=…`, do not POST. Mirrors `cd/notify.py`. |
+
+### Tests
+
+Unit tests in `tests/master/test_notify.py`:
+
+- `notify_reply` is a no-op when no channels are configured.
+- Discord-only configured: one POST, payload shape correct.
+- Telegram-only configured: one POST to the right URL with `chat_id` in body.
+- Both configured: two POSTs, no ordering dependency.
+- Workspace `NOTIFY_DISCORD_WEBHOOK_URL` overrides global.
+- Workspace `NOTIFY_DISABLED=true` skips even when channels are configured.
+- `MASTER_PUBLIC_URL` unset → URL line omitted in body.
+- `NOTIFY_PREVIEW_CHARS=0` → preview omitted.
+- Long reply truncated to `NOTIFY_PREVIEW_CHARS` with `…`.
+- Provider returns 500 → logged, does not raise, sibling channel still
+  delivered.
+- `dry_run=True` → no HTTP call, log line emitted.
+
+UAT cases (in `docs/test-plans/agent-message-notification.md`, written by
+tester):
+
+| Case | Type |
+|---|---|
+| Configure Discord webhook globally; send agent message; receive Discord ping with topic URL | needs-human |
+| Configure Telegram bot + chat id at workspace scope; send agent message; receive Telegram ping | needs-human |
+| Set `NOTIFY_DISABLED=true` on workspace; send agent message; observe no notification | needs-human |
+| Leave all notification config unset; send agent message; verify no errors in master log | automated |
+| Click the URL in a real notification; verify it lands on the correct topic | needs-human |
+
+## Alternatives Considered
+
+### A. Generic webhook with operator-supplied JSON template
+
+A single `MASTER_NOTIFY_WEBHOOK_URL` plus a Jinja-style template lets
+operators target any service. Rejected — pushes JSON-template authoring
+onto every operator, poor first-time UX, and the only service that really
+needs a custom shape (Slack vs Discord) differs by one field name. The
+named-channel approach is shorter for users.
+
+### B. Notification dispatched from the WebSocket hub instead of MQTT callback
+
+The hub already broadcasts every message; we could hook there. Rejected —
+the hub also receives status events and possibly synthetic / replayed
+messages; gating "only on first-time agent reply" is cleaner at the MQTT
+boundary where we already distinguish `response` from `status`.
+
+### C. New `notifications` table to record every send
+
+Persist each delivery attempt for an audit trail. Rejected for v1.
+Notifications are advisory; loss is tolerable; storing them adds a table,
+a retention policy, and a UI without a clear use case. The CD daemon's
+`notify` does not persist either, and that has been adequate.
+
+### D. Reuse `MASTER_URL` for the topic deep link
+
+`MASTER_URL` is an in-cluster address (default `http://master:8080`)
+already used by agent containers calling back to the API. Embedding it in
+a chat message would produce a non-clickable URL for users on a different
+network. The new `MASTER_PUBLIC_URL` keeps the two concerns separate.
+
+### E. Per-user preferences keyed by some user identity
+
+The deployment is single-user (ADR-0009 §E). A second user dimension is
+unwarranted and would compound with the workspace dimension.
+
+### F. Build the external adapter referenced in ADR-0006 instead
+
+A separate service that bridges Discord/Telegram events to
+`POST /api/workspaces/{id}/topics/{tid}/messages` would be a much larger
+piece of work covering inbound flows, identity mapping, message
+formatting, and per-platform thread tracking. That work is still on the
+table for the future; it does not block the user-visible win of
+"notify me when my agent finished".
+
+## Open Questions
+
+- [ ] Does `runtime_config.load_agent_env` (ADR-0009 §4) expose a clean
+      programmatic merge for arbitrary key prefixes, or do we need a
+      thin wrapper that reads `config` rows directly with
+      `scope_type IN ('global','workspace')`? (Owner: engineer at slice
+      start.)
+- [ ] Should `MASTER_PUBLIC_URL` be a global-only setting or also
+      overrideable per workspace (e.g. for users hosting different
+      projects on different domains)? Defaulting to global-only for v1
+      since most deployments expose a single web UI; revisit if a real
+      multi-domain user appears.
+- [ ] Telegram `disable_web_page_preview` — set true (cleaner) or false
+      (lets users see the topic title at a glance via OG metadata)?
+      Defaulting to true; the UI does not yet emit Open Graph tags.
+- [ ] Markdown escaping in agent previews. v1 sends plain text, but if a
+      future provider (e.g. Slack) is added with markdown rendering, we
+      will need a per-provider escape pass. Track when that channel
+      lands.
+- [ ] Should we surface the configured channels in the workspace UI as a
+      "Notifications" sub-panel with a "send test message" button, or is
+      raw key-value editing in `WorkspaceEnvVarsPanel.vue` enough for
+      v1? (Owner: frontend engineer; a "test" button is a small,
+      valuable add but not blocking.)
+
+## Implementation Plan
+
+Single slice, sequenced top-to-bottom inside the slice:
+
+1. **`src/master/notify.py`** — new module with `post_webhook`,
+   `_discord_payload`, `_telegram_payload`, `NotificationContent`,
+   `build_topic_url`, `notify_reply`. Lift `post_webhook` from
+   `src/cd/notify.py` (keep both copies; do not refactor across
+   master/cd boundaries in this slice).
+2. **`src/master/config.py`** — add `master_public_url`,
+   `notify_discord_webhook_url`, `notify_telegram_bot_token`,
+   `notify_telegram_chat_id`, `notify_preview_chars` to `MasterSettings`
+   and `load_master_settings`.
+3. **`src/master/mqtt_client.py`** — thread `settings` through
+   `build_client(...)` and `userdata`; call `notify.notify_reply` after
+   `_record_agent_response`.
+4. **`src/master/main.py`** — pass `settings` into `build_client`.
+5. **Frontend** — extend `SECRET_KEY_SUBSTRINGS` in
+   `WorkspaceEnvVarsPanel.vue` (ADR-0010) with `WEBHOOK` so the Discord
+   URL is masked by default.
+6. **Docs** — `docs/references/config.md` updated with the five new env
+   vars and the five workspace `config` keys; `.env.example` updated.
+7. **Tests** — unit tests per the list above; test plan committed.
+8. **UAT** — needs-human cases against a real Discord channel and a real
+   Telegram bot.
+
+No DB migration. No new HTTP endpoints. No new MQTT topics.

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -25,6 +25,26 @@ The master service (`src/master/`) reads these environment variables on startup.
 | `MASTER_CODEX_AUTH_JSON_PATH` | No | unset | Host path to the shared Codex `auth.json` mounted into agents |
 | `MASTER_SSH_AUTH_SOCK_PATH` | No | unset | Host path to the SSH agent socket mounted into agent containers |
 | `MASTER_SSH_KNOWN_HOSTS_PATH` | No | unset | Host path to `known_hosts` mounted into agent containers |
+| `MASTER_PUBLIC_URL` | No | unset | Externally reachable base URL of the web UI (e.g. `https://codex.example.com`). Used to build deep links in notifications. If unset, notifications omit the URL. |
+| `MASTER_NOTIFY_DISCORD_WEBHOOK_URL` | No | unset | Discord incoming-webhook URL for agent-reply notifications. Leave unset to disable Discord globally. |
+| `MASTER_NOTIFY_TELEGRAM_BOT_TOKEN` | No | unset | Telegram bot token. Required together with `MASTER_NOTIFY_TELEGRAM_CHAT_ID`. |
+| `MASTER_NOTIFY_TELEGRAM_CHAT_ID` | No | unset | Telegram chat or channel ID (numeric or `@channelusername`). Required together with `MASTER_NOTIFY_TELEGRAM_BOT_TOKEN`. |
+| `MASTER_NOTIFY_PREVIEW_CHARS` | No | `200` | Max characters of the agent reply included as a preview in notifications. Set to `0` to omit the preview entirely. |
+
+### Workspace config keys (notification overrides)
+
+Per-workspace notification settings are stored in the `config` table and can be
+managed via the workspace Env Vars panel in the web UI. Workspace rows override
+the global env-var defaults above; an empty or absent value falls back to the
+global default.
+
+| Key | Effect |
+|-----|--------|
+| `NOTIFY_DISCORD_WEBHOOK_URL` | Override or set Discord destination for this workspace. |
+| `NOTIFY_TELEGRAM_BOT_TOKEN` | Workspace-specific Telegram bot token. |
+| `NOTIFY_TELEGRAM_CHAT_ID` | Workspace-specific Telegram chat or channel ID. |
+| `NOTIFY_PREVIEW_CHARS` | Workspace-specific preview length (characters). |
+| `NOTIFY_DISABLED` | If truthy (`1`, `true`, `yes`, `on`), skip all notifications for this workspace regardless of global config. |
 
 ### Database
 

--- a/docs/test-plans/agent-message-notification.md
+++ b/docs/test-plans/agent-message-notification.md
@@ -1,0 +1,143 @@
+# Test Plan: Agent Message Notification
+
+- **Feature design:** [docs/design/agent-message-notification.md](../design/agent-message-notification.md)
+- **ADR:** [docs/decisions/0011-agent-message-notification.md](../decisions/0011-agent-message-notification.md)
+- **Date:** 2026-05-05
+- **Components under test:** `src/master/notify.py`, `src/master/config.py` (new settings fields), `src/master/mqtt_client.py` (call site integration)
+
+---
+
+## 1. Scope
+
+### In scope
+
+- `src/master/notify.py` module in isolation:
+  - `build_topic_url` — URL construction from public base and identifiers.
+  - `_render_body` — notification text assembly from `NotificationContent`.
+  - `_discord_payload` — Discord-specific JSON payload builder.
+  - `_telegram_payload` — Telegram-specific JSON payload builder.
+  - `post_webhook` — HTTP POST helper with error swallowing and dry-run support.
+  - `notify_reply` — main entry point: DB lookup, config merge, channel dispatch.
+- Config resolution: global `MasterSettings` fields as default; per-workspace `config` table rows as override (`NOTIFY_*` keys).
+- `NOTIFY_DISABLED` per-workspace suppression flag.
+- Preview truncation to `NOTIFY_PREVIEW_CHARS` characters with ellipsis.
+- Fire-and-forget dispatch on daemon threads (no blocking of the WebSocket broadcast path).
+- Failure isolation between channels: a 5xx from one provider must not suppress delivery on the other.
+- `dry_run` mode: no HTTP call, log line emitted.
+- Live UAT against a real testbed: Discord webhook delivery, Telegram bot delivery, URL deep link correctness.
+
+### Out of scope
+
+- Inbound chat commands (explicitly excluded by ADR-0006 and ADR-0011).
+- WhatsApp Business API (deferred in ADR-0011).
+- Notification persistence or audit log (rejected alternative C in the design doc).
+- Presence-aware suppression ("only notify when no browser tab is watching", deferred).
+- Per-user preferences (single-user deployment, deferred).
+- Retry on delivery failure (fire-and-forget by design; same posture as `cd/notify.py`).
+- Open Graph / markdown rendering in notification bodies.
+- Frontend `SECRET_KEY_SUBSTRINGS` extension for `WEBHOOK` (verified separately via component tests).
+- `docs/references/config.md` and `.env.example` accuracy (doc-writer scope).
+
+---
+
+## 2. Test Cases
+
+### 2.1 Unit tests (automated)
+
+All unit tests live in `tests/master/test_notify.py`. They run against `src/master/notify.py` with `sqlite3` on a real temporary file-backed database (matching the pattern in `tests/master/test_mqtt_client.py` and `tests/master/test_db.py`). HTTP calls are patched via `unittest.mock.patch` at `src.master.notify.post_webhook` or `src.master.notify.urllib.request.urlopen`.
+
+| # | Test name | What is asserted | Status |
+|---|-----------|-----------------|--------|
+| U-01 | `test_no_channels_configured_no_post` | When all `notify_*` settings are empty/unset, `notify_reply` spawns no threads and calls `post_webhook` zero times. | automated |
+| U-02 | `test_discord_only_one_post_correct_payload` | Discord URL configured; one POST to that URL; payload has `content` key containing workspace name and topic subject. | automated |
+| U-03 | `test_telegram_only_one_post_correct_url_and_body` | Telegram token + chat_id configured; one POST to `https://api.telegram.org/bot<TOKEN>/sendMessage`; body has `chat_id` and `text`. | automated |
+| U-04 | `test_both_configured_two_posts` | Both Discord and Telegram configured; exactly two POSTs dispatched, one to each provider. | automated |
+| U-05 | `test_workspace_discord_webhook_overrides_global` | Workspace `config` row `NOTIFY_DISCORD_WEBHOOK_URL` overrides the global webhook URL from `MasterSettings`. | automated |
+| U-06 | `test_notify_disabled_skips_all_channels` | Workspace `config` row `NOTIFY_DISABLED=true`; all configured channels skipped; `post_webhook` never called. | automated |
+| U-06b | `test_notify_disabled_uppercase_true_skips` | `NOTIFY_DISABLED=TRUE` (uppercase) is also treated as truthy. | automated |
+| U-07 | `test_no_public_url_omits_url_from_body` | `master_public_url=""` (unset); Discord payload `content` field contains no HTTP URL. | automated |
+| U-08 | `test_preview_chars_zero_omits_preview` | `notify_preview_chars=0`; agent reply text absent from the notification body. | automated |
+| U-09 | `test_long_reply_truncated_with_ellipsis` | Reply longer than `notify_preview_chars`; body contains truncated text with `…` appended; full reply absent. | automated |
+| U-09b | `test_reply_at_exact_limit_not_truncated` | Reply length equal to limit; no ellipsis added. | automated |
+| U-10 | `test_discord_500_sibling_telegram_still_delivered` | Discord `post_webhook` raises `urllib.error.HTTPError(500)`; Telegram URL is still called; no exception propagates. | automated |
+| U-11 | `test_dry_run_no_http_call` | `settings.dry_run=True`; `urllib.request.urlopen` never called; a log record containing `dry_run` is emitted. | automated |
+| U-12 | `test_deleted_topic_logs_and_returns` | `topic_id` not present in the database; `post_webhook` never called; no exception raised. | automated |
+| U-13 | `test_telegram_token_without_chat_id_skips_telegram` | Bot token set but `chat_id` empty; Telegram skipped; only Discord (if configured) dispatched. | automated |
+| U-14 | `test_workspace_preview_chars_override` | Workspace `NOTIFY_PREVIEW_CHARS=5` overrides global `notify_preview_chars=200`; reply truncated at 5 chars. | automated |
+| U-15 | `test_workspace_telegram_config_used_when_global_absent` | No global Telegram config; workspace `config` rows provide both token and chat_id; Telegram delivery occurs. | automated |
+| U-16 | `test_normal_url` (`build_topic_url`) | `build_topic_url("https://codex.example.com", "ws1", "t1")` → `"https://codex.example.com/workspaces/ws1/topics/t1"`. | automated |
+| U-17 | `test_trailing_slash_stripped` (`build_topic_url`) | Trailing slash on `public_url` is stripped before concatenation; result has no double slash. | automated |
+| U-18 | `test_none_public_url_returns_none` (`build_topic_url`) | `None` input → `None` return. | automated |
+| U-19 | `test_empty_string_public_url_returns_none` (`build_topic_url`) | `""` input → `None` return. | automated |
+| U-20 | `test_http_500_does_not_raise` (`post_webhook`) | `urlopen` raises `HTTPError(500)`; `post_webhook` swallows it without re-raising. | automated |
+| U-21 | `test_http_500_is_logged` (`post_webhook`) | `HTTPError(500)` produces a WARNING log record referencing the status code or the word "failed". | automated |
+| U-22 | `test_url_error_does_not_raise` (`post_webhook`) | `urlopen` raises `URLError("connection refused")`; no exception propagates. | automated |
+| U-23 | `test_dry_run_skips_http_call` (`post_webhook`) | `post_webhook(..., dry_run=True)` does not call `urlopen`. | automated |
+| U-24 | `test_dry_run_emits_log_line` (`post_webhook`) | `post_webhook(..., dry_run=True)` emits a log record containing `dry_run`. | automated |
+| U-25 | `test_has_content_key` (`_discord_payload`) | Return value has a `"content"` key whose value is a string. | automated |
+| U-26 | `test_has_chat_id_and_text` (`_telegram_payload`) | Return value has `chat_id` matching supplied value and a `"text"` key. | automated |
+| U-27 | `test_disable_web_page_preview` (`_telegram_payload`) | `disable_web_page_preview` is `True` in the Telegram payload. | automated |
+
+### 2.2 UAT cases
+
+UAT cases are executed against a live testbed deployment. Cases that require real credentials or visual verification are marked `needs-human`. Cases that can be driven entirely by API calls or log inspection are marked `automated`.
+
+| # | Test case | Type | What to verify / how |
+|---|-----------|------|----------------------|
+| A-01 | Configure `MASTER_NOTIFY_DISCORD_WEBHOOK_URL` globally; trigger an agent reply; verify a Discord message arrives | needs-human | Set the env var in `.env` and redeploy (or use the global config API). Send a message to a topic via the web UI. Check the configured Discord channel for a message containing the workspace name, topic subject, and a clickable `https://…/workspaces/…/topics/…` URL. |
+| A-02 | Configure Telegram token + chat id at workspace scope; trigger an agent reply; verify Telegram delivery | needs-human | Using the workspace config API (`PATCH /api/workspaces/{id}/config`) set `NOTIFY_TELEGRAM_BOT_TOKEN` and `NOTIFY_TELEGRAM_CHAT_ID`. Send a message to a topic in that workspace. Check the Telegram chat for a message from the bot. |
+| A-03 | Set `NOTIFY_DISABLED=true` on a workspace; trigger an agent reply; confirm no notification and no errors | needs-human | Using `PATCH /api/workspaces/{id}/config` set `NOTIFY_DISABLED=true`. Both Discord (global) and/or Telegram (workspace) must be configured so the suppression is observable. Send a message. Verify: (a) no Discord/Telegram message arrives; (b) master logs contain no `ERROR` lines related to notify. |
+| A-04 | Leave all notification config unset; trigger an agent reply; confirm master log has no errors | automated | On a testbed with no `MASTER_NOTIFY_*` env vars set and no workspace `NOTIFY_*` rows, send a topic message. Inspect master container logs (`docker logs master`) for any `ERROR` or `EXCEPTION` lines referencing `notify`. Pass criterion: zero such lines. |
+| A-05 | Click the URL in a received notification; confirm it opens the correct topic in the web UI | needs-human | After A-01 or A-02 produces a notification containing a deep link, click that link in the Discord or Telegram client. Verify the browser opens the correct workspace and topic in the web UI (URL path matches `/workspaces/{wsId}/topics/{topicId}` and the topic subject is displayed). |
+
+---
+
+## 3. Pass / Fail Criteria
+
+### Unit tests
+
+All unit tests in `tests/master/test_notify.py` must pass (`pytest` exit code 0) before the feature branch is considered merge-ready. A single failure is a blocking defect.
+
+### UAT
+
+| Result | Meaning |
+|--------|---------|
+| `pass` | Executed programmatically or by human; outcome matches the expected result stated in the test case. |
+| `fail` | Executed; outcome did not match. A failing UAT case blocks merge and is handed off to `engineer` with the full error detail. |
+| `needs-human` | Cannot be verified without real credentials, a real chat account, or visual browser interaction. The human reviewer must reply on the PR with a per-row `pass` or `fail` before the PR is considered signed off. |
+
+The PR is ready to merge only when:
+1. All unit tests are green.
+2. All `automated` UAT cases pass.
+3. All `needs-human` UAT cases have been signed off (marked `pass`) by the user as a PR comment.
+4. No `fail` UAT case is unresolved.
+
+---
+
+## 4. Edge Cases and Failure Modes
+
+These edge cases are covered by the unit tests above and documented here for reference.
+
+| Scenario | Expected behaviour | Covered by |
+|----------|--------------------|------------|
+| `MASTER_PUBLIC_URL` unset | `build_topic_url` returns `None`; notification body omits the URL line; notification is still sent (if channel is configured). | U-07, U-18, U-19 |
+| `NOTIFY_PREVIEW_CHARS=0` | Preview omitted from body entirely. Workspace name and subject still present. | U-08 |
+| Reply exactly at the preview character limit | No truncation, no ellipsis appended. | U-09b |
+| Provider returns HTTP 5xx | `post_webhook` logs at WARNING level, does not re-raise. The sibling channel's delivery is not affected. | U-10, U-20, U-21 |
+| Provider URL unreachable / `URLError` | Same as 5xx: logged, swallowed, sibling channel unaffected. | U-22 |
+| Both channels misconfigured (e.g. Discord URL is empty, Telegram has token but no chat_id) | Both channels are individually skipped; `notify_reply` returns without error; one INFO log per skipped channel. | U-01, U-13 |
+| Topic deleted between agent dispatch and reply arriving | DB join returns no row; `notify_reply` logs and returns without sending any notification. | U-12 |
+| `dry_run=True` at the settings level | `post_webhook` is not called; all channel paths emit a `dry_run` log line instead. | U-11, U-23, U-24 |
+| `NOTIFY_DISABLED=true` with mixed case | Truthy string check is case-insensitive (`"TRUE"`, `"True"`, `"1"`, `"yes"` all disable). | U-06, U-06b |
+| Master process shuts down with notifications in flight | Background threads are daemons; they are abandoned on shutdown. Acceptable per fire-and-forget contract. | Design-only; not unit-testable without process lifecycle harness. |
+
+---
+
+## 5. Non-functional Requirements
+
+| Requirement | Verification method |
+|-------------|---------------------|
+| `notify_reply` must not block the WebSocket broadcast | Confirmed by architecture: dispatch uses `daemon=True` threads; `notify_reply` returns without joining. Verified structurally in code review; not load-tested in v1. |
+| Each `post_webhook` call has a 10-second timeout | Verified in implementation review (matches `cd/notify.py` posture). Not covered by automated tests (would require a slow HTTP server fixture). |
+| Webhook URLs and bot tokens are treated as secrets | `NOTIFY_DISCORD_WEBHOOK_URL` and `NOTIFY_TELEGRAM_BOT_TOKEN` are masked in the workspace config UI via the `SECRET_KEY_SUBSTRINGS` extension (`WEBHOOK` substring added). Verified manually in the workspace UI during UAT. |
+| No new DB tables, no new HTTP endpoints, no new MQTT topics | Confirmed by the implementation plan in the design doc (§ Implementation Plan last paragraph). Verified in code review. |

--- a/frontend/src/components/WorkspaceEnvVarsPanel.vue
+++ b/frontend/src/components/WorkspaceEnvVarsPanel.vue
@@ -73,7 +73,7 @@ const props = defineProps({
   containerRunning: { type: Boolean, default: false },
 })
 
-const SECRET_KEY_SUBSTRINGS = ['KEY', 'TOKEN', 'SECRET', 'PASSWORD', 'CREDENTIAL', 'PASSPHRASE']
+const SECRET_KEY_SUBSTRINGS = ['KEY', 'TOKEN', 'SECRET', 'PASSWORD', 'CREDENTIAL', 'PASSPHRASE', 'WEBHOOK']
 
 const mergedConfig = ref({})
 const globalConfig = ref({})

--- a/src/master/config.py
+++ b/src/master/config.py
@@ -31,6 +31,11 @@ class MasterSettings:
     master_url: str = "http://master:8080"
     agent_idle_timeout_seconds: int = 3600
     agent_auth_refresh_interval_seconds: int = 43200
+    master_public_url: str = ""
+    notify_discord_webhook_url: str = ""
+    notify_telegram_bot_token: str = ""
+    notify_telegram_chat_id: str = ""
+    notify_preview_chars: int = 200
 
     @property
     def attachment_max_size_bytes(self) -> int:
@@ -130,6 +135,22 @@ def load_master_settings() -> MasterSettings:
     agent_auth_refresh_interval_seconds = int(os.getenv("AGENT_AUTH_REFRESH_INTERVAL_SECONDS", "43200") or "43200")
     _log_env("AGENT_AUTH_REFRESH_INTERVAL_SECONDS", os.getenv("AGENT_AUTH_REFRESH_INTERVAL_SECONDS"))
 
+    master_public_url = os.getenv("MASTER_PUBLIC_URL", "").strip()
+    _log_env("MASTER_PUBLIC_URL", os.getenv("MASTER_PUBLIC_URL"))
+
+    notify_discord_webhook_url = os.getenv("MASTER_NOTIFY_DISCORD_WEBHOOK_URL", "").strip()
+    _log_env("MASTER_NOTIFY_DISCORD_WEBHOOK_URL", "<redacted>" if os.getenv("MASTER_NOTIFY_DISCORD_WEBHOOK_URL") else None)
+
+    notify_telegram_bot_token = os.getenv("MASTER_NOTIFY_TELEGRAM_BOT_TOKEN", "").strip()
+    _log_env("MASTER_NOTIFY_TELEGRAM_BOT_TOKEN", "<redacted>" if os.getenv("MASTER_NOTIFY_TELEGRAM_BOT_TOKEN") else None)
+
+    notify_telegram_chat_id = os.getenv("MASTER_NOTIFY_TELEGRAM_CHAT_ID", "").strip()
+    _log_env("MASTER_NOTIFY_TELEGRAM_CHAT_ID", os.getenv("MASTER_NOTIFY_TELEGRAM_CHAT_ID"))
+
+    raw_notify_preview_chars = os.getenv("MASTER_NOTIFY_PREVIEW_CHARS", "200").strip()
+    _log_env("MASTER_NOTIFY_PREVIEW_CHARS", os.getenv("MASTER_NOTIFY_PREVIEW_CHARS"))
+    notify_preview_chars = int(raw_notify_preview_chars) if raw_notify_preview_chars else 200
+
     LOGGER.info(
         "master.env_load done data_dir=%s dry_run=%s mqtt=%s:%s runtime=%s master_url=%s",
         data_dir, dry_run, mqtt_host, mqtt_port, container_runtime, master_url,
@@ -158,4 +179,9 @@ def load_master_settings() -> MasterSettings:
         master_url=master_url,
         agent_idle_timeout_seconds=agent_idle_timeout_seconds,
         agent_auth_refresh_interval_seconds=agent_auth_refresh_interval_seconds,
+        master_public_url=master_public_url,
+        notify_discord_webhook_url=notify_discord_webhook_url,
+        notify_telegram_bot_token=notify_telegram_bot_token,
+        notify_telegram_chat_id=notify_telegram_chat_id,
+        notify_preview_chars=notify_preview_chars,
     )

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 
 import paho.mqtt.client as mqtt
 
+from . import notify
 from .config import MasterSettings
 
 LOGGER = logging.getLogger(__name__)
@@ -150,6 +151,12 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
         if db_path:
             _save_agent_response(db_path, topic_id, payload)
             _record_agent_response(db_path, topic_id)
+            notify.notify_reply(
+                db_path=db_path,
+                settings=userdata["settings"],
+                topic_id=topic_id,
+                payload=payload,
+            )
     else:
         return
 
@@ -165,7 +172,7 @@ def build_client(
     loop: asyncio.AbstractEventLoop | None = None,
     db_path: str | None = None,
 ) -> mqtt.Client:
-    userdata = {"hub": hub, "loop": loop, "db_path": db_path}
+    userdata = {"hub": hub, "loop": loop, "db_path": db_path, "settings": settings}
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, userdata=userdata)
     client.on_connect = _on_connect
     client.on_disconnect = _on_disconnect

--- a/src/master/notify.py
+++ b/src/master/notify.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib import error as url_error
+from urllib import request
+
+if TYPE_CHECKING:
+    from .config import MasterSettings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NotificationContent:
+    workspace_name: str
+    topic_subject: str
+    topic_url: str | None  # None if MASTER_PUBLIC_URL unset
+    preview: str  # already trimmed, may be ""
+
+
+def build_topic_url(public_url: str | None, workspace_id: str, topic_id: str) -> str | None:
+    """Return the deep-link URL for a topic, or None if public_url is absent or blank."""
+    if not public_url or not public_url.strip():
+        return None
+    base = public_url.rstrip("/")
+    return f"{base}/workspaces/{workspace_id}/topics/{topic_id}"
+
+
+def _render_body(content: NotificationContent) -> str:
+    """Render the notification text shared by all channel adapters."""
+    lines: list[str] = [f"Agent replied in {content.workspace_name} / {content.topic_subject}"]
+    if content.preview:
+        lines.append("")
+        lines.append(content.preview)
+    if content.topic_url is not None:
+        lines.append("")
+        lines.append(content.topic_url)
+    return "\n".join(lines)
+
+
+def _discord_payload(content: NotificationContent) -> dict:  # type: ignore[type-arg]
+    return {"content": _render_body(content)}
+
+
+def _telegram_payload(content: NotificationContent, chat_id: str) -> dict:  # type: ignore[type-arg]
+    return {
+        "chat_id": chat_id,
+        "text": _render_body(content),
+        "disable_web_page_preview": True,
+    }
+
+
+def post_webhook(url: str, payload: dict, dry_run: bool = False) -> None:  # type: ignore[type-arg]
+    """POST *payload* as JSON to *url* with a 10-second timeout.
+
+    If dry_run is True the payload is only logged. Errors are logged and
+    swallowed so the caller is never interrupted by delivery failures.
+    """
+    if dry_run:
+        logger.info("master.notify.dry_run url=%s message=%r", url, payload)
+        return
+
+    data = json.dumps(payload).encode()
+    req = request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "codex-slack-master/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=10):
+            pass
+    except url_error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode(errors="replace")
+        except Exception:  # noqa: BLE001
+            pass
+        logger.warning("master.notify.failed url=%s status=%s body=%s", url, exc.code, body)
+    except (url_error.URLError, OSError) as exc:
+        logger.warning("master.notify.failed url=%s error=%s", url, exc)
+
+
+def notify_reply(
+    db_path: str,
+    settings: MasterSettings,
+    topic_id: str,
+    payload: dict,  # type: ignore[type-arg]
+) -> None:
+    """Fire-and-forget notification when an agent finishes a reply.
+
+    Resolves effective notification config by merging global settings with
+    workspace-level config rows (workspace wins). Spawns one daemon thread
+    per configured channel; never joins them.
+    """
+    try:
+        row = _fetch_topic_workspace(db_path, topic_id)
+    except Exception:
+        logger.exception("master.notify.db_error topic_id=%s", topic_id)
+        return
+
+    if row is None:
+        logger.info("master.notify.skipped reason=topic_not_found topic_id=%s", topic_id)
+        return
+
+    workspace_id, workspace_name, topic_subject = row
+
+    try:
+        effective = _resolve_effective_config(db_path, workspace_id, settings)
+    except Exception:
+        logger.exception("master.notify.config_error workspace_id=%s", workspace_id)
+        return
+
+    if _is_truthy(effective.get("NOTIFY_DISABLED", "")):
+        logger.info(
+            "master.notify.skipped reason=disabled workspace_id=%s topic_id=%s",
+            workspace_id,
+            topic_id,
+        )
+        return
+
+    preview_chars = int(effective.get("NOTIFY_PREVIEW_CHARS", settings.notify_preview_chars))
+    raw_preview = payload.get("last_response", "") or ""
+    preview = _trim_preview(raw_preview, preview_chars)
+
+    content = NotificationContent(
+        workspace_name=workspace_name,
+        topic_subject=topic_subject,
+        topic_url=build_topic_url(settings.master_public_url, workspace_id, topic_id),
+        preview=preview,
+    )
+
+    discord_url = effective.get("NOTIFY_DISCORD_WEBHOOK_URL", "")
+    if discord_url:
+        threading.Thread(
+            target=post_webhook,
+            args=(discord_url, _discord_payload(content), settings.dry_run),
+            daemon=True,
+        ).start()
+
+    telegram_token = effective.get("NOTIFY_TELEGRAM_BOT_TOKEN", "")
+    telegram_chat_id = effective.get("NOTIFY_TELEGRAM_CHAT_ID", "")
+    if telegram_token and telegram_chat_id:
+        telegram_url = f"https://api.telegram.org/bot{telegram_token}/sendMessage"
+        threading.Thread(
+            target=post_webhook,
+            args=(telegram_url, _telegram_payload(content, telegram_chat_id), settings.dry_run),
+            daemon=True,
+        ).start()
+
+
+def _fetch_topic_workspace(
+    db_path: str, topic_id: str
+) -> tuple[str, str, str] | None:
+    """Return (workspace_id, workspace_name, topic_subject) or None if not found."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT w.id, w.name, t.subject"
+            " FROM topics t JOIN workspaces w ON t.workspace_id = w.id"
+            " WHERE t.id = ?",
+            (topic_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return str(row["id"]), str(row["name"]), str(row["subject"])
+    finally:
+        conn.close()
+
+
+def _resolve_effective_config(
+    db_path: str, workspace_id: str, settings: MasterSettings
+) -> dict[str, str]:
+    """Merge global env defaults with workspace config rows; workspace wins."""
+    global_defaults: dict[str, str] = {}
+    if settings.notify_discord_webhook_url:
+        global_defaults["NOTIFY_DISCORD_WEBHOOK_URL"] = settings.notify_discord_webhook_url
+    if settings.notify_telegram_bot_token:
+        global_defaults["NOTIFY_TELEGRAM_BOT_TOKEN"] = settings.notify_telegram_bot_token
+    if settings.notify_telegram_chat_id:
+        global_defaults["NOTIFY_TELEGRAM_CHAT_ID"] = settings.notify_telegram_chat_id
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT key, value, scope_type FROM config"
+            " WHERE (scope_type='global' OR (scope_type='workspace' AND scope_id=?))"
+            " ORDER BY scope_type",
+            (workspace_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    # ORDER BY scope_type: 'global' < 'workspace' alphabetically, so workspace rows
+    # are processed last and overwrite global rows — workspace wins.
+    workspace_config: dict[str, str] = {}
+    global_config_rows: dict[str, str] = {}
+    for r in rows:
+        if r["scope_type"] == "global":
+            global_config_rows[r["key"]] = r["value"]
+        else:
+            workspace_config[r["key"]] = r["value"]
+
+    effective = {**global_defaults, **global_config_rows, **workspace_config}
+    return effective
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _trim_preview(text: str, max_chars: int) -> str:
+    if max_chars <= 0:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "…"

--- a/src/master/notify.py
+++ b/src/master/notify.py
@@ -131,10 +131,11 @@ def notify_reply(
     raw_preview = payload.get("last_response", "") or ""
     preview = _trim_preview(raw_preview, preview_chars)
 
+    public_url = effective.get("MASTER_PUBLIC_URL") or settings.master_public_url
     content = NotificationContent(
         workspace_name=workspace_name,
         topic_subject=topic_subject,
-        topic_url=build_topic_url(settings.master_public_url, workspace_id, topic_id),
+        topic_url=build_topic_url(public_url, workspace_id, topic_id),
         preview=preview,
     )
 

--- a/src/master/runtime_config.py
+++ b/src/master/runtime_config.py
@@ -27,10 +27,16 @@ def load_global_env(db_path: str) -> dict[str, str]:
         conn.close()
 
 _SYSTEM_VARIABLES: list[dict] = [
-    {"name": "GH_TOKEN",                "sensitive": True},
-    {"name": "ANTHROPIC_API_KEY",       "sensitive": True},
-    {"name": "CLAUDE_CODE_OAUTH_TOKEN", "sensitive": True},
-    {"name": "OPENAI_API_KEY",          "sensitive": True},
+    {"name": "GH_TOKEN",                         "sensitive": True},
+    {"name": "ANTHROPIC_API_KEY",                "sensitive": True},
+    {"name": "CLAUDE_CODE_OAUTH_TOKEN",          "sensitive": True},
+    {"name": "OPENAI_API_KEY",                   "sensitive": True},
+    # Agent-reply notifications
+    {"name": "MASTER_PUBLIC_URL",                "sensitive": False},
+    {"name": "NOTIFY_DISCORD_WEBHOOK_URL",       "sensitive": True},
+    {"name": "NOTIFY_TELEGRAM_BOT_TOKEN",        "sensitive": True},
+    {"name": "NOTIFY_TELEGRAM_CHAT_ID",          "sensitive": False},
+    {"name": "NOTIFY_PREVIEW_CHARS",             "sensitive": False},
 ]
 
 global_router = APIRouter(prefix="/config", tags=["config"])

--- a/tests/master/test_mqtt_client.py
+++ b/tests/master/test_mqtt_client.py
@@ -130,17 +130,20 @@ def _make_db(tmp_path) -> str:
 def test_on_message_status_does_not_record_response(tmp_path):
     db = _make_db(tmp_path)
     msg = _make_msg("codex-slack/workspace/ws1/topic/t1/status", {"state": "thinking"})
+    settings = _make_settings()
     with patch("src.master.mqtt_client._record_agent_response") as mock_rec:
-        _on_message(MagicMock(), {"db_path": db}, msg)
+        _on_message(MagicMock(), {"db_path": db, "settings": settings}, msg)
         mock_rec.assert_not_called()
 
 
 def test_on_message_response_records_response(tmp_path):
     db = _make_db(tmp_path)
     msg = _make_msg("codex-slack/workspace/ws1/topic/t1/response", {"last_response": "done"})
+    settings = _make_settings()
     with patch("src.master.mqtt_client._record_agent_response") as mock_rec, \
-         patch("src.master.mqtt_client._save_agent_response"):
-        _on_message(MagicMock(), {"db_path": db}, msg)
+         patch("src.master.mqtt_client._save_agent_response"), \
+         patch("src.master.mqtt_client.notify.notify_reply"):
+        _on_message(MagicMock(), {"db_path": db, "settings": settings}, msg)
         mock_rec.assert_called_once_with(db, "t1")
 
 

--- a/tests/master/test_notify.py
+++ b/tests/master/test_notify.py
@@ -1,0 +1,802 @@
+"""Unit tests for src/master/notify.py — agent message notification module."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import urllib.error
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.master.notify import (
+    NotificationContent,
+    _discord_payload,
+    _render_body,
+    _telegram_payload,
+    build_topic_url,
+    notify_reply,
+    post_webhook,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_settings(
+    *,
+    master_public_url: str = "",
+    notify_discord_webhook_url: str = "",
+    notify_telegram_bot_token: str = "",
+    notify_telegram_chat_id: str = "",
+    notify_preview_chars: int = 200,
+    dry_run: bool = False,
+) -> Any:
+    """Return a minimal MasterSettings-compatible object for notification tests."""
+
+    @dataclass(frozen=True)
+    class _Settings:
+        master_public_url: str
+        notify_discord_webhook_url: str
+        notify_telegram_bot_token: str
+        notify_telegram_chat_id: str
+        notify_preview_chars: int
+        dry_run: bool
+
+    return _Settings(
+        master_public_url=master_public_url,
+        notify_discord_webhook_url=notify_discord_webhook_url,
+        notify_telegram_bot_token=notify_telegram_bot_token,
+        notify_telegram_chat_id=notify_telegram_chat_id,
+        notify_preview_chars=notify_preview_chars,
+        dry_run=dry_run,
+    )
+
+
+def _make_db(tmp_path, *, workspace_name: str = "My Workspace", topic_subject: str = "Fix bug #42") -> str:
+    """Create a minimal SQLite database pre-seeded with one workspace and one topic."""
+    db = str(tmp_path / "test.db")
+    conn = sqlite3.connect(db)
+    now = "2026-01-01T00:00:00Z"
+    conn.executescript(f"""
+        CREATE TABLE workspaces (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            repo_url TEXT NOT NULL,
+            container_name TEXT,
+            created_at TEXT NOT NULL,
+            archived_at TEXT,
+            last_refreshed_at TEXT,
+            last_message_at TEXT,
+            last_dispatched_at TEXT,
+            last_responded_at TEXT
+        );
+        CREATE TABLE topics (
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            branch_name TEXT NOT NULL,
+            worktree_path TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            archived_at TEXT
+        );
+        CREATE TABLE config (
+            scope_type TEXT NOT NULL,
+            scope_id   TEXT NOT NULL DEFAULT '',
+            key        TEXT NOT NULL,
+            value      TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (scope_type, scope_id, key)
+        );
+        INSERT INTO workspaces (id, name, repo_url, created_at)
+            VALUES ('ws1', '{workspace_name}', 'https://github.com/x/y', '{now}');
+        INSERT INTO topics (id, workspace_id, subject, branch_name, worktree_path, created_at)
+            VALUES ('t1', 'ws1', '{topic_subject}', 'fix-bug-42', '/tmp/wt', '{now}');
+    """)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _set_config(db: str, scope_type: str, scope_id: str, key: str, value: str) -> None:
+    conn = sqlite3.connect(db)
+    now = "2026-01-01T00:00:00Z"
+    conn.execute(
+        "INSERT OR REPLACE INTO config (scope_type, scope_id, key, value, updated_at) VALUES (?, ?, ?, ?, ?)",
+        (scope_type, scope_id, key, value, now),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# build_topic_url
+# ---------------------------------------------------------------------------
+
+class TestBuildTopicUrl:
+    def test_normal_url(self):
+        result = build_topic_url("https://codex.example.com", "ws1", "t1")
+        assert result == "https://codex.example.com/workspaces/ws1/topics/t1"
+
+    def test_trailing_slash_stripped(self):
+        result = build_topic_url("https://codex.example.com/", "ws1", "t1")
+        assert result == "https://codex.example.com/workspaces/ws1/topics/t1"
+
+    def test_multiple_trailing_slashes_stripped(self):
+        result = build_topic_url("https://codex.example.com///", "ws1", "t1")
+        assert result == "https://codex.example.com/workspaces/ws1/topics/t1"
+
+    def test_none_public_url_returns_none(self):
+        assert build_topic_url(None, "ws1", "t1") is None
+
+    def test_empty_string_public_url_returns_none(self):
+        assert build_topic_url("", "ws1", "t1") is None
+
+    def test_whitespace_only_public_url_returns_none(self):
+        assert build_topic_url("   ", "ws1", "t1") is None
+
+
+# ---------------------------------------------------------------------------
+# _render_body
+# ---------------------------------------------------------------------------
+
+class TestRenderBody:
+    def _content(self, **kwargs) -> NotificationContent:
+        defaults = dict(
+            workspace_name="My Workspace",
+            topic_subject="Fix bug #42",
+            topic_url="https://codex.example.com/workspaces/ws1/topics/t1",
+            preview="The agent fixed the bug.",
+        )
+        return NotificationContent(**{**defaults, **kwargs})
+
+    def test_full_body_contains_all_parts(self):
+        body = _render_body(self._content())
+        assert "My Workspace" in body
+        assert "Fix bug #42" in body
+        assert "The agent fixed the bug." in body
+        assert "https://codex.example.com/workspaces/ws1/topics/t1" in body
+
+    def test_no_url_omits_url_line(self):
+        body = _render_body(self._content(topic_url=None))
+        assert "http" not in body
+        assert "My Workspace" in body
+
+    def test_empty_preview_omits_preview_line(self):
+        body = _render_body(self._content(preview=""))
+        assert "The agent" not in body
+        # workspace and subject still present
+        assert "My Workspace" in body
+        assert "Fix bug #42" in body
+
+    def test_no_url_no_preview(self):
+        body = _render_body(self._content(topic_url=None, preview=""))
+        assert "My Workspace" in body
+        assert "Fix bug #42" in body
+        assert "http" not in body
+
+
+# ---------------------------------------------------------------------------
+# _discord_payload
+# ---------------------------------------------------------------------------
+
+class TestDiscordPayload:
+    def test_has_content_key(self):
+        content = NotificationContent(
+            workspace_name="WS",
+            topic_subject="Subject",
+            topic_url="https://x.com",
+            preview="preview text",
+        )
+        payload = _discord_payload(content)
+        assert "content" in payload
+        assert isinstance(payload["content"], str)
+
+    def test_content_includes_workspace_and_subject(self):
+        content = NotificationContent(
+            workspace_name="My WS",
+            topic_subject="The subject",
+            topic_url="https://x.com",
+            preview="short preview",
+        )
+        payload = _discord_payload(content)
+        assert "My WS" in payload["content"]
+        assert "The subject" in payload["content"]
+
+
+# ---------------------------------------------------------------------------
+# _telegram_payload
+# ---------------------------------------------------------------------------
+
+class TestTelegramPayload:
+    def test_has_chat_id_and_text(self):
+        content = NotificationContent(
+            workspace_name="WS",
+            topic_subject="Subject",
+            topic_url="https://x.com",
+            preview="preview",
+        )
+        payload = _telegram_payload(content, chat_id="@mychannel")
+        assert payload["chat_id"] == "@mychannel"
+        assert "text" in payload
+        assert "WS" in payload["text"]
+
+    def test_disable_web_page_preview(self):
+        content = NotificationContent(
+            workspace_name="WS",
+            topic_subject="Subject",
+            topic_url=None,
+            preview="",
+        )
+        payload = _telegram_payload(content, chat_id="12345")
+        # design specifies disable_web_page_preview=true
+        assert payload.get("disable_web_page_preview") is True
+
+
+# ---------------------------------------------------------------------------
+# post_webhook
+# ---------------------------------------------------------------------------
+
+class TestPostWebhook:
+    def _make_response(self, status: int = 200) -> MagicMock:
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = status
+        return resp
+
+    def test_posts_json_body(self):
+        payload = {"content": "hello"}
+        with patch("src.master.notify.request.urlopen") as mock_open:
+            mock_open.return_value = self._make_response()
+            post_webhook("https://example.com/hook", payload)
+        mock_open.assert_called_once()
+        req = mock_open.call_args.args[0]
+        body = json.loads(req.data)
+        assert body == payload
+
+    def test_http_500_does_not_raise(self):
+        exc = urllib.error.HTTPError(
+            url="https://example.com/hook",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=None,
+            fp=BytesIO(b"server error"),
+        )
+        with patch("src.master.notify.request.urlopen", side_effect=exc):
+            # must not raise
+            post_webhook("https://example.com/hook", {"content": "hello"})
+
+    def test_http_500_is_logged(self, caplog):
+        import logging
+
+        exc = urllib.error.HTTPError(
+            url="https://example.com/hook",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=None,
+            fp=BytesIO(b"server error"),
+        )
+        with caplog.at_level(logging.WARNING, logger="src.master.notify"):
+            with patch("src.master.notify.request.urlopen", side_effect=exc):
+                post_webhook("https://example.com/hook", {"content": "hello"})
+        assert any("500" in r.message or "failed" in r.message.lower() for r in caplog.records)
+
+    def test_url_error_does_not_raise(self):
+        exc = urllib.error.URLError("connection refused")
+        with patch("src.master.notify.request.urlopen", side_effect=exc):
+            post_webhook("https://example.com/hook", {"content": "hello"})
+
+    def test_dry_run_skips_http_call(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="src.master.notify"):
+            with patch("src.master.notify.request.urlopen") as mock_open:
+                post_webhook("https://example.com/hook", {"content": "hello"}, dry_run=True)
+                mock_open.assert_not_called()
+
+    def test_dry_run_emits_log_line(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="src.master.notify"):
+            with patch("src.master.notify.request.urlopen"):
+                post_webhook("https://example.com/hook", {"content": "test"}, dry_run=True)
+        assert any("dry_run" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# notify_reply — main entry point
+# ---------------------------------------------------------------------------
+
+class TestNotifyReply:
+    """Tests for notify_reply using a real in-memory-style SQLite db on disk."""
+
+    def _run_notify_and_join(self, tmp_path, settings, payload=None, topic_id="t1"):
+        """Call notify_reply and wait for background threads to complete.
+
+        Threads started by notify_reply are daemons and unjoinable externally,
+        so we patch threading.Thread to track and join them manually.
+        """
+        if payload is None:
+            payload = {"last_response": "The agent replied."}
+        db = _make_db(tmp_path)
+        return db
+
+    # ── TC-01: no channels configured — no-op ─────────────────────────────
+
+    def test_no_channels_configured_no_post(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings()  # all notify fields empty
+        threads_started: list[threading.Thread] = []
+        original_thread = threading.Thread
+
+        def capturing_thread(*args, **kwargs):
+            t = original_thread(*args, **kwargs)
+            threads_started.append(t)
+            return t
+
+        with patch("src.master.notify.threading.Thread", side_effect=capturing_thread):
+            with patch("src.master.notify.post_webhook") as mock_post:
+                notify_reply(
+                    db_path=db,
+                    settings=settings,
+                    topic_id="t1",
+                    payload={"last_response": "hello"},
+                )
+        # No threads should have been spawned; no POST should be called
+        assert len(threads_started) == 0
+        mock_post.assert_not_called()
+
+    # ── TC-02: Discord-only configured — one POST with correct payload ─────
+
+    def test_discord_only_one_post_correct_payload(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+        )
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "Agent is done."},
+            )
+
+        # Allow any threads to complete
+        assert len(posted) == 1
+        url, payload = posted[0]
+        assert url == "https://discord.com/api/webhooks/123/abc"
+        assert "content" in payload
+        assert "My Workspace" in payload["content"]
+        assert "Fix bug #42" in payload["content"]
+
+    # ── TC-03: Telegram-only configured — one POST to correct URL ──────────
+
+    def test_telegram_only_one_post_correct_url_and_body(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_telegram_bot_token="bot123:TOKEN",
+            notify_telegram_chat_id="@testchannel",
+        )
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "Done!"},
+            )
+
+        assert len(posted) == 1
+        url, payload = posted[0]
+        assert "api.telegram.org" in url
+        assert "bot123:TOKEN" in url
+        assert "sendMessage" in url
+        assert payload["chat_id"] == "@testchannel"
+        assert "text" in payload
+
+    # ── TC-04: Both configured — two POSTs ────────────────────────────────
+
+    def test_both_configured_two_posts(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/999/xyz",
+            notify_telegram_bot_token="bot456:TOKEN",
+            notify_telegram_chat_id="12345678",
+        )
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "Agent replied."},
+            )
+
+        assert len(posted) == 2
+        urls = {url for url, _ in posted}
+        discord_urls = {u for u in urls if "discord.com" in u}
+        telegram_urls = {u for u in urls if "telegram.org" in u}
+        assert len(discord_urls) == 1
+        assert len(telegram_urls) == 1
+
+    # ── TC-05: Workspace config overrides global Discord webhook ──────────
+
+    def test_workspace_discord_webhook_overrides_global(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/GLOBAL/hook",
+        )
+        # Set workspace-level override
+        _set_config(db, "workspace", "ws1", "NOTIFY_DISCORD_WEBHOOK_URL",
+                    "https://discord.com/api/webhooks/WORKSPACE/hook")
+
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "done"},
+            )
+
+        assert len(posted) == 1
+        url, _ = posted[0]
+        assert "WORKSPACE" in url
+        assert "GLOBAL" not in url
+
+    # ── TC-06: NOTIFY_DISABLED=true skips all channels ────────────────────
+
+    def test_notify_disabled_skips_all_channels(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            notify_telegram_bot_token="bot123:TOKEN",
+            notify_telegram_chat_id="@chan",
+        )
+        _set_config(db, "workspace", "ws1", "NOTIFY_DISABLED", "true")
+
+        with patch("src.master.notify.post_webhook") as mock_post:
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "reply"},
+            )
+
+        mock_post.assert_not_called()
+
+    def test_notify_disabled_uppercase_true_skips(self, tmp_path):
+        """NOTIFY_DISABLED=TRUE (all-caps) should also be treated as truthy."""
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+        )
+        _set_config(db, "workspace", "ws1", "NOTIFY_DISABLED", "TRUE")
+
+        with patch("src.master.notify.post_webhook") as mock_post:
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "reply"},
+            )
+
+        mock_post.assert_not_called()
+
+    # ── TC-07: MASTER_PUBLIC_URL unset — no URL in notification body ───────
+
+    def test_no_public_url_omits_url_from_body(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            master_public_url="",  # unset
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+        )
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "done"},
+            )
+
+        assert len(posted) == 1
+        _, payload = posted[0]
+        body_text = payload.get("content", "")
+        assert "http" not in body_text
+
+    # ── TC-08: NOTIFY_PREVIEW_CHARS=0 — no preview in body ───────────────
+
+    def test_preview_chars_zero_omits_preview(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            notify_preview_chars=0,
+        )
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "This should not appear in the notification."},
+            )
+
+        assert len(posted) == 1
+        _, payload = posted[0]
+        body_text = payload.get("content", "")
+        assert "This should not appear" not in body_text
+
+    # ── TC-09: Long reply truncated to NOTIFY_PREVIEW_CHARS with ellipsis ─
+
+    def test_long_reply_truncated_with_ellipsis(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            notify_preview_chars=10,
+        )
+        long_reply = "A" * 200
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": long_reply},
+            )
+
+        assert len(posted) == 1
+        _, payload = posted[0]
+        body_text = payload.get("content", "")
+        # The full long reply must not appear
+        assert long_reply not in body_text
+        # An ellipsis must be appended to signal truncation
+        assert "…" in body_text or "..." in body_text
+
+    def test_reply_at_exact_limit_not_truncated(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            notify_preview_chars=5,
+        )
+        exact_reply = "Hello"  # exactly 5 chars
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": exact_reply},
+            )
+
+        assert len(posted) == 1
+        _, payload = posted[0]
+        body_text = payload.get("content", "")
+        assert "Hello" in body_text
+        # No ellipsis when reply fits exactly
+        assert "…" not in body_text
+
+    # ── TC-10: Provider returns 500 — logged, does not raise, sibling delivered
+
+    def test_discord_500_sibling_telegram_still_delivered(self, tmp_path):
+        """When Discord urlopen returns 500, post_webhook swallows it and Telegram is still POSTed.
+
+        Both channels are dispatched on separate daemon threads.  We patch
+        request.urlopen so the real post_webhook runs (and logs) the error, then
+        we also track every urlopen call to confirm the Telegram URL is reached.
+        """
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/FAIL/hook",
+            notify_telegram_bot_token="bot123:TOKEN",
+            notify_telegram_chat_id="@chan",
+        )
+
+        called_urls: list[str] = []
+        discord_exc = urllib.error.HTTPError(
+            url="https://discord.com/api/webhooks/FAIL/hook",
+            code=500,
+            msg="Server Error",
+            hdrs=None,
+            fp=BytesIO(b"err"),
+        )
+
+        def fake_urlopen(req, timeout=None):
+            called_urls.append(req.full_url)
+            if "discord" in req.full_url:
+                raise discord_exc
+            # Return a context-manager-compatible mock for Telegram
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        # Threads are daemon and unjoinable externally; capture threads to join them.
+        spawned: list[threading.Thread] = []
+        original_thread_start = threading.Thread.start
+
+        def capturing_start(self_thread):
+            spawned.append(self_thread)
+            original_thread_start(self_thread)
+
+        with patch("src.master.notify.request.urlopen", side_effect=fake_urlopen):
+            with patch.object(threading.Thread, "start", capturing_start):
+                notify_reply(
+                    db_path=db,
+                    settings=settings,
+                    topic_id="t1",
+                    payload={"last_response": "done"},
+                )
+            # Wait for all daemon threads to complete
+            for t in spawned:
+                t.join(timeout=5)
+
+        # Telegram URL should have been called despite Discord's 500
+        assert any("telegram" in u for u in called_urls)
+
+    # ── TC-11: dry_run=True — no HTTP call, log line emitted ──────────────
+
+    def test_dry_run_no_http_call(self, tmp_path, caplog):
+        import logging
+
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            dry_run=True,
+        )
+
+        with caplog.at_level(logging.INFO, logger="src.master.notify"):
+            with patch("src.master.notify.request.urlopen") as mock_open:
+                notify_reply(
+                    db_path=db,
+                    settings=settings,
+                    topic_id="t1",
+                    payload={"last_response": "reply"},
+                )
+                mock_open.assert_not_called()
+
+        assert any("dry_run" in r.message for r in caplog.records)
+
+    # ── TC-12: Unknown / deleted topic — log and return, no crash ─────────
+
+    def test_deleted_topic_logs_and_returns(self, tmp_path, caplog):
+        import logging
+
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="src.master.notify"):
+            with patch("src.master.notify.post_webhook") as mock_post:
+                notify_reply(
+                    db_path=db,
+                    settings=settings,
+                    topic_id="nonexistent-topic",
+                    payload={"last_response": "reply"},
+                )
+                mock_post.assert_not_called()
+
+    # ── TC-13: Telegram missing chat_id — Telegram skipped, no crash ──────
+
+    def test_telegram_token_without_chat_id_skips_telegram(self, tmp_path):
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            notify_telegram_bot_token="bot123:TOKEN",
+            notify_telegram_chat_id="",  # missing
+        )
+        posted: list[str] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append(url)
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "done"},
+            )
+
+        # Only Discord should have been called; no Telegram
+        assert len(posted) == 1
+        assert "discord" in posted[0]
+
+    # ── Workspace config overrides: NOTIFY_PREVIEW_CHARS ──────────────────
+
+    def test_workspace_preview_chars_override(self, tmp_path):
+        """Workspace NOTIFY_PREVIEW_CHARS=5 overrides the global default of 200."""
+        db = _make_db(tmp_path)
+        settings = _make_settings(
+            notify_discord_webhook_url="https://discord.com/api/webhooks/123/abc",
+            notify_preview_chars=200,  # global default
+        )
+        _set_config(db, "workspace", "ws1", "NOTIFY_PREVIEW_CHARS", "5")
+
+        long_reply = "B" * 100
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": long_reply},
+            )
+
+        assert len(posted) == 1
+        _, payload = posted[0]
+        body_text = payload.get("content", "")
+        assert long_reply not in body_text
+        # Truncated at 5, ellipsis appended
+        assert "…" in body_text or "..." in body_text
+
+    # ── Workspace Telegram override ────────────────────────────────────────
+
+    def test_workspace_telegram_config_used_when_global_absent(self, tmp_path):
+        """Workspace-only Telegram config triggers Telegram delivery."""
+        db = _make_db(tmp_path)
+        settings = _make_settings()  # no global telegram config
+        _set_config(db, "workspace", "ws1", "NOTIFY_TELEGRAM_BOT_TOKEN", "wsbot:TOKEN")
+        _set_config(db, "workspace", "ws1", "NOTIFY_TELEGRAM_CHAT_ID", "@wschan")
+
+        posted: list[tuple[str, dict]] = []
+
+        def fake_post(url, payload, dry_run=False):
+            posted.append((url, payload))
+
+        with patch("src.master.notify.post_webhook", side_effect=fake_post):
+            notify_reply(
+                db_path=db,
+                settings=settings,
+                topic_id="t1",
+                payload={"last_response": "workspace reply"},
+            )
+
+        assert len(posted) == 1
+        url, payload = posted[0]
+        assert "telegram.org" in url
+        assert "wsbot:TOKEN" in url
+        assert payload["chat_id"] == "@wschan"


### PR DESCRIPTION
## Summary

- Sends a fire-and-forget push notification to Discord (webhook) and/or Telegram (Bot API) when an agent finishes replying on a topic
- Notification includes workspace name, topic subject, reply preview, and a deep link built from `MASTER_PUBLIC_URL`
- Configuration is layered: global env-var defaults with per-workspace overrides via the existing `config` table (ADR-0009/0010); `NOTIFY_DISABLED=true` mutes a single workspace
- Delivery runs on daemon threads with a 10 s timeout — errors are logged and swallowed so the existing MQTT → DB → WebSocket path is never blocked

Closes #118. See [ADR-0011](docs/decisions/0011-agent-message-notification.md) and [design doc](docs/design/agent-message-notification.md).

## Test plan

- [x] 37 unit tests in `tests/master/test_notify.py` — all passing (308 total, 0 failures)
- [x] UAT (automated): no notification config set → agent response processed → zero notification errors in master log ✅
- [ ] UAT (needs-human): configure `MASTER_NOTIFY_DISCORD_WEBHOOK_URL` globally; trigger an agent reply; confirm Discord message arrives with topic deep link
- [ ] UAT (needs-human): configure `NOTIFY_TELEGRAM_BOT_TOKEN` + `NOTIFY_TELEGRAM_CHAT_ID` at workspace scope; trigger an agent reply; confirm Telegram delivery
- [ ] UAT (needs-human): set `NOTIFY_DISABLED=true` on a workspace; trigger a reply; confirm no notification and no errors in logs
- [ ] UAT (needs-human): click the URL in a received notification; confirm it opens the correct topic in the web UI

🤖 Generated with repository automation