### PR TITLE
fix(agent): collect all result events when Claude emits multiple final responses

### DIFF
--- a/docs/knowledge-base/lessons-learned.md
+++ b/docs/knowledge-base/lessons-learned.md
@@ -30,6 +30,18 @@ Append-only log. Each entry: date, summary, root cause, fix applied, prevention.
 
 ---
 
+## 2026-05-05 — Multiple final responses from Claude CLI were silently dropped
+
+*Summary:* When the Claude CLI produces more than one `result` event in a single run (e.g. a main response followed by a background-task completion notification), the frontend only showed the last one. The first response was silently discarded.
+
+*Root cause:* `_run_claude_once` in `src/agent/mqtt_loop.py` assigned `output = event.get("result")` inside the `result`-event loop, overwriting on each iteration. Only the final result event's text survived.
+
+*Fix applied:* Changed to collect all result texts into a list (`outputs`) and join them with `"\n\n---\n\n"` after the loop. Also changed `is_error` to accumulate with `or` so any error in any turn is preserved.
+
+*Prevention:* When iterating over a stream of events and extracting a single value, check whether multiple occurrences of the target event type are possible. If so, accumulate rather than overwrite.
+
+---
+
 ## 2026-05-02 — `--verbose` required for stream-json `result` event (v3 slices 3–4)
 
 *Summary:* The claude-code agent returned `(no output)` for all LLM turns, and no `session_id` was ever stored in the `sessions` table. Agent responses appeared empty in the UI.

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -96,7 +96,7 @@ def _run_claude_once(
         result = subprocess.run(cmd, cwd=worktree, capture_output=True, text=True, timeout=_LLM_TIMEOUT)
         events = []
         new_session_id = None
-        output = None
+        outputs: list[str] = []
         is_error = False
         for line in result.stdout.splitlines():
             line = line.strip()
@@ -107,11 +107,15 @@ def _run_claude_once(
                 events.append(event)
                 if event.get("type") == "result":
                     new_session_id = event.get("session_id")
-                    output = event.get("result") or event.get("last_response")
-                    is_error = bool(event.get("is_error"))
+                    result_text = event.get("result") or event.get("last_response")
+                    if result_text:
+                        outputs.append(result_text)
+                    if event.get("is_error"):
+                        is_error = True
             except (json.JSONDecodeError, AttributeError):
                 continue
         transcript = json.dumps(events) if events else None
+        output = "\n\n---\n\n".join(outputs) if outputs else None
         if not output:
             output = result.stderr.strip() or "(no output)"
         return output, new_session_id, transcript, is_error

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -52,6 +52,26 @@ def test_run_claude_returns_stdout(tmp_path):
     assert isinstance(_json.loads(transcript), list)
 
 
+def test_run_claude_joins_multiple_final_responses(tmp_path):
+    """When the CLI emits more than one result event (e.g. main response + background
+    task notification), all result texts must be joined so nothing is dropped."""
+    import json as _json
+    events = [
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "First response"}]}},
+        {"type": "result", "result": "First response", "session_id": "s1", "is_error": False},
+        {"type": "system", "subtype": "task_updated"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "Second response"}]}},
+        {"type": "result", "result": "Second response", "session_id": "s1", "is_error": False},
+    ]
+    stream = "\n".join(_json.dumps(e) for e in events)
+    with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=stream, stderr="", returncode=0)
+        text, session, transcript = _run_claude(str(tmp_path), "run it", None, False, None, None, None)
+    assert "First response" in text
+    assert "Second response" in text
+    assert session == "s1"
+
+
 def test_run_claude_includes_resume_when_session_id(tmp_path):
     with patch("src.agent.mqtt_loop.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(stdout='{"type":"result","result":"ok","session_id":"ses-123"}', stderr="", returncode=0)


### PR DESCRIPTION
## Summary
- When the Claude CLI produces more than one `result` event in a single run (e.g. main response + background-task completion notification), only the last one was kept — earlier responses were silently dropped and never shown in the frontend
- Fixed `_run_claude_once` in `src/agent/mqtt_loop.py` to accumulate all result texts into a list and join them with a `---` separator instead of overwriting on each iteration
- Also fixed `is_error` to accumulate with `or` so any error turn is preserved (previously only the last result's error flag was kept)

## Test plan
- [x] New unit test `test_run_claude_joins_multiple_final_responses` — verifies that when the CLI stream contains two `result` events, both texts appear in the returned output
- [x] Full test suite (272 tests) passes with no regressions
- [ ] Manual: trigger a Claude agent task that spawns a background task (e.g. run tests in background); confirm both the main response and the background-task result appear as one message in the frontend

🤖 Generated with repository automation