### PR TITLE
fix(workspace): defer branch fetch until user opens branch picker

### DIFF
--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -32,7 +32,7 @@
             <input
               v-model="branchFilter"
               @input="onBranchInput"
-              @focus="branchDropdownOpen = true"
+              @focus="onBranchFocus"
               @blur="scheduleBranchClose"
               placeholder="Branch (required)"
               autocomplete="off"
@@ -185,6 +185,7 @@ let statusTimer = null
 
 const branches = ref([])
 const branchesLoading = ref(false)
+const branchesFetched = ref(false)
 const branchFilter = ref('')
 const selectedBranch = ref('')
 const branchDropdownOpen = ref(false)
@@ -264,13 +265,22 @@ async function fetchAgentStatus() {
 }
 
 async function fetchBranches() {
+  if (branchesFetched.value) return
   branchesLoading.value = true
   try {
     const r = await fetch(`/api/workspaces/${id}/branches`)
-    if (r.ok) branches.value = await r.json()
+    if (r.ok) {
+      branches.value = await r.json()
+      branchesFetched.value = true
+    }
   } catch { /* ignore */ } finally {
     branchesLoading.value = false
   }
+}
+
+function onBranchFocus() {
+  fetchBranches()
+  branchDropdownOpen.value = true
 }
 
 function onBranchInput() {
@@ -290,6 +300,7 @@ function clearBranch() {
 }
 
 function toggleBranchDropdown() {
+  if (!branchDropdownOpen.value) fetchBranches()
   branchDropdownOpen.value = !branchDropdownOpen.value
 }
 
@@ -416,7 +427,6 @@ async function deleteStaff(name) {
 onMounted(async () => {
   await load()
   if (!isArchived.value) {
-    fetchBranches()
     await fetchAgentStatus()
     statusTimer = setInterval(fetchAgentStatus, 10000)
   }


### PR DESCRIPTION
## Summary
- Branches were fetched from the GitHub API on every workspace page load, causing rate limit exhaustion (issue #138)
- `fetchBranches()` is now triggered lazily on first focus of the branch input or first click of the caret dropdown
- A `branchesFetched` guard prevents duplicate API calls within the same session
- Removes the eager `fetchBranches()` call from `onMounted`

## Test plan
- [ ] Open a workspace detail page — confirm no network request to `/api/workspaces/{id}/branches` is made on load
- [ ] Click into the branch input field — confirm the API request fires and the dropdown populates
- [ ] Click the caret (▾) button — confirm the API request fires if branches not yet loaded
- [ ] Interact with the branch picker a second time — confirm no duplicate API request is made (check Network tab)
- [ ] Select a branch, submit a new topic — confirm it works end-to-end as before

🤖 Generated with repository automation