### PR TITLE
feat(frontend): mobile-adaptive layout (closes #157)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,15 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch, provide } from 'vue'
+import { useRoute } from 'vue-router'
 import RecentTopicsSidebar from './components/RecentTopicsSidebar.vue'
 
 const masterVersion = ref('')
+const sidebarOpen = ref(false)
+const route = useRoute()
+
+provide('sidebar', { open: sidebarOpen, close: () => { sidebarOpen.value = false } })
+
+watch(() => route.fullPath, () => { sidebarOpen.value = false })
 
 onMounted(async () => {
   try {
@@ -15,11 +22,27 @@ onMounted(async () => {
 <template>
   <div id="root">
     <nav>
-      <RouterLink to="/">Codex Slack<span v-if="masterVersion" class="version">{{ masterVersion }}</span></RouterLink>
+      <button
+        class="nav-toggle"
+        :aria-expanded="sidebarOpen"
+        aria-label="Toggle recent topics"
+        @click="sidebarOpen = !sidebarOpen"
+      >
+        <span class="bar" /><span class="bar" /><span class="bar" />
+      </button>
+      <RouterLink to="/" class="brand">
+        <span class="brand-text">Codex Slack</span>
+        <span v-if="masterVersion" class="version">{{ masterVersion }}</span>
+      </RouterLink>
       <RouterLink to="/settings" class="nav-settings">Settings</RouterLink>
     </nav>
-    <div class="body-layout">
-      <RecentTopicsSidebar />
+    <div class="body-layout" :class="{ 'sidebar-open': sidebarOpen }">
+      <div
+        v-if="sidebarOpen"
+        class="sidebar-backdrop"
+        @click="sidebarOpen = false"
+      />
+      <RecentTopicsSidebar :open="sidebarOpen" @close="sidebarOpen = false" />
       <main>
         <RouterView />
       </main>
@@ -36,18 +59,60 @@ nav {
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 nav a { color: #93c5fd; }
+.brand { display: inline-flex; align-items: baseline; gap: 0.4rem; }
 .nav-settings { margin-left: auto; font-size: 0.9rem; font-weight: 400; }
-.version { font-size: 0.7em; font-weight: 400; opacity: 0.65; margin-left: 0.4rem; }
+.version { font-size: 0.7em; font-weight: 400; opacity: 0.65; }
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  padding: 0.4rem;
+  margin: -0.4rem 0 -0.4rem -0.4rem;
+  cursor: pointer;
+  flex-direction: column;
+  gap: 4px;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+}
+.nav-toggle .bar {
+  display: block;
+  width: 1.25rem;
+  height: 2px;
+  background: #f8fafc;
+  border-radius: 1px;
+}
+
 .body-layout {
   display: flex;
   min-height: calc(100vh - 3rem);
+  position: relative;
+}
+.sidebar-backdrop {
+  display: none;
 }
 main {
   flex: 1;
   padding: 1.5rem;
   min-width: 0;
+}
+
+@media (max-width: 768px) {
+  nav { padding: 0.6rem 0.9rem; gap: 0.6rem; font-size: 1rem; }
+  .nav-toggle { display: flex; }
+  .brand-text { font-size: 0.95rem; }
+  main { padding: 1rem 0.9rem; }
+  .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    z-index: 40;
+  }
 }
 </style>

--- a/frontend/src/components/RecentTopicsSidebar.vue
+++ b/frontend/src/components/RecentTopicsSidebar.vue
@@ -1,12 +1,12 @@
 <template>
-  <aside class="sidebar">
+  <aside class="sidebar" :class="{ 'is-open': open }" :aria-hidden="!open && isMobile">
     <div class="sidebar-title">Recent Topics</div>
     <RouterLink
       v-for="topic in topics"
       :key="topic.topic_id"
       :to="`/workspaces/${topic.workspace_id}/topics/${topic.topic_id}`"
       active-class="active"
-      @click="markSeen(topic.topic_id)"
+      @click="onTopicClick(topic.topic_id)"
     >
       <span class="topic-name">{{ topicLabel(topic) }}</span>
       <span v-if="isNew(topic)" class="new-badge">new</span>
@@ -19,11 +19,21 @@
 import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
+const props = defineProps({
+  open: { type: Boolean, default: false },
+})
+const emit = defineEmits(['close'])
+
 let ws = null
 let wsTimer = null
 
 const route = useRoute()
 const topics = ref([])
+const isMobile = ref(false)
+
+function syncIsMobile() {
+  isMobile.value = window.matchMedia('(max-width: 768px)').matches
+}
 
 async function load() {
   try {
@@ -42,6 +52,11 @@ function getLastSeen(topicId) {
 
 function markSeen(topicId) {
   localStorage.setItem(`topic-last-seen:${topicId}`, nowTs())
+}
+
+function onTopicClick(topicId) {
+  markSeen(topicId)
+  emit('close')
 }
 
 function midTrunc(str, max) {
@@ -88,11 +103,14 @@ onMounted(() => {
   load()
   connectWs()
   interval = setInterval(load, 60_000)
+  syncIsMobile()
+  window.addEventListener('resize', syncIsMobile)
 })
 onUnmounted(() => {
   clearInterval(interval)
   clearTimeout(wsTimer)
   if (ws) { ws.onclose = null; ws.close() }
+  window.removeEventListener('resize', syncIsMobile)
 })
 </script>
 
@@ -162,5 +180,26 @@ onUnmounted(() => {
   font-size: 0.8rem;
   color: #475569;
   font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    top: 3rem;
+    bottom: 0;
+    left: 0;
+    z-index: 50;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.25);
+    width: 80vw;
+    max-width: 280px;
+    min-width: 0;
+  }
+  .sidebar.is-open {
+    transform: translateX(0);
+  }
+  .sidebar a { font-size: 0.95rem; padding: 0.6rem 1rem; }
+  .sidebar-title { font-size: 0.75rem; padding: 0 1rem 0.75rem; }
 }
 </style>

--- a/frontend/src/components/WorkspaceEnvVarsPanel.vue
+++ b/frontend/src/components/WorkspaceEnvVarsPanel.vue
@@ -26,7 +26,8 @@
 
     <p v-if="loading" class="muted">Loading…</p>
     <p v-else-if="!rows.length" class="muted">No env vars set for this workspace.</p>
-    <table v-else class="config-table">
+    <div v-else class="table-wrap">
+      <table class="config-table">
       <thead>
         <tr><th>Key</th><th>Value</th><th>Source</th><th></th></tr>
       </thead>
@@ -60,7 +61,8 @@
           </td>
         </tr>
       </tbody>
-    </table>
+      </table>
+    </div>
   </section>
 </template>
 
@@ -265,4 +267,14 @@ h2 { margin: 0; }
 
 .btn-add { padding: 0.35rem 0.85rem; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
 .btn-add:disabled { opacity: 0.6; cursor: default; }
+
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+@media (max-width: 768px) {
+  .config-key-input { width: 100%; }
+  .config-val-input { width: 100%; flex: 1 1 100%; }
+  .config-add-form .btn-add { width: 100%; }
+  .restart-banner { flex-wrap: wrap; }
+  .config-val { max-width: none; white-space: normal; word-break: break-word; }
+}
 </style>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -52,24 +52,26 @@
       </div>
 
       <p v-if="!staffs.length && !showStaffForm" class="muted">No global staff configured.</p>
-      <table v-else-if="staffs.length" class="staff-table">
-        <thead>
-          <tr><th>@Name</th><th>Adapter</th><th>Model</th><th>Session</th><th>Default</th><th></th></tr>
-        </thead>
-        <tbody>
-          <tr v-for="s in staffs" :key="s.name">
-            <td><code>@{{ s.name }}</code></td>
-            <td>{{ s.adapter }}</td>
-            <td>{{ s.model || '—' }}</td>
-            <td>{{ s.session_scope }}</td>
-            <td>{{ s.is_default ? '✓' : '' }}</td>
-            <td class="actions">
-              <button class="action-btn" @click="startEditStaff(s)">Edit</button>
-              <button class="action-btn remove-btn" @click="deleteStaff(s.name)">✕</button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-else-if="staffs.length" class="table-wrap">
+        <table class="staff-table">
+          <thead>
+            <tr><th>@Name</th><th>Adapter</th><th>Model</th><th>Session</th><th>Default</th><th></th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="s in staffs" :key="s.name">
+              <td><code>@{{ s.name }}</code></td>
+              <td>{{ s.adapter }}</td>
+              <td>{{ s.model || '—' }}</td>
+              <td>{{ s.session_scope }}</td>
+              <td>{{ s.is_default ? '✓' : '' }}</td>
+              <td class="actions">
+                <button class="action-btn" @click="startEditStaff(s)">Edit</button>
+                <button class="action-btn remove-btn" @click="deleteStaff(s.name)">✕</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
 
     <!-- ── System Variables ──────────────────────────────────────────── -->
@@ -80,37 +82,39 @@
       <p class="muted hint">Credentials injected into every agent container. Set these to enable the corresponding features.</p>
       <p class="warn hint">⚠ Values are stored as plain text. Treat this database file as a sensitive asset.</p>
 
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Value</th><th></th></tr>
-        </thead>
-        <tbody>
-          <tr v-for="sv in systemVars" :key="sv.name">
-            <td><code>{{ sv.name }}</code></td>
-            <td class="config-val">
-              <template v-if="editingSysVar === sv.name">
-                <input v-model="sysVarEditValue" class="config-inline-input" @keydown.enter="saveSysVar(sv.name)" @keydown.escape="editingSysVar = null" />
-              </template>
-              <template v-else-if="config[sv.name] !== undefined">
-                <span v-if="sv.sensitive && !revealedKeys[sv.name]">••••••••</span>
-                <span v-else>{{ config[sv.name] }}</span>
-                <button v-if="sv.sensitive" class="reveal-btn" @click="toggleReveal(sv.name)">{{ revealedKeys[sv.name] ? 'hide' : 'show' }}</button>
-              </template>
-              <span v-else class="unset-label">— unset —</span>
-            </td>
-            <td class="sysvar-actions">
-              <template v-if="editingSysVar === sv.name">
-                <button class="action-btn" @click="saveSysVar(sv.name)">Save</button>
-                <button class="action-btn" @click="editingSysVar = null">Cancel</button>
-              </template>
-              <template v-else>
-                <button class="action-btn" @click="startEditSysVar(sv.name)">{{ config[sv.name] !== undefined ? 'Update' : 'Set' }}</button>
-                <button v-if="config[sv.name] !== undefined" class="action-btn remove-btn" @click="deleteConfigKey(sv.name)">Unset</button>
-              </template>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Value</th><th></th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="sv in systemVars" :key="sv.name">
+              <td><code>{{ sv.name }}</code></td>
+              <td class="config-val">
+                <template v-if="editingSysVar === sv.name">
+                  <input v-model="sysVarEditValue" class="config-inline-input" @keydown.enter="saveSysVar(sv.name)" @keydown.escape="editingSysVar = null" />
+                </template>
+                <template v-else-if="config[sv.name] !== undefined">
+                  <span v-if="sv.sensitive && !revealedKeys[sv.name]">••••••••</span>
+                  <span v-else>{{ config[sv.name] }}</span>
+                  <button v-if="sv.sensitive" class="reveal-btn" @click="toggleReveal(sv.name)">{{ revealedKeys[sv.name] ? 'hide' : 'show' }}</button>
+                </template>
+                <span v-else class="unset-label">— unset —</span>
+              </td>
+              <td class="sysvar-actions">
+                <template v-if="editingSysVar === sv.name">
+                  <button class="action-btn" @click="saveSysVar(sv.name)">Save</button>
+                  <button class="action-btn" @click="editingSysVar = null">Cancel</button>
+                </template>
+                <template v-else>
+                  <button class="action-btn" @click="startEditSysVar(sv.name)">{{ config[sv.name] !== undefined ? 'Update' : 'Set' }}</button>
+                  <button v-if="config[sv.name] !== undefined" class="action-btn remove-btn" @click="deleteConfigKey(sv.name)">Unset</button>
+                </template>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
 
     <!-- ── User-defined Config ────────────────────────────────────────── -->
@@ -128,18 +132,20 @@
       <p v-if="sysVarWarning" class="sysvar-warning">⚠ {{ sysVarWarning }}</p>
 
       <p v-if="!userConfigKeys.length" class="muted">No user-defined config keys set.</p>
-      <table v-else class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Value</th><th></th></tr>
-        </thead>
-        <tbody>
-          <tr v-for="key in userConfigKeys" :key="key">
-            <td><code>{{ key }}</code></td>
-            <td class="config-val">{{ isSensitive(key) ? '••••••••' : config[key] }}</td>
-            <td><button class="action-btn remove-btn" @click="deleteConfigKey(key)">✕</button></td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-else class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Value</th><th></th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="key in userConfigKeys" :key="key">
+              <td><code>{{ key }}</code></td>
+              <td class="config-val">{{ isSensitive(key) ? '••••••••' : config[key] }}</td>
+              <td><button class="action-btn remove-btn" @click="deleteConfigKey(key)">✕</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   </div>
 </template>
@@ -327,6 +333,7 @@ section { margin-bottom: 3rem; border-top: 1px solid #e2e8f0; padding-top: 1.5re
 .checkbox-label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9em; padding-top: 0.2rem; }
 .form-actions { display: flex; gap: 0.75rem; align-items: center; }
 
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .staff-table, .config-table { width: 100%; border-collapse: collapse; font-size: 0.9em; margin-top: 0.5rem; }
 .staff-table th, .config-table th { text-align: left; padding: 0.4rem 0.75rem; border-bottom: 2px solid #e2e8f0; color: #64748b; font-weight: 600; }
 .staff-table td, .config-table td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #f1f5f9; }
@@ -349,4 +356,24 @@ section { margin-bottom: 3rem; border-top: 1px solid #e2e8f0; padding-top: 1.5re
 .action-btn:hover { background: #eff6ff; }
 .remove-btn { color: #94a3b8; text-decoration: none; }
 .remove-btn:hover { background: #fee2e2; color: #dc2626; }
+
+@media (max-width: 768px) {
+  h1 { font-size: 1.5rem; margin-bottom: 1.25rem; }
+  section { margin-bottom: 2rem; padding-top: 1rem; }
+  .section-header { flex-wrap: wrap; gap: 0.5rem; }
+  .section-header h2 { font-size: 1.15rem; }
+  .card { padding: 1rem; }
+  .form-grid { grid-template-columns: 1fr; gap: 0.25rem 0; }
+  .form-grid label { padding-top: 0.25rem; font-weight: 500; }
+  .form-grid label + input,
+  .form-grid label + select,
+  .form-grid label + textarea,
+  .form-grid label + .checkbox-label { margin-bottom: 0.5rem; }
+  .form-actions { flex-wrap: wrap; }
+  .config-add-form { flex-wrap: wrap; }
+  .config-key-input { width: 100%; }
+  .config-val-input { width: 100%; flex: 1 1 100%; }
+  .config-add-form .btn-primary { width: 100%; }
+  .config-val { max-width: none; white-space: normal; word-break: break-word; }
+}
 </style>

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -669,4 +669,15 @@ onUnmounted(() => {
 .tool-use-fold > summary { cursor: pointer; list-style: none; }
 .tool-use-fold > summary::-webkit-details-marker { display: none; }
 .tool-use-fold[open] > summary { color: #ccc; }
+
+@media (max-width: 768px) {
+  .chat-layout { height: calc(100vh - 90px); }
+  .message { max-width: 90%; }
+  .message.agent { max-width: 96%; }
+  .bubble { padding: 0.5rem 0.75rem; }
+  .send-form { gap: 0.35rem; }
+  .send-form textarea { font-size: 16px; padding: 0.5rem 0.6rem; }
+  .send-form button { padding: 0.5rem 0.85rem; }
+  .breadcrumb { font-size: 0.8em; word-break: break-word; }
+}
 </style>

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -136,31 +136,33 @@
       </div>
 
       <p v-if="!staffs.length" class="muted">No staff configured.</p>
-      <table v-else class="staff-table">
-        <thead>
-          <tr><th>@Name</th><th>Adapter</th><th>Model</th><th>Session</th><th>Default</th><th>Source</th><th v-if="!isArchived"></th></tr>
-        </thead>
-        <tbody>
-          <tr v-for="s in staffs" :key="s.name" :class="{ inherited: s.inherited_from }">
-            <td><code>@{{ s.name }}</code></td>
-            <td>{{ s.adapter }}</td>
-            <td>{{ s.model || '—' }}</td>
-            <td>{{ s.session_scope }}</td>
-            <td>{{ s.is_default ? '✓' : '' }}</td>
-            <td>
-              <span v-if="s.inherited_from" class="badge-global">{{ s.inherited_from }}</span>
-              <span v-else class="badge-local">workspace</span>
-            </td>
-            <td v-if="!isArchived" class="actions">
-              <template v-if="!s.inherited_from">
-                <button class="action-btn" @click="startEditStaff(s)">Edit</button>
-                <button class="action-btn remove-btn" @click="deleteStaff(s.name)">✕</button>
-              </template>
-              <span v-else class="muted small">manage in <RouterLink to="/settings">Settings</RouterLink></span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-else class="table-wrap">
+        <table class="staff-table">
+          <thead>
+            <tr><th>@Name</th><th>Adapter</th><th>Model</th><th>Session</th><th>Default</th><th>Source</th><th v-if="!isArchived"></th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="s in staffs" :key="s.name" :class="{ inherited: s.inherited_from }">
+              <td><code>@{{ s.name }}</code></td>
+              <td>{{ s.adapter }}</td>
+              <td>{{ s.model || '—' }}</td>
+              <td>{{ s.session_scope }}</td>
+              <td>{{ s.is_default ? '✓' : '' }}</td>
+              <td>
+                <span v-if="s.inherited_from" class="badge-global">{{ s.inherited_from }}</span>
+                <span v-else class="badge-local">workspace</span>
+              </td>
+              <td v-if="!isArchived" class="actions">
+                <template v-if="!s.inherited_from">
+                  <button class="action-btn" @click="startEditStaff(s)">Edit</button>
+                  <button class="action-btn remove-btn" @click="deleteStaff(s.name)">✕</button>
+                </template>
+                <span v-else class="muted small">manage in <RouterLink to="/settings">Settings</RouterLink></span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   </div>
 </template>
@@ -450,7 +452,8 @@ onUnmounted(() => {
 <style scoped>
 .breadcrumb { font-size: 0.9em; color: #64748b; margin-bottom: 1rem; }
 .archived-banner { background: #fef9c3; border: 1px solid #fde047; border-radius: 6px; padding: 0.5rem 1rem; margin-bottom: 1rem; font-size: 0.9em; color: #713f12; }
-.agent-status-bar { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; font-size: 0.85em; }
+.agent-status-bar { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem; font-size: 0.85em; flex-wrap: wrap; }
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .agent-status-label { color: #64748b; }
 .status-badge { padding: 2px 10px; border-radius: 10px; font-weight: 600; font-size: 0.85em; }
 .status-running { background: #dcfce7; color: #15803d; }
@@ -527,4 +530,25 @@ section { margin-bottom: 2rem; }
 .branch-hint { color: #94a3b8; cursor: default !important; font-size: 0.85em; }
 .branch-hint:hover { background: none !important; }
 .repo-ref-badge { background: #dbeafe; color: #1d4ed8; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 500; margin-left: 0.25rem; }
+
+@media (max-width: 768px) {
+  h2 { font-size: 1.15rem; }
+  .breadcrumb { font-size: 0.85em; word-break: break-word; }
+  .header-row { flex-wrap: wrap; gap: 0.5rem; }
+  .agent-status-bar { gap: 0.4rem 0.5rem; }
+  .btn-refresh-auth { margin-left: 0; }
+  .create-form input { flex: 1 1 100%; min-width: 0; }
+  .branch-picker { flex: 1 1 100%; max-width: none; }
+  .create-form button { width: 100%; }
+  .list li { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .topic-row { flex-wrap: wrap; }
+  .card { padding: 1rem; }
+  .form-grid { grid-template-columns: 1fr; gap: 0.25rem 0; }
+  .form-grid label { padding-top: 0.25rem; font-weight: 500; }
+  .form-grid label + input,
+  .form-grid label + select,
+  .form-grid label + textarea,
+  .form-grid label + .checkbox-label { margin-bottom: 0.5rem; }
+  .form-actions { flex-wrap: wrap; }
+}
 </style>

--- a/frontend/src/views/WorkspaceList.vue
+++ b/frontend/src/views/WorkspaceList.vue
@@ -20,8 +20,10 @@
     <ul v-else class="list">
       <li v-for="ws in workspaces" :key="ws.id">
         <div class="list-row">
-          <RouterLink :to="`/workspaces/${ws.id}`">{{ ws.name }}</RouterLink>
-          <span class="muted small"> — {{ ws.repo_url }}</span>
+          <div class="ws-info">
+            <RouterLink :to="`/workspaces/${ws.id}`">{{ ws.name }}</RouterLink>
+            <span class="muted small ws-repo">{{ ws.repo_url }}</span>
+          </div>
           <button class="remove-btn" @click.prevent="deleteWorkspace(ws.id, ws.name)" title="Archive workspace">Archive</button>
         </div>
       </li>
@@ -92,11 +94,21 @@ h2 { margin: 0; }
 .list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
 .list li { background: #fff; padding: 0.75rem 1rem; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
 .list-row { display: flex; align-items: center; gap: 0.5rem; }
-.list-row a { font-weight: 500; }
-.list-row .muted { flex: 1; }
-.remove-btn { background: none; border: none; color: #94a3b8; cursor: pointer; font-size: 0.9em; padding: 0.15rem 0.4rem; border-radius: 3px; }
+.ws-info { display: flex; align-items: baseline; gap: 0.5rem; flex: 1; min-width: 0; flex-wrap: wrap; }
+.ws-info a { font-weight: 500; }
+.ws-repo { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
+.remove-btn { background: none; border: none; color: #94a3b8; cursor: pointer; font-size: 0.9em; padding: 0.15rem 0.4rem; border-radius: 3px; flex-shrink: 0; }
 .remove-btn:hover { background: #fee2e2; color: #dc2626; }
 .muted { color: #64748b; }
 .small { font-size: 0.85em; }
 .error { color: #dc2626; font-size: 0.9em; }
+
+@media (max-width: 768px) {
+  .header-row { flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem; }
+  h2 { font-size: 1.15rem; }
+  .create-form input { flex: 1 1 100%; min-width: 0; }
+  .create-form button { width: 100%; }
+  .ws-info { flex-direction: column; gap: 0.15rem; align-items: flex-start; }
+  .ws-repo { font-size: 0.8em; word-break: break-all; white-space: normal; }
+}
 </style>


### PR DESCRIPTION
## Summary

- Recent-topics sidebar collapses behind a hamburger toggle below 768px, slides in as a drawer with a backdrop, and auto-closes on navigation.
- Settings, WorkspaceDetail, and WorkspaceEnvVarsPanel: form grids stack labels above inputs on mobile, tables wrap in horizontal-scroll containers, and create-form/agent-status rows wrap.
- WorkspaceList rows stack name above repo URL on narrow screens; TopicChat tightens bubble widths and uses 16px textarea font to suppress iOS auto-zoom.
- Closes #157.

## Test plan

- [x] \`npm run build\` succeeds (vite build → src/master/static).
- [x] \`npm test -- --run\` — 11/11 unit tests pass.
- [x] Desktop (≥768px): sidebar visible by default, no hamburger; pages render unchanged.
- [x] Mobile (≤768px) — Recent topics: hamburger opens drawer; backdrop tap, link tap, and route change all close it.
- [x] Mobile — Settings: staff form labels stack above inputs; staff/system-vars/user-config tables scroll horizontally; \"Add / Update\" button is full-width.
- [x] Mobile — Workspace list: \"New Workspace\" form inputs stack vertically; workspace rows show name on top of repo URL.
- [x] Mobile — Workspace detail: agent-status bar wraps; topics list stacks Archive button below the row; staff table scrolls horizontally; env-vars form stacks.
- [x] Mobile — Topic chat: bubbles take ~90% width; send-form stays usable; iOS does not zoom on textarea focus.

🤖 Generated with repository automation