### PR TITLE
feat(frontend): small chat & workspace QoL fixes

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -163,7 +163,7 @@
           placeholder="Type a message…"
           rows="3"
           :disabled="sending"
-          @keydown.enter.exact.prevent="sendMessage"
+          @keydown.enter.shift.exact.prevent="sendMessage"
           @paste="onPaste"
         />
         <button type="submit" :disabled="sending || !text.trim()">
@@ -171,7 +171,7 @@
         </button>
       </form>
       <p v-if="sendError" class="send-error">{{ sendError }}</p>
-      <p class="hint muted">Enter to send · Shift+Enter for new line · Use <code>@name</code> to address a specific staff</p>
+      <p class="hint muted">Shift+Enter to send · Enter for new line · Use <code>@name</code> to address a specific staff</p>
     </template>
   </div>
 </template>
@@ -348,14 +348,16 @@ function handleChunk({ message_id, agent_name, seq, event }) {
 
 function finaliseMessage(data) {
   const idx = messages.value.findIndex(m => m.id === data.message_id)
+  const existing = idx >= 0 ? messages.value[idx] : null
   const finalMsg = {
     id: data.message_id, sender: data.sender || 'agent',
     agent_name: data.agent_name || null,
-    text: data.last_response || data.text || '',
-    transcript: data.transcript || null,
-    traceRows: transcriptToRows(data.transcript),
+    text: data.last_response || data.text || existing?.text || '',
+    transcript: data.transcript || existing?.transcript || null,
+    traceRows: transcriptToRows(data.transcript) || existing?.traceRows || [],
+    attachments: data.attachments ?? existing?.attachments ?? [],
     traceOpen: false, streaming: false,
-    created_at: new Date().toISOString(),
+    created_at: existing?.created_at || new Date().toISOString(),
   }
   if (idx >= 0) messages.value.splice(idx, 1, finalMsg)
   else messages.value.push(finalMsg)
@@ -600,7 +602,7 @@ onUnmounted(() => {
 .message.agent { align-self: flex-start; align-items: flex-start; }
 .label { font-size: 0.75em; color: #64748b; margin-bottom: 2px; }
 .bubble { padding: 0.6rem 0.9rem; border-radius: 12px; line-height: 1.45; }
-.message.user .bubble { background: #2563eb; color: #fff; border-bottom-right-radius: 3px; white-space: pre-wrap; }
+.message.user .bubble { background: #fff; color: #1e293b; border: 1px solid #2563eb; border-bottom-right-radius: 3px; white-space: pre-wrap; }
 .message.agent .bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 3px; max-width: 100%; overflow: hidden; }
 .ts { font-size: 0.7em; color: #94a3b8; margin-top: 2px; }
 .detail-panel { margin-top: 4px; max-width: 100%; }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -75,7 +75,7 @@
             <MarkdownMessage :text="m.text" />
             <span v-if="m.streaming" class="cursor">▍</span>
           </template>
-          <template v-else>{{ m.text }}</template>
+          <template v-else><MarkdownMessage :text="m.text" /></template>
         </div>
         <div v-if="m.attachments && m.attachments.length" class="attachment-list">
           <template v-for="a in m.attachments" :key="a.id">
@@ -602,7 +602,7 @@ onUnmounted(() => {
 .message.agent { align-self: flex-start; align-items: flex-start; }
 .label { font-size: 0.75em; color: #64748b; margin-bottom: 2px; }
 .bubble { padding: 0.6rem 0.9rem; border-radius: 12px; line-height: 1.45; }
-.message.user .bubble { background: #fff; color: #1e293b; border: 1px solid #2563eb; border-bottom-right-radius: 3px; white-space: pre-wrap; }
+.message.user .bubble { background: #fff; color: #1e293b; border: 1px solid #2563eb; border-bottom-right-radius: 3px; max-width: 100%; overflow: hidden; }
 .message.agent .bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 3px; max-width: 100%; overflow: hidden; }
 .ts { font-size: 0.7em; color: #94a3b8; margin-top: 2px; }
 .detail-panel { margin-top: 4px; max-width: 100%; }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -496,7 +496,7 @@ async function sendMessage() {
       text.value = ''
       selectedFiles.value = []
       const data = await r.json()
-      messages.value.push({
+      const localMsg = {
         id: data.message_id,
         sender: 'user',
         agent_name: null,
@@ -504,7 +504,10 @@ async function sendMessage() {
         transcript: data.dispatch || null,
         attachments: data.attachments || [],
         created_at: new Date().toISOString(),
-      })
+      }
+      const idx = messages.value.findIndex(m => m.id === localMsg.id)
+      if (idx >= 0) messages.value.splice(idx, 1, localMsg)
+      else messages.value.push(localMsg)
       scrollToBottom()
     } else {
       const err = await r.json().catch(() => ({}))

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -272,6 +272,14 @@ async function fetchBranches() {
     if (r.ok) {
       branches.value = await r.json()
       branchesFetched.value = true
+      if (!selectedBranch.value) {
+        const fallback = branches.value.find(b => b === 'master')
+          || branches.value.find(b => b === 'main')
+        if (fallback) {
+          selectedBranch.value = fallback
+          branchFilter.value = fallback
+        }
+      }
     }
   } catch { /* ignore */ } finally {
     branchesLoading.value = false
@@ -429,6 +437,7 @@ onMounted(async () => {
   if (!isArchived.value) {
     await fetchAgentStatus()
     statusTimer = setInterval(fetchAgentStatus, 10000)
+    fetchBranches()
   }
 })
 

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -199,6 +199,9 @@ async def send_message(
         "topic_id": topic_id,
         "message_id": message_id,
         "sender": "user",
+        "text": text.strip(),
+        "transcript": payload,
+        "attachments": attachment_metas,
     })
 
     mqtt_topic = _PROMPT_TOPIC.format(workspace_id=workspace_id, topic_id=topic_id)


### PR DESCRIPTION
## Summary

Bundles four small frontend/UX fixes:

- **#155 (bug)** — messages sent from other tabs rendered as empty bubbles because the user-message WebSocket broadcast omitted `text`/`transcript`/`attachments`. Backend now includes them, and `finaliseMessage` preserves existing fields when the broadcast is partial (so the local POST response and WS replay no longer clobber each other).
- **#152 (qol)** — send keybinding swapped to **Shift+Enter**; bare Enter now inserts a newline. Hint text updated.
- **#151 (qol)** — user message bubble switches from solid blue to white background with a blue outline so rendered markdown content stays legible.
- **#150 (qol)** — workspace branch picker pre-fetches branches on mount and defaults the selection to `master` or `main` when present.

Closes #155. Closes #152. Closes #151. Closes #150.

## Test plan

- [x] Open a topic in two browser tabs side-by-side. Send a message from Tab A — Tab B should display the message text immediately (and any attachments), not an empty bubble.
- [x] In the chat textarea, press **Enter** alone — caret moves to a new line, message is *not* sent. Press **Shift+Enter** — message sends.
- [x] Send a message containing markdown (e.g. `**bold** `code``) — user bubble shows white background, blue border, with markdown rendered legibly.
- [x] Open a workspace detail page on a repo that has `master` (or `main`) — branch picker shows that branch pre-selected without needing to click. Clear it and confirm validation still requires a branch.
- [x] Pre-existing paste-image tests still pass (`npm test` in `frontend/`).
- [x] Backend unit tests still pass (`.sre/test.sh`).

🤖 Generated with repository automation
