### PR TITLE
docs: release notes for v4.6

### DIFF
--- a/docs/releases/v4.6.md
+++ b/docs/releases/v4.6.md
@@ -1,0 +1,119 @@
+# Release Notes — v4.6
+
+**Base:** `master` @ `b23a5b9`
+**Release tag:** `v4.6`
+**Date:** 2026-05-08
+
+---
+
+## Summary
+
+v4.6 introduces **event-based staff actions** — the system can now bind in-system events to automatic Staff invocations, with the same session sharing and dispatch semantics as user-triggered messages.
+
+Topic-scope events covered in this release:
+
+- `topic_message_sent` (before / after a user message dispatches)
+- `topic_message_received` (after an agent reply lands)
+- `topic_scheduler` (cron-driven, minute resolution)
+- `topic_archived` (after a topic is archived)
+
+This is the first feature that introduces project-wide timezone awareness via the new `system.timezone` setting, and the first per-topic configurable surface in the UI.
+
+See [ADR-0013](../decisions/0013-event-based-staff-action.md), [design doc](../design/event-based-staff-action.md), and the [operator guide](../guides/event-actions.md).
+
+---
+
+## What's New
+
+### Event-Based Staff Actions
+
+Operators can now configure a Staff to fire automatically when any of the four supported events occur in a topic. The action is declarative, scoped to one topic, and shares the existing `staff_sessions` row with user-triggered invocations of the same Staff — meaning the agent stays inside the same conversation across both trigger paths.
+
+Each action carries a **prompt template** with `{variable}` placeholders that the dispatcher substitutes at fire time. Available variables differ by event type (`msgbody`, `topic_name`, `workspace_name`).
+
+Multiple actions on the same event fire in **parallel** and are independent: failure or timeout of one does not block siblings.
+
+### Single-Point Event Handling
+
+All emit sites (request handlers, MQTT thread, scheduler thread) call a single threadsafe `emit_event(...)` that pushes onto an `asyncio.Queue`. One async worker drains the queue, looking up matching actions, resolving Staffs, rendering templates, and calling the same `dispatch_to_staff` extracted from the user-message path. Per-dispatch timeout is 10 s; an observation-only stall watchdog logs WARN if the worker idles on a non-empty queue for over 60 s.
+
+### `system.timezone` Setting
+
+A new system-level setting (`GET / PATCH /api/config/system-settings`) controls how cron strings are interpreted. Default is the OS time zone via `tzlocal`; operators can override in `/settings`. Cron expressions are evaluated in this zone; storage continues to be UTC throughout.
+
+### Topic Settings Page
+
+`/workspaces/:wsId/topics/:topicId/settings` is a new SPA route hosting per-topic configuration. Reachable via gear icons on the topic chat header (`TopicChat.vue`) and on the topic-list rows (`WorkspaceDetail.vue`). v4.6 hosts only the event-actions card; future per-topic settings will land here.
+
+### Per-Action Observability
+
+Every action row carries `last_run_at`, `last_run_status` (`ok` / `staff_missing` / `render_error` / `dispatch_error`), and `last_run_output` (rendered prompt prefix on success, error message on failure). The action-list UI surfaces these inline with a coloured badge.
+
+---
+
+## API Surface
+
+| Method | Path | Notes |
+|---|---|---|
+| `GET / POST` | `/api/workspaces/{wid}/topics/{tid}/event-actions` | List, create |
+| `GET / PATCH / DELETE` | `/api/workspaces/{wid}/topics/{tid}/event-actions/{id}` | Read, update, delete |
+| `GET / PATCH` | `/api/config/system-settings` | Read, update `system.timezone` |
+
+POST and PATCH bodies use `extra='forbid'`: unknown fields return 422. PATCH uses `model_dump(exclude_unset=True)` so explicit `null` is distinguishable from omitted (lets you clear nullable fields like `timing` on `topic_archived`). Cron strings are validated as exactly 5-field; the 6-field with-seconds variant is rejected (sub-minute precision is out of scope).
+
+`messages.sender` now accepts `'event'` in addition to `'user'` and `'agent'`. Event-triggered messages carry this sender so message-event hooks gate on `sender='user'` / `sender='agent'` and never re-fire themselves.
+
+---
+
+## Schema Changes
+
+New table `event_actions` added to `_SCHEMA` (idempotent CREATE TABLE IF NOT EXISTS). Pure additive — no row-level migration required. Existing deployments pick up the new table on next process start.
+
+Columns of note:
+
+- `last_fired_at` — scheduler watermark, advanced by the tick *before* enqueue (optimistic; trade-off documented in ADR-0013).
+- `last_run_at` / `last_run_status` / `last_run_output` — written by the worker after each dispatch attempt; distinct from `last_fired_at`.
+
+---
+
+## Dependencies
+
+- `croniter>=2.0.0` — cron expression parsing in the scheduler tick.
+- `tzlocal>=5.0` — OS-level time zone discovery for `system.timezone` default.
+
+---
+
+## Migration Notes
+
+No operator action required. The first process start after upgrade creates the `event_actions` table; the `system.timezone` setting initialises to the OS zone on first read.
+
+To begin using the feature, navigate to a topic in the UI and click the gear icon to reach the new Topic Settings page. Configure actions there.
+
+---
+
+## Out of Scope (Tracked for Future Work)
+
+- **Backpressure / spillover policy** for long-running scheduler actions — [#154](https://github.com/pandazxx/codex-slack/issues/154).
+- **Vetoable `topic_archiving` event** (pre-commit interceptor with structured response) — [#156](https://github.com/pandazxx/codex-slack/issues/156).
+- **Project-wide timezone-awareness audit** of every existing `*_at` column and date-rendering site — [#158](https://github.com/pandazxx/codex-slack/issues/158).
+- **Workspace-scope events** — schema admits `scope_type='workspace'` for forward compatibility, but only `'topic'` is implemented in v4.6.
+
+---
+
+## Validation
+
+- Unit + integration: 326 passed, 1 skipped (FANOUT-03 — wall-clock parallel-fanout timing, marked `needs-human`), 0 failed.
+- Stack tests at the testbed (`v4.6-rc4`): CRUD round-trip, validation matrix (5-field cron, extra_forbidden, cross-field 422), edit-prompt + edit-cron, SPA route, and the `topic_archived timing='after'` regression all green.
+- Frontend UAT: all 15 `needs-human` cases (FE-01–FE-15) signed off in [PR #163](https://github.com/pandazxx/codex-slack/pull/163).
+- Two reviewer passes: 2 blockers + 8 non-blocking findings all addressed before merge.
+
+---
+
+## Related
+
+- [ADR-0013: Event-based staff actions](../decisions/0013-event-based-staff-action.md)
+- [Design doc](../design/event-based-staff-action.md)
+- [Test plan](../test-plans/event-based-staff-action.md)
+- [Operator guide](../guides/event-actions.md)
+- Original issue: [#143](https://github.com/pandazxx/codex-slack/issues/143)
+- Merge PR: [#163](https://github.com/pandazxx/codex-slack/pull/163)


### PR DESCRIPTION
## Summary

- Adds `docs/releases/v4.6.md` covering the event-based staff actions release.
- v4.6 release tag already pushed; promote-release workflow has retagged `:rc` → `:v4.6` on GHCR.

## Test plan

- [x] File structure and content reviewed against existing release notes (`v3.9.md`)
- [ ] Reviewer eye on accuracy (links, version numbers, follow-up issue numbers)

🤖 Generated with repository automation