### PR TITLE
feat: vetoable topic_archiving pre-commit interceptor (ADR-0014)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,72 @@
+FROM python:3.11-slim
+
+ARG CODEX_NPM_PACKAGE=@openai/codex
+ARG CLAUDE_NPM_PACKAGE=@anthropic-ai/claude-code
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Add Docker's official apt repo so we get docker-ce-cli + compose plugin.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+       https://download.docker.com/linux/debian \
+       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    docker-ce-cli \
+    docker-compose-plugin \
+    git \
+    gh \
+    jq \
+    less \
+    make \
+    mosquitto-clients \
+    openssh-client \
+    poppler-utils \
+    tini \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
+
+RUN useradd -m -u 1000 -s /bin/bash appuser \
+    && mkdir -p /workspace/home /home/appuser/.claude /opt/codex-slack/data/master \
+    && chown -R appuser:appuser /workspace /home/appuser/.claude /opt/codex-slack
+
+WORKDIR /opt/codex-slack
+
+# Install Python deps globally (before USER switch) so pytest and other
+# entrypoints land in /usr/local/bin and resolve under tini, which does not
+# extend PATH for the exec'd command.
+COPY requirements.txt ./requirements.txt
+RUN python -m pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+USER appuser
+
+COPY --chown=appuser:appuser frontend/package.json frontend/package-lock.json* ./frontend/
+RUN cd frontend && npm ci --prefer-offline 2>/dev/null || npm install
+
+# Copy all files needed at test time (avoids bind-mount dependency,
+# enabling remote DOCKER_HOST=ssh://... runs without local paths).
+COPY --chown=appuser:appuser src ./src
+COPY --chown=appuser:appuser tests ./tests
+COPY --chown=appuser:appuser frontend ./frontend
+COPY --chown=appuser:appuser config ./config
+COPY --chown=appuser:appuser Dockerfile.agent-minimal ./
+COPY --chown=appuser:appuser docker ./docker
+
+# Default command runs pytest; override in compose for other test commands
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["pytest", "-vv", "tests/", "--tb=short"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,20 +1,23 @@
-# CI override — used by GitHub Actions for test runs.
-# Builds the test stage of Dockerfile. No Traefik labels; no published ports.
+# CI testing configuration — runs tests in container
+# Invoked by CI workflows and .sre/test.sh via:
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml ...
+#
+# Dockerfile.test bakes src+tests into the image so no volume mounts are needed,
+# enabling use with remote Docker hosts (DOCKER_HOST=ssh://...) as well as CI runners.
+
 services:
   master:
     build:
       context: .
-      dockerfile: Dockerfile
-      target: test
-    deploy:
-      resources:
-        limits:
-          memory: 1g
-          cpus: "1.0"
-
-  mosquitto:
-    deploy:
-      resources:
-        limits:
-          memory: 128m
-          cpus: "0.25"
+      dockerfile: Dockerfile.test
+    image: codex-slack:test
+    working_dir: /opt/codex-slack
+    environment:
+      PYTHONDONTWRITEBYTECODE: "1"
+      PYTHONUNBUFFERED: "1"
+      PYTHONPATH: "/opt/codex-slack"
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+    networks:
+      - internal

--- a/docs/decisions/0014-vetoable-topic-archiving-event.md
+++ b/docs/decisions/0014-vetoable-topic-archiving-event.md
@@ -1,0 +1,269 @@
+---
+title: "ADR-0014: Vetoable topic_archiving event (pre-commit interceptor)"
+status: accepted
+date: 2026-05-09
+decision-makers: [architect, engineer]
+consulted: [tester, sre]
+informed: [doc-writer, users]
+---
+
+## Context and Problem Statement
+
+ADR-0013 ships `topic_archived` as an observe-only **post-commit** event: the topic is archived
+first, the event fires afterwards, and the resulting agent reply lands in the archived view.
+
+Operators have asked for the opposite: a **pre-commit** event that runs a staff *before* the
+archive transition completes and can **veto** it (example: "don't archive — there are unanswered
+review comments"). This is the `topic_archiving` event, where the `-ing` suffix is reserved in
+v1 for pre-commit interceptors.
+
+This ADR describes v2 of event-based staff actions, scoped to the archive use-case, with the
+interceptor pattern designed for generalisation to other pre-commit events in future.
+
+See GitHub issue [#156](https://github.com/pandazxx/codex-slack/issues/156).
+
+## Decision Drivers
+
+- **Pre-commit semantics.** The event must fire before `archived_at` is committed; the archive
+  must be contingent on every matching action's verdict.
+- **Synchronous HTTP response.** The caller of `DELETE /…/topics/{tid}` needs a definitive answer
+  (archived, vetoed, or timeout) in the same HTTP response. No polling.
+- **Structured verdict protocol.** Free-form text replies are insufficient; a machine-readable
+  `{verdict, reason}` contract is required between master and agent.
+- **Agent adapter transparency.** The agent is prompted with natural language and emits JSON; no
+  new CLI flags needed. The adapter layer in the agent container extracts the verdict from the
+  LLM output.
+- **Additive, not breaking.** Existing `topic_archived` (post-commit) and all v1 event_actions
+  mechanics remain unchanged. `topic_archiving` is a new event_type alongside them.
+- **Operator escape hatch.** A veto should never permanently block an archive. An `override`
+  query parameter on the archive endpoint lets operators bypass interceptors when needed.
+- **Generalisation path.** The structured-verdict protocol and synchronous-await dispatch path
+  introduced here are the building blocks for future pre-commit interceptors
+  (`topic_message_sending`, `topic_creating`, etc.) — design once, not ad hoc.
+
+## Considered Options
+
+### Synchronous-await dispatch path
+
+A. **asyncio.Future per prompt message_id, resolved by MQTT verdict handler.** `veto_dispatch()`
+   dispatches staff (publishes MQTT prompt), registers a `Future` in `app_state.veto_futures` keyed
+   by the prompt's `message_id`, then awaits all futures with a hard timeout.
+B. **Polling a new DB column.** `veto_dispatch()` writes a pending row; the MQTT handler updates
+   it; the endpoint polls via `asyncio.sleep` loop.
+C. **In-process synchronous subprocess.** Run the agent LLM inline in a thread and await the
+   thread result. Breaks session sharing and the MQTT contract.
+
+### Structured verdict protocol
+
+P. **New MQTT `/verdict` subtopic.** Agent publishes `{reply_to, verdict, reason}` there when
+   `response_mode="verdict"` is set in the prompt payload. Master subscribes to `/verdict` and
+   routes by `reply_to` to the waiting Future. The normal `/response` message also fires so the
+   agent's text reasoning lands in the topic chat.
+Q. **Parse verdict from `/response` payload.** No new subtopic; master tries to JSON-parse the
+   response text for a verdict object.
+R. **New `verdict` field in the existing `/response` payload.** Structurally extends the current
+   protocol without a new subtopic.
+
+### Timeout fallback policy
+
+T1. **504 Gateway Timeout to caller; override available.** If the veto staff does not respond
+    within N seconds, the API returns 504. The frontend offers "Override and archive anyway".
+T2. **Auto-allow (silently archive).** Timeout is treated as implicit allow.
+T3. **Auto-deny (require manual override).** Timeout blocks the archive until an explicit
+    `?override=true` request.
+
+### Multiple-action semantics
+
+M1. **First-deny-wins.** Any action that denies blocks the archive. All actions that allow must
+    complete (or time out) before allow is confirmed.
+M2. **Majority/quorum.** More complex; no operator demand.
+M3. **Last-action-wins.** Non-deterministic with parallel dispatch.
+
+### Override mechanism
+
+O1. **Query param `?override=true`.** Skips veto checks; proceeds directly to archive.
+O2. **Separate admin endpoint.** Adds surface area; no benefit for v1.
+
+## Decision Outcome
+
+**Chosen: A + P + T1 + M1 + O1.** Concretely:
+
+### 1. New event type: `topic_archiving`
+
+A new `event_type='topic_archiving'` is added to `event_actions`. Constraints:
+
+- `timing` must be `NULL` (timing is implicit: always pre-commit).
+- `cron_expr` must be `NULL` (not a scheduler event).
+- Validation mirrors `topic_archived` except the semantics are pre-commit.
+
+The DB schema CHECK constraint is updated via a table-recreation migration (SQLite cannot modify
+CHECK constraints in-place).
+
+### 2. New `last_run_status` values
+
+`vetoed` and `veto_timeout` are added to the `last_run_status` CHECK so operators can see whether
+a veto action denied or timed out in the event-actions panel. The same migration that rebuilds
+the `event_actions` table adds these values.
+
+### 3. Synchronous-await dispatch via asyncio.Future (option A)
+
+`veto_dispatch()` in `event_dispatcher.py`:
+
+1. Queries `event_actions` for all enabled `topic_archiving` rows for the topic.
+2. For each, resolves the staff and renders the template (same path as `_dispatch_one`).
+3. Calls `dispatch_to_staff(…, response_mode="verdict")` to publish the MQTT prompt and get
+   back a `message_id`.
+4. Registers `app_state.veto_futures[message_id] = asyncio.Future()`.
+5. `asyncio.wait(futures, timeout=VETO_TIMEOUT_S)` — default **30 s**.
+6. Returns a `VetoResult(allowed, reason, timed_out)` named tuple.
+
+`veto_futures` is a `dict[str, asyncio.Future]` initialised on `app_state` in the FastAPI
+lifespan. Entries are removed after `asyncio.wait` completes (or times out), whether or not the
+Future was resolved.
+
+### 4. MQTT `/verdict` subtopic (option P)
+
+The agent container's `mqtt_loop.py` is extended:
+
+- When `response_mode="verdict"` is present in the prompt payload, after the LLM call completes,
+  `_extract_verdict(response_text)` parses the last JSON object in the output for
+  `{verdict: "allow"|"deny", reason: "..."}`. Falls back to `{"verdict": "allow", "reason": "(no verdict found)"}` if
+  the LLM output contains no parseable JSON verdict.
+- The agent publishes on `codex-slack/workspace/{wid}/topic/{tid}/verdict` with
+  `{reply_to: message_id, verdict, reason, agent_name}` (QoS 1).
+- The agent **also** publishes on `/response` as normal, so the reasoning text lands in the
+  topic chat for the operator to read.
+
+The master subscribes to `codex-slack/workspace/+/topic/+/verdict` (QoS 1). In `_on_message`,
+when `msg_type == "verdict"`, it calls `loop.call_soon_threadsafe` to look up
+`app_state.veto_futures[reply_to]` and set its result if still pending.
+
+### 5. Archive endpoint contract (option T1)
+
+`DELETE /api/workspaces/{wid}/topics/{tid}` becomes `async def` and gains
+`override: bool = False` (query param).
+
+| Scenario | HTTP status | Body |
+|---|---|---|
+| No `topic_archiving` actions, or all allowed | 204 | (empty) |
+| At least one action denied | 423 Locked | `{"reason": "..."}` |
+| Veto staff did not respond within 30 s | 504 Gateway Timeout | `{"reason": "veto staff did not respond in time"}` |
+| `?override=true` | 204 | (empty — veto skipped) |
+
+On 423 or 504, the frontend renders the reason and offers an "Override and archive anyway" button
+that re-issues `DELETE` with `?override=true`.
+
+`topic_archived` (post-commit) still fires on all successful archives (override or normal).
+
+### 6. Multiple-action semantics (option M1)
+
+If multiple `topic_archiving` actions exist, they all dispatch in parallel (same
+`asyncio.gather` pattern as `_handle_event`). First deny wins: as soon as one Future resolves
+with `verdict=deny`, `veto_dispatch` can short-circuit. In practice `asyncio.wait` collects all
+completed futures and we scan them; we do not cancel the remaining pending futures early
+(they run to completion or timeout for observability). The `vetoed` status is recorded for the
+denying action; `ok` for the allowing ones.
+
+### 7. `response_mode` in dispatch payload (option P)
+
+`dispatch_to_staff()` gains an optional `response_mode: str | None = None` parameter. When
+non-None, the value is included in the MQTT prompt payload as `"response_mode"`. Existing callers
+pass nothing and are unaffected. Event-worker (`_dispatch_one`) does not pass `response_mode`,
+preserving the fire-and-forget semantics of `topic_archived` and other post-commit events.
+
+### Alignment with ADR-0013
+
+- The existing queue + worker remains unchanged. `topic_archiving` does **not** go through the
+  queue; it uses its own synchronous-await path in `veto_dispatch`. This is the minimum change:
+  pre-commit interceptors need a return value; the queue is fire-and-forget by design.
+- Loop prevention: `veto_dispatch` calls `dispatch_to_staff(sender="event")`, same as the
+  existing event worker. Agent replies to veto prompts carry `sender="agent"` and fire
+  `topic_message_received` normally, but the verdict machinery is separate.
+- `topic_archived` still fires post-commit on successful archives (including overrides), giving
+  the post-commit summariser use-case an unchanged trigger.
+
+### Generalisation path
+
+The `_extract_verdict` / `/verdict` protocol is generic — the same mechanism would serve
+`topic_message_sending` or `topic_creating` interceptors. The only archive-specific pieces are
+the `veto_dispatch` call site in `topics.py` and the event_type value. Future pre-commit events
+add a new `event_type` and a new `veto_dispatch` call at their emit site; no protocol changes
+needed.
+
+### Consequences
+
+- **Good**
+  - Operators get a genuine pre-commit veto: archive is only committed after every enabled
+    interceptor says allow.
+  - 30 s timeout + 504 response + override button gives operators agency when agents are slow
+    or misconfigured — no topic can be permanently un-archivable.
+  - The `/verdict` subtopic is additive — agent containers that don't know about `response_mode`
+    just publish `/response` as before; no veto fires and `veto_futures` entries time out
+    (defaulting to 504, resolved by `?override=true`).
+  - `last_run_status` records `vetoed` or `veto_timeout` per action, surfaced in the UI event
+    panel alongside existing `ok`/`staff_missing`/`render_error`/`dispatch_error` statuses.
+  - The prompt template can include any instructions the operator wants; the agent reasons freely
+    and the adapter extracts the verdict JSON from the last JSON object in the output — no new
+    CLI flags needed.
+- **Bad / accepted tradeoffs**
+  - `DELETE /…/topics/{tid}` is now potentially slow (up to 30 s). Clients must not assume the
+    endpoint is fast. The frontend shows a loading state.
+  - If no `topic_archiving` actions exist, the endpoint is unchanged in latency (same as before).
+  - Veto JSON extraction relies on the agent following the prompt instructions. A poorly written
+    template may produce no JSON verdict; the agent defaults to `allow`, which is permissive but
+    safe (archive proceeds). Operators should test their templates.
+  - A single slow or hung agent can block an archive for 30 s. The timeout bounds this; the
+    override bypass removes the ceiling entirely.
+  - The verdict Future dict (`app_state.veto_futures`) is in-memory: a master restart while a
+    veto is in-flight will drop the Future, and the HTTP request will receive a 504 (the client
+    can then retry with `?override=true`). Acceptable for v1.
+  - Parallel multi-action veto with first-deny-wins does not cancel already-dispatched sibling
+    agents. Agents that are still running will eventually publish a verdict that is ignored
+    (Future is gone). This is benign — they may leave a chat message in the topic.
+
+### Confirmation
+
+- Unit tests in `tests/master/test_topic_archiving_veto.py`:
+  - Allow path: `veto_dispatch` resolves all Futures with `allow` → `delete_topic` returns 204.
+  - Deny path: at least one Future resolves with `deny` + reason → 423 with body.
+  - Timeout path: Futures not resolved within VETO_TIMEOUT_S → 504.
+  - Override path: `?override=true` skips `veto_dispatch` entirely → 204.
+  - No actions path: no `topic_archiving` rows → `veto_dispatch` returns immediately → 204.
+  - `topic_archived` still fires after a successful (allowed or override) archive.
+  - `last_run_status` recorded correctly for allow, deny, timeout, staff-missing cases.
+- Agent tests (`tests/agent/test_mqtt_loop.py`):
+  - `_extract_verdict` extracts `{verdict, reason}` from inline JSON, trailing JSON, and falls
+    back to `allow` when no JSON found.
+  - `_process_prompt` with `response_mode="verdict"` publishes on `/verdict` in addition to
+    `/response`.
+- Integration test (dev env):
+  - Configure a `topic_archiving` action invoking `@reviewer`; attempt archive; observe 423 when
+    the staff's template asks it to deny; observe 204 after `?override=true`. `automated`.
+  - Configure a `topic_archiving` action against a stopped agent; observe 504 after 30 s
+    (adjusted to a shorter timeout in test config). `automated`.
+
+## Pros and Cons of the Options
+
+### Synchronous-await dispatch path
+
+| Option | Pro | Con |
+|---|---|---|
+| A — asyncio.Future + veto_futures dict (chosen) | Zero new I/O; reuses existing async event loop; Futures can be resolved from the MQTT thread via call_soon_threadsafe | In-memory: crash drops pending futures (resolved by 504 + override) |
+| B — DB polling | Durable across restarts | ~1 s polling latency per action; more complex; extra column/table |
+| C — inline subprocess | Simple to reason about | Breaks session sharing; bypasses MQTT contract; not compatible with remote agent containers |
+
+### Structured verdict protocol
+
+| Option | Pro | Con |
+|---|---|---|
+| P — new /verdict subtopic (chosen) | Clean separation; /response still lands in chat; no ambiguity between text and verdict | New MQTT subscription on master and new publish path on agent |
+| Q — parse /response payload | No new subtopic | Ambiguous for text that happens to contain JSON; /response already saved as a chat message before verdict is acted on |
+| R — verdict field in /response payload | No new subtopic; one publish | Couples the agent-response-saving path to the veto logic; harder to test independently |
+
+### Timeout fallback policy
+
+| Option | Pro | Con |
+|---|---|---|
+| T1 — 504 + override (chosen) | Operator sees the timeout; override gives agency; no silent data loss | Slower UX if agents are systematically slow |
+| T2 — auto-allow | No UX disruption for slow agents | Silently archives even when the veto staff is unhealthy; undermines the veto contract |
+| T3 — auto-deny | Safest | Permanently blocks archive if agent is down; operator has no path forward without admin intervention |

--- a/docs/test-plans/topic-archiving-veto.md
+++ b/docs/test-plans/topic-archiving-veto.md
@@ -1,0 +1,242 @@
+# Test Plan: Vetoable topic_archiving event
+
+**Design doc:** [ADR-0014](../decisions/0014-vetoable-topic-archiving-event.md)
+**Feature issue:** #156
+
+---
+
+## Scope
+
+Covers the `topic_archiving` pre-commit interceptor: the synchronous-await dispatch path,
+structured verdict protocol, API contract changes (423 / 504), frontend veto dialog, and
+operator override. Does not cover the existing `topic_archived` post-commit event (covered
+by prior test suite).
+
+---
+
+## Test Cases
+
+### TC-01 — No topic_archiving actions: archive proceeds normally
+
+**Type:** automated (unit)
+**Path:** allow
+
+1. Create workspace + topic.
+2. No `topic_archiving` event_actions for the topic.
+3. `DELETE /api/workspaces/{wid}/topics/{tid}` → **204**.
+4. Topic has `archived_at` set in DB.
+5. `topic_archived` post-commit event fires (existing behaviour unchanged).
+
+---
+
+### TC-02 — Allow path: veto staff returns allow
+
+**Type:** automated (unit)
+**Path:** allow
+
+1. Create workspace + topic.
+2. Create a `topic_archiving` event_action on the topic (staff: a mock/stub).
+3. Stub `dispatch_to_staff` to succeed and immediately resolve the veto Future with
+   `{"verdict": "allow", "reason": ""}`.
+4. `DELETE /api/workspaces/{wid}/topics/{tid}` → **204**.
+5. `topic_archived` fires; topic `archived_at` is set.
+6. `last_run_status = 'ok'` recorded for the event_action.
+
+---
+
+### TC-03 — Deny path: veto staff returns deny
+
+**Type:** automated (unit)
+**Path:** deny
+
+1. Create workspace + topic with a `topic_archiving` event_action.
+2. Stub veto Future to resolve with `{"verdict": "deny", "reason": "unanswered review comments"}`.
+3. `DELETE /api/workspaces/{wid}/topics/{tid}` → **423 Locked**.
+4. Response body: `{"detail": {"reason": "unanswered review comments"}}`.
+5. Topic `archived_at` is **not** set.
+6. `topic_archived` does **not** fire.
+7. `last_run_status = 'vetoed'`; `last_run_output` contains the reason.
+
+---
+
+### TC-04 — Timeout path: veto staff does not respond
+
+**Type:** automated (unit — VETO_TIMEOUT_S patched to 0.1 s)
+**Path:** timeout
+
+1. Create workspace + topic with a `topic_archiving` event_action.
+2. Stub `dispatch_to_staff` to succeed but never resolve the veto Future.
+3. `DELETE /api/workspaces/{wid}/topics/{tid}` → **504 Gateway Timeout** (after ≤0.1 s).
+4. Response body: `{"detail": {"reason": "veto staff did not respond in time"}}`.
+5. Topic `archived_at` is **not** set.
+6. `last_run_status = 'veto_timeout'` recorded.
+
+---
+
+### TC-05 — Override path: bypass veto with ?override=true
+
+**Type:** automated (unit)
+**Path:** override
+
+1. Create workspace + topic with a `topic_archiving` event_action that would deny.
+2. `DELETE /api/workspaces/{wid}/topics/{tid}?override=true` → **204**.
+3. `veto_dispatch` is **not called** (no dispatch to staff).
+4. Topic `archived_at` is set.
+5. `topic_archived` fires normally.
+
+---
+
+### TC-06 — Multiple actions: first-deny-wins
+
+**Type:** automated (unit)
+**Path:** deny
+
+1. Create topic with two `topic_archiving` actions.
+2. First action resolves `allow`; second resolves `deny`.
+3. `DELETE` → **423**.
+4. `last_run_status = 'ok'` for the allow action; `'vetoed'` for the deny action.
+
+---
+
+### TC-07 — Multiple actions: all allow → proceeds
+
+**Type:** automated (unit)
+**Path:** allow
+
+1. Two `topic_archiving` actions both resolving `allow`.
+2. `DELETE` → **204**.
+3. Both actions have `last_run_status = 'ok'`.
+
+---
+
+### TC-08 — Staff missing: action skipped, archive proceeds
+
+**Type:** automated (unit)
+
+1. `topic_archiving` action references a deleted/non-existent staff.
+2. `DELETE` → **204** (no veto Future registered; `veto_dispatch` returns allow).
+3. `last_run_status = 'staff_missing'`.
+
+---
+
+### TC-09 — Disabled action: not dispatched
+
+**Type:** automated (unit)
+
+1. `topic_archiving` action with `enabled=false`.
+2. `DELETE` → **204** without dispatching (same as no actions).
+
+---
+
+### TC-10 — topic_archiving CRUD: create/list/get/patch/delete
+
+**Type:** automated (unit)
+
+1. POST `topic_archiving` with valid body (no timing/cron) → 201.
+2. GET → action listed.
+3. PATCH → update `prompt_template` → 200.
+4. POST with `timing='before'` → **422** (timing must be null or 'after').
+5. POST with `cron_expr='* * * * *'` → **422** (cron_expr must be null).
+6. DELETE → 204; GET → 404.
+
+---
+
+### TC-11 — DB migration: existing databases gain topic_archiving
+
+**Type:** automated (unit)
+
+1. Create a DB with the old schema (no `topic_archiving` in event_type CHECK).
+2. Run `init_db`.
+3. INSERT `topic_archiving` row → succeeds.
+4. INSERT old `topic_archived` row → still succeeds (existing data unaffected).
+
+---
+
+### TC-12 — Agent verdict extraction: inline JSON
+
+**Type:** automated (unit — `_extract_verdict`)
+
+1. Input: `'{"verdict": "deny", "reason": "open PRs exist"}'`
+2. Output: `{"verdict": "deny", "reason": "open PRs exist"}`.
+
+---
+
+### TC-13 — Agent verdict extraction: trailing JSON in prose
+
+**Type:** automated (unit — `_extract_verdict`)
+
+1. Input: `'After reviewing the topic, I recommend holding off.\n\n{"verdict": "deny", "reason": "2 unanswered questions"}'`
+2. Output: `{"verdict": "deny", "reason": "2 unanswered questions"}`.
+
+---
+
+### TC-14 — Agent verdict extraction: no JSON falls back to allow
+
+**Type:** automated (unit — `_extract_verdict`)
+
+1. Input: `'This topic looks good to archive.'`
+2. Output: `{"verdict": "allow", "reason": "(no verdict found in response)"}`.
+
+---
+
+### TC-15 — Agent: response_mode=verdict publishes on /verdict and /response
+
+**Type:** automated (unit — `_process_prompt` patched)
+
+1. Payload includes `response_mode="verdict"`.
+2. After LLM call, agent publishes on `/verdict` (QoS 1) with `{reply_to, verdict, reason, agent_name}`.
+3. Agent also publishes on `/response` as normal (text message appears in topic chat).
+
+---
+
+### TC-16 — Frontend: veto dialog shown on 423, override proceeds
+
+**Type:** needs-human (visual)
+
+1. Configure a `topic_archiving` action whose template causes the agent to deny.
+2. Click Archive on a topic.
+3. Observe the loading state ("Archiving…") on the button while the veto runs.
+4. Observe the veto dialog: heading "Archive blocked", topic name, reason text, "Override and archive anyway" + "Cancel".
+5. Click "Override and archive anyway" → topic disappears from active list.
+
+---
+
+### TC-17 — Frontend: veto dialog shown on 504
+
+**Type:** needs-human (visual)
+
+1. Archive a topic when the agent container is stopped.
+2. After 30 s (or a shortened test timeout), the veto dialog appears with heading "Veto staff timed out" and the timeout message.
+3. Click "Cancel" → dialog closes; topic remains active.
+4. Click Archive again → veto dialog appears again.
+
+---
+
+### TC-18 — Integration: full allow path against dev env
+
+**Type:** automated (stack)
+
+1. Configure a `topic_archiving` action invoking `@reviewer` with a template that asks it to allow.
+2. `DELETE /api/…/topics/{tid}` → 204.
+3. Agent's reasoning text appears in the topic's message history.
+4. Topic appears in archived list.
+
+---
+
+### TC-19 — Integration: full deny path against dev env
+
+**Type:** automated (stack)
+
+1. Configure a `topic_archiving` action with a template that instructs the agent to deny with a specific reason.
+2. `DELETE /api/…/topics/{tid}` → 423 with the reason in the body.
+3. Topic remains in active list.
+4. Agent's text reply (the reasoning) appears in the topic's message history.
+
+---
+
+## Pass / Fail Criteria
+
+- All automated unit tests pass (`tests/master/test_topic_archiving_veto.py`; `tests/agent/test_mqtt_loop.py`).
+- TC-16 and TC-17 signed off by a human reviewer in the PR.
+- No regression in existing `topic_archived` tests.
+- `DELETE /api/workspaces/{wid}/topics/{tid}` without any `topic_archiving` actions: latency unchanged (< 200 ms).

--- a/frontend/src/views/TopicSettings.vue
+++ b/frontend/src/views/TopicSettings.vue
@@ -33,7 +33,14 @@
           </select>
 
           <label>Staff <span class="req">*</span></label>
-          <input v-model="form.staff_name" placeholder="e.g. reviewer" />
+          <select v-model="form.staff_name">
+            <option value="" disabled>— select staff —</option>
+            <template v-for="group in staffGroups" :key="group.label">
+              <optgroup :label="group.label">
+                <option v-for="s in group.items" :key="s.name" :value="s.name">{{ s.name }}</option>
+              </optgroup>
+            </template>
+          </select>
 
           <label>Prompt template <span class="req">*</span></label>
           <div>
@@ -144,6 +151,7 @@ const saving = ref(false)
 const formError = ref('')
 const configuredTimezone = ref(Intl.DateTimeFormat().resolvedOptions().timeZone)
 const expandedOutputs = ref({})
+const staffGroups = ref([])
 
 const emptyForm = () => ({
   event_type: 'topic_message_sent',
@@ -170,10 +178,13 @@ const variableHint = computed(() => {
 async function load() {
   loading.value = true
   try {
-    const [topicRes, actionsRes, tzRes] = await Promise.all([
+    const [topicRes, actionsRes, tzRes, globalStaffRes, wsStaffRes, topicStaffRes] = await Promise.all([
       fetch(`/api/workspaces/${wsId}/topics/${topicId}`),
       fetch(`/api/workspaces/${wsId}/topics/${topicId}/event-actions`),
       fetch('/api/config/system-settings'),
+      fetch('/api/staffs'),
+      fetch(`/api/workspaces/${wsId}/staffs`),
+      fetch(`/api/workspaces/${wsId}/topics/${topicId}/staffs`),
     ])
     if (topicRes.ok) {
       const t = await topicRes.json()
@@ -186,6 +197,20 @@ async function load() {
         ? tz.timezone
         : Intl.DateTimeFormat().resolvedOptions().timeZone
     }
+    const groups = []
+    if (topicStaffRes.ok) {
+      const items = (await topicStaffRes.json()).filter(s => !s.inherited_from)
+      if (items.length) groups.push({ label: 'Topic', items })
+    }
+    if (wsStaffRes.ok) {
+      const items = (await wsStaffRes.json()).filter(s => !s.inherited_from)
+      if (items.length) groups.push({ label: 'Workspace', items })
+    }
+    if (globalStaffRes.ok) {
+      const items = (await globalStaffRes.json()).filter(s => !s.inherited_from)
+      if (items.length) groups.push({ label: 'Global', items })
+    }
+    staffGroups.value = groups
   } finally {
     loading.value = false
   }

--- a/frontend/src/views/TopicSettings.vue
+++ b/frontend/src/views/TopicSettings.vue
@@ -29,6 +29,7 @@
             <option value="topic_message_received">topic_message_received — agent replies</option>
             <option value="topic_scheduler">topic_scheduler — cron schedule</option>
             <option value="topic_archived">topic_archived — topic is archived</option>
+            <option value="topic_archiving">topic_archiving — before topic is archived (veto)</option>
           </select>
 
           <label>Staff <span class="req">*</span></label>
@@ -161,6 +162,7 @@ const variableHint = computed(() => {
     topic_message_received: '{msgbody}, {response_json}, {topic_name}, {topic_json}',
     topic_scheduler: '{topic_name}, {workspace_name}, {topic_json}',
     topic_archived: '{topic_name}, {topic_json}',
+    topic_archiving: '{topic_name}, {topic_json}',
   }
   return m[form.value.event_type] || ''
 })
@@ -305,6 +307,7 @@ function typeBadgeClass(eventType) {
     'badge-received': eventType === 'topic_message_received',
     'badge-scheduler': eventType === 'topic_scheduler',
     'badge-archived': eventType === 'topic_archived',
+    'badge-archiving': eventType === 'topic_archiving',
   }
 }
 

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -74,7 +74,13 @@
             </span>
           </span>
           <RouterLink v-if="!isArchived && !t.archived_at" :to="`/workspaces/${id}/topics/${t.id}/settings`" class="topic-settings-btn" title="Topic settings">&#9881;</RouterLink>
-          <button v-if="!isArchived" class="remove-btn" @click="deleteTopic(t.id, t.subject)" :disabled="archiving" title="Archive topic">{{ archiving ? 'Archiving…' : 'Archive' }}</button>
+          <button v-if="!isArchived" class="remove-btn"
+            :class="{ 'veto-rejected-btn': !!vetoResults[t.id] }"
+            @click="handleArchiveClick(t)"
+            :disabled="!!archivingTopics[t.id]"
+            :title="vetoResults[t.id] ? 'Click to see veto details' : 'Archive topic'">
+            {{ archivingTopics[t.id] ? 'Archiving…' : vetoResults[t.id] ? 'Archive rejected' : 'Archive' }}
+          </button>
         </li>
       </ul>
     </section>
@@ -226,8 +232,9 @@ const savingStaff = ref(false)
 const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
 
-const archiving = ref(false)
-const vetoDialog = ref(null)  // null | { topicId, subject, status: 'vetoed'|'timeout', reason }
+const archivingTopics = ref({})  // topicId → true while DELETE is in flight
+const vetoResults = ref({})     // topicId → { topicId, subject, status, reason }
+const vetoDialog = ref(null)    // null | entry from vetoResults (shown when user clicks the button)
 
 const isArchived = computed(() => !!workspace.value?.archived_at)
 
@@ -393,36 +400,58 @@ async function createTopic() {
   }
 }
 
+function handleArchiveClick(t) {
+  if (archivingTopics.value[t.id]) return
+  if (vetoResults.value[t.id]) {
+    vetoDialog.value = vetoResults.value[t.id]
+  } else {
+    deleteTopic(t.id, t.subject)
+  }
+}
+
+function showVetoDialog(topicId) {
+  vetoDialog.value = vetoResults.value[topicId] || null
+}
+
 async function deleteTopic(topicId, subject) {
   if (!confirm(`Archive topic "${subject}"?`)) return
-  archiving.value = true
-  vetoDialog.value = null
+  archivingTopics.value = { ...archivingTopics.value, [topicId]: true }
   try {
     const res = await fetch(`/api/workspaces/${id}/topics/${topicId}`, { method: 'DELETE' })
     if (res.status === 204) {
+      const next = { ...vetoResults.value }
+      delete next[topicId]
+      vetoResults.value = next
       await load()
     } else if (res.status === 423) {
       const body = await res.json().catch(() => ({}))
-      vetoDialog.value = { topicId, subject, status: 'vetoed', reason: body?.detail?.reason || body?.detail || 'Archive blocked by veto staff.' }
+      vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'vetoed', reason: body?.detail?.reason || body?.detail || 'Archive blocked by veto staff.' } }
     } else if (res.status === 504) {
       const body = await res.json().catch(() => ({}))
-      vetoDialog.value = { topicId, subject, status: 'timeout', reason: body?.detail?.reason || 'Veto staff did not respond in time.' }
+      vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'timeout', reason: body?.detail?.reason || 'Veto staff did not respond in time.' } }
     }
   } finally {
-    archiving.value = false
+    const next = { ...archivingTopics.value }
+    delete next[topicId]
+    archivingTopics.value = next
   }
 }
 
 async function overrideTopic() {
   if (!vetoDialog.value) return
-  const { topicId, subject } = vetoDialog.value
+  const { topicId } = vetoDialog.value
   vetoDialog.value = null
-  archiving.value = true
+  archivingTopics.value = { ...archivingTopics.value, [topicId]: true }
   try {
     await fetch(`/api/workspaces/${id}/topics/${topicId}?override=true`, { method: 'DELETE' })
+    const next = { ...vetoResults.value }
+    delete next[topicId]
+    vetoResults.value = next
     await load()
   } finally {
-    archiving.value = false
+    const next = { ...archivingTopics.value }
+    delete next[topicId]
+    archivingTopics.value = next
   }
 }
 
@@ -609,6 +638,8 @@ section { margin-bottom: 2rem; }
   .form-grid label + .checkbox-label { margin-bottom: 0.5rem; }
   .form-actions { flex-wrap: wrap; }
 }
+.veto-rejected-btn { background: #fef2f2 !important; color: #dc2626 !important; border: 1px solid #fecaca !important; }
+.veto-rejected-btn:hover { background: #fee2e2 !important; }
 .veto-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 100; }
 .veto-dialog { background: #fff; border-radius: 8px; padding: 1.5rem; max-width: 480px; width: 90%; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
 .veto-dialog h3 { margin: 0 0 0.75rem; color: #dc2626; }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -233,11 +233,8 @@ const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
 
 const archivingTopics = ref({})  // topicId → true while DELETE is in flight
+const vetoResults = ref({})     // topicId → { topicId, subject, status, reason } — mirrors DB
 const vetoDialog = ref(null)    // null | entry from vetoResults (shown when user clicks the button)
-
-const _vetoKey = `veto-results-${id}`
-const vetoResults = ref(JSON.parse(localStorage.getItem(_vetoKey) || '{}'))
-function _saveVetoResults() { localStorage.setItem(_vetoKey, JSON.stringify(vetoResults.value)) }
 
 const isArchived = computed(() => !!workspace.value?.archived_at)
 
@@ -369,6 +366,12 @@ async function load() {
     ])
     topics.value = await topicsRes.json()
     staffs.value = await staffsRes.json()
+    // Rebuild vetoResults from DB-backed topic fields
+    const vr = {}
+    for (const t of topics.value) {
+      if (t.veto_status) vr[t.id] = { topicId: t.id, subject: t.subject, status: t.veto_status, reason: t.veto_reason || '' }
+    }
+    vetoResults.value = vr
   } finally {
     loading.value = false
   }
@@ -425,16 +428,16 @@ async function deleteTopic(topicId, subject) {
       const next = { ...vetoResults.value }
       delete next[topicId]
       vetoResults.value = next
-      _saveVetoResults()
+
       await load()
     } else if (res.status === 423) {
       const body = await res.json().catch(() => ({}))
       vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'vetoed', reason: body?.detail?.reason || body?.detail || 'Archive blocked by veto staff.' } }
-      _saveVetoResults()
+
     } else if (res.status === 504) {
       const body = await res.json().catch(() => ({}))
       vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'timeout', reason: body?.detail?.reason || 'Veto staff did not respond in time.' } }
-      _saveVetoResults()
+
     }
   } finally {
     const next = { ...archivingTopics.value }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -233,8 +233,11 @@ const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
 
 const archivingTopics = ref({})  // topicId → true while DELETE is in flight
-const vetoResults = ref({})     // topicId → { topicId, subject, status, reason }
 const vetoDialog = ref(null)    // null | entry from vetoResults (shown when user clicks the button)
+
+const _vetoKey = `veto-results-${id}`
+const vetoResults = ref(JSON.parse(localStorage.getItem(_vetoKey) || '{}'))
+function _saveVetoResults() { localStorage.setItem(_vetoKey, JSON.stringify(vetoResults.value)) }
 
 const isArchived = computed(() => !!workspace.value?.archived_at)
 
@@ -422,13 +425,16 @@ async function deleteTopic(topicId, subject) {
       const next = { ...vetoResults.value }
       delete next[topicId]
       vetoResults.value = next
+      _saveVetoResults()
       await load()
     } else if (res.status === 423) {
       const body = await res.json().catch(() => ({}))
       vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'vetoed', reason: body?.detail?.reason || body?.detail || 'Archive blocked by veto staff.' } }
+      _saveVetoResults()
     } else if (res.status === 504) {
       const body = await res.json().catch(() => ({}))
       vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'timeout', reason: body?.detail?.reason || 'Veto staff did not respond in time.' } }
+      _saveVetoResults()
     }
   } finally {
     const next = { ...archivingTopics.value }
@@ -447,6 +453,7 @@ async function overrideTopic() {
     const next = { ...vetoResults.value }
     delete next[topicId]
     vetoResults.value = next
+    _saveVetoResults()
     await load()
   } finally {
     const next = { ...archivingTopics.value }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -181,6 +181,7 @@
         <p v-if="vetoDialog.reason" class="veto-reason">{{ vetoDialog.reason }}</p>
         <div class="form-actions">
           <button class="btn-primary" @click="overrideTopic">Override and archive anyway</button>
+          <button class="btn-secondary" @click="checkAgain">Check again</button>
           <button class="btn-secondary" @click="vetoDialog = null">Cancel</button>
         </div>
       </div>
@@ -419,8 +420,7 @@ function showVetoDialog(topicId) {
   vetoDialog.value = vetoResults.value[topicId] || null
 }
 
-async function deleteTopic(topicId, subject) {
-  if (!confirm(`Archive topic "${subject}"?`)) return
+async function _archiveTopic(topicId, subject) {
   archivingTopics.value = { ...archivingTopics.value, [topicId]: true }
   try {
     const res = await fetch(`/api/workspaces/${id}/topics/${topicId}`, { method: 'DELETE' })
@@ -428,22 +428,36 @@ async function deleteTopic(topicId, subject) {
       const next = { ...vetoResults.value }
       delete next[topicId]
       vetoResults.value = next
-
       await load()
     } else if (res.status === 423) {
       const body = await res.json().catch(() => ({}))
       vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'vetoed', reason: body?.detail?.reason || body?.detail || 'Archive blocked by veto staff.' } }
-
+      vetoDialog.value = vetoResults.value[topicId]
     } else if (res.status === 504) {
       const body = await res.json().catch(() => ({}))
       vetoResults.value = { ...vetoResults.value, [topicId]: { topicId, subject, status: 'timeout', reason: body?.detail?.reason || 'Veto staff did not respond in time.' } }
-
+      vetoDialog.value = vetoResults.value[topicId]
     }
   } finally {
     const next = { ...archivingTopics.value }
     delete next[topicId]
     archivingTopics.value = next
   }
+}
+
+async function deleteTopic(topicId, subject) {
+  if (!confirm(`Archive topic "${subject}"?`)) return
+  await _archiveTopic(topicId, subject)
+}
+
+async function checkAgain() {
+  if (!vetoDialog.value) return
+  const { topicId, subject } = vetoDialog.value
+  vetoDialog.value = null
+  const next = { ...vetoResults.value }
+  delete next[topicId]
+  vetoResults.value = next
+  await _archiveTopic(topicId, subject)
 }
 
 async function overrideTopic() {
@@ -456,7 +470,6 @@ async function overrideTopic() {
     const next = { ...vetoResults.value }
     delete next[topicId]
     vetoResults.value = next
-    _saveVetoResults()
     await load()
   } finally {
     const next = { ...archivingTopics.value }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -74,7 +74,7 @@
             </span>
           </span>
           <RouterLink v-if="!isArchived && !t.archived_at" :to="`/workspaces/${id}/topics/${t.id}/settings`" class="topic-settings-btn" title="Topic settings">&#9881;</RouterLink>
-          <button v-if="!isArchived" class="remove-btn" @click="deleteTopic(t.id, t.subject)" title="Archive topic">Archive</button>
+          <button v-if="!isArchived" class="remove-btn" @click="deleteTopic(t.id, t.subject)" :disabled="archiving" title="Archive topic">{{ archiving ? 'Archiving…' : 'Archive' }}</button>
         </li>
       </ul>
     </section>
@@ -165,6 +165,20 @@
         </table>
       </div>
     </section>
+
+    <!-- ── Veto dialog ──────────────────────────────────────────────── -->
+    <div v-if="vetoDialog" class="veto-overlay">
+      <div class="veto-dialog card">
+        <h3 v-if="vetoDialog.status === 'vetoed'">Archive blocked</h3>
+        <h3 v-else>Veto staff timed out</h3>
+        <p class="veto-subject">Topic: <strong>{{ vetoDialog.subject }}</strong></p>
+        <p v-if="vetoDialog.reason" class="veto-reason">{{ vetoDialog.reason }}</p>
+        <div class="form-actions">
+          <button class="btn-primary" @click="overrideTopic">Override and archive anyway</button>
+          <button class="btn-secondary" @click="vetoDialog = null">Cancel</button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -211,6 +225,9 @@ const editingStaff = ref(null)
 const savingStaff = ref(false)
 const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
+
+const archiving = ref(false)
+const vetoDialog = ref(null)  // null | { topicId, subject, status: 'vetoed'|'timeout', reason }
 
 const isArchived = computed(() => !!workspace.value?.archived_at)
 
@@ -378,8 +395,35 @@ async function createTopic() {
 
 async function deleteTopic(topicId, subject) {
   if (!confirm(`Archive topic "${subject}"?`)) return
-  await fetch(`/api/workspaces/${id}/topics/${topicId}`, { method: 'DELETE' })
-  await load()
+  archiving.value = true
+  vetoDialog.value = null
+  try {
+    const res = await fetch(`/api/workspaces/${id}/topics/${topicId}`, { method: 'DELETE' })
+    if (res.status === 204) {
+      await load()
+    } else if (res.status === 423) {
+      const body = await res.json().catch(() => ({}))
+      vetoDialog.value = { topicId, subject, status: 'vetoed', reason: body?.detail?.reason || body?.detail || 'Archive blocked by veto staff.' }
+    } else if (res.status === 504) {
+      const body = await res.json().catch(() => ({}))
+      vetoDialog.value = { topicId, subject, status: 'timeout', reason: body?.detail?.reason || 'Veto staff did not respond in time.' }
+    }
+  } finally {
+    archiving.value = false
+  }
+}
+
+async function overrideTopic() {
+  if (!vetoDialog.value) return
+  const { topicId, subject } = vetoDialog.value
+  vetoDialog.value = null
+  archiving.value = true
+  try {
+    await fetch(`/api/workspaces/${id}/topics/${topicId}?override=true`, { method: 'DELETE' })
+    await load()
+  } finally {
+    archiving.value = false
+  }
 }
 
 function startCreateStaff() {
@@ -565,4 +609,9 @@ section { margin-bottom: 2rem; }
   .form-grid label + .checkbox-label { margin-bottom: 0.5rem; }
   .form-actions { flex-wrap: wrap; }
 }
+.veto-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 100; }
+.veto-dialog { background: #fff; border-radius: 8px; padding: 1.5rem; max-width: 480px; width: 90%; box-shadow: 0 8px 32px rgba(0,0,0,0.18); }
+.veto-dialog h3 { margin: 0 0 0.75rem; color: #dc2626; }
+.veto-subject { margin: 0 0 0.5rem; font-size: 0.95em; }
+.veto-reason { background: #fef2f2; border: 1px solid #fecaca; border-radius: 4px; padding: 0.5rem 0.75rem; font-size: 0.9em; color: #991b1b; margin: 0.5rem 0 1rem; white-space: pre-wrap; }
 </style>

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -57,6 +57,10 @@ def _chunk_topic(workspace_id: str, topic_id: str) -> str:
     return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/chunk"
 
 
+def _verdict_topic(workspace_id: str, topic_id: str) -> str:
+    return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/verdict"
+
+
 def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str, repo_ref: str = "", base_sha: str = "") -> None:
     if Path(worktree_path).exists():
         return
@@ -82,6 +86,31 @@ def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str, repo_ref: s
 
 
 _SESSION_NOT_FOUND = "No conversation found with session ID"
+
+_VERDICT_RE = __import__("re").compile(r'\{[^{}]+\}')
+
+
+def _extract_verdict(response_text: str) -> dict:  # type: ignore[type-arg]
+    """Find the last {verdict, reason} JSON object in the LLM response.
+
+    Tries to parse the entire text as JSON first, then scans for the last
+    JSON object containing a valid verdict key. Falls back to allow if none found.
+    """
+    text = response_text.strip()
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict) and data.get("verdict") in ("allow", "deny"):
+            return data
+    except (json.JSONDecodeError, ValueError):
+        pass
+    for m in reversed(_VERDICT_RE.findall(text)):
+        try:
+            data = json.loads(m)
+            if isinstance(data, dict) and data.get("verdict") in ("allow", "deny"):
+                return data
+        except (json.JSONDecodeError, ValueError):
+            continue
+    return {"verdict": "allow", "reason": "(no verdict found in response)"}
 
 
 def _fetch_attachment(master_url: str, attachment_id: str, filename: str, worktree: str) -> None:
@@ -383,6 +412,7 @@ def _process_prompt(
     system_prompt = payload.get("system_prompt")
     attachments = payload.get("attachments", [])
     master_url = payload.get("master_url", "http://master:8080")
+    response_mode = payload.get("response_mode")
 
     if not text:
         LOGGER.warning("agent.empty_prompt topic_id=%s", topic_id)
@@ -449,6 +479,25 @@ def _process_prompt(
         }),
         qos=1,
     )
+
+    if response_mode == "verdict":
+        verdict = _extract_verdict(response_text)
+        client.publish(
+            _verdict_topic(workspace_id, topic_id),
+            json.dumps({
+                "reply_to": message_id,
+                "agent_name": agent_name,
+                "verdict": verdict["verdict"],
+                "reason": verdict.get("reason", ""),
+            }),
+            qos=1,
+        )
+        LOGGER.info(
+            "agent.verdict_published topic_id=%s verdict=%s",
+            topic_id,
+            verdict["verdict"],
+        )
+
     client.publish(_status_topic(workspace_id, topic_id), json.dumps({"state": "idle"}), qos=0)
 
 

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -118,7 +118,8 @@ CREATE TABLE IF NOT EXISTS event_actions (
                         'topic_message_sent',
                         'topic_message_received',
                         'topic_scheduler',
-                        'topic_archived'
+                        'topic_archived',
+                        'topic_archiving'
                     )),
     scope_type      TEXT NOT NULL CHECK (scope_type IN ('topic')),
     scope_id        TEXT NOT NULL,
@@ -132,7 +133,9 @@ CREATE TABLE IF NOT EXISTS event_actions (
                         'ok',
                         'staff_missing',
                         'render_error',
-                        'dispatch_error'
+                        'dispatch_error',
+                        'vetoed',
+                        'veto_timeout'
                     )),
     last_run_output   TEXT,
     enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
@@ -145,7 +148,7 @@ CREATE TABLE IF NOT EXISTS event_actions (
         OR
         (event_type = 'topic_message_sent'   AND cron_expr IS NULL     AND timing IN ('before','after'))
         OR
-        (event_type IN ('topic_message_received','topic_archived')
+        (event_type IN ('topic_message_received','topic_archived','topic_archiving')
                                               AND cron_expr IS NULL     AND (timing IS NULL OR timing = 'after'))
     )
 );
@@ -245,6 +248,75 @@ def _migrate_agents_to_staffs(conn: sqlite3.Connection) -> None:
     LOGGER.info("db.migration_done agents_to_staffs")
 
 
+def _migrate_event_actions_v2(conn: sqlite3.Connection) -> None:
+    """Add topic_archiving event_type and vetoed/veto_timeout last_run_status values.
+
+    SQLite cannot modify CHECK constraints in-place; we recreate the table.
+    Idempotent: skips if topic_archiving is already present in the schema.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='event_actions'"
+    ).fetchone()
+    if row is None or "topic_archiving" in (row[0] or ""):
+        return
+    LOGGER.info("db.migration_start event_actions_v2")
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS event_actions_new (
+            id              TEXT PRIMARY KEY,
+            event_type      TEXT NOT NULL CHECK (event_type IN (
+                                'topic_message_sent',
+                                'topic_message_received',
+                                'topic_scheduler',
+                                'topic_archived',
+                                'topic_archiving'
+                            )),
+            scope_type      TEXT NOT NULL CHECK (scope_type IN ('topic')),
+            scope_id        TEXT NOT NULL,
+            staff_name      TEXT NOT NULL,
+            prompt_template TEXT NOT NULL,
+            timing          TEXT CHECK (timing IN ('before', 'after')),
+            cron_expr       TEXT,
+            last_fired_at   TEXT,
+            last_run_at     TEXT,
+            last_run_status TEXT CHECK (last_run_status IN (
+                                'ok',
+                                'staff_missing',
+                                'render_error',
+                                'dispatch_error',
+                                'vetoed',
+                                'veto_timeout'
+                            )),
+            last_run_output TEXT,
+            enabled         INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+            created_at      TEXT NOT NULL,
+            updated_at      TEXT NOT NULL,
+            CHECK (
+                (event_type = 'topic_scheduler'      AND cron_expr IS NOT NULL AND timing IS NULL)
+                OR
+                (event_type = 'topic_message_sent'   AND cron_expr IS NULL     AND timing IN ('before','after'))
+                OR
+                (event_type IN ('topic_message_received','topic_archived','topic_archiving')
+                                                      AND cron_expr IS NULL     AND (timing IS NULL OR timing = 'after'))
+            )
+        );
+        INSERT OR IGNORE INTO event_actions_new
+            SELECT id, event_type, scope_type, scope_id, staff_name, prompt_template,
+                   timing, cron_expr, last_fired_at, last_run_at, last_run_status,
+                   last_run_output, enabled, created_at, updated_at
+            FROM event_actions;
+        DROP TABLE event_actions;
+        ALTER TABLE event_actions_new RENAME TO event_actions;
+        CREATE INDEX IF NOT EXISTS idx_event_actions_scope_event
+            ON event_actions (scope_type, scope_id, event_type, enabled);
+        CREATE INDEX IF NOT EXISTS idx_event_actions_scheduler
+            ON event_actions (event_type, enabled) WHERE event_type = 'topic_scheduler';
+    """)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.commit()
+    LOGGER.info("db.migration_done event_actions_v2")
+
+
 def init_db(db_path: str) -> None:
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
@@ -262,6 +334,7 @@ def init_db(db_path: str) -> None:
                 pass  # column already exists
         _migrate_workspace_name_uniqueness(conn)
         _migrate_agents_to_staffs(conn)
+        _migrate_event_actions_v2(conn)
         conn.commit()
     finally:
         conn.close()

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -173,7 +173,7 @@ _MIGRATIONS = [
     "ALTER TABLE workspaces ADD COLUMN last_responded_at TEXT",
     "ALTER TABLE workspaces ADD COLUMN last_agent_state TEXT",
     "ALTER TABLE chunks ADD COLUMN agent_name TEXT",
-    "ALTER TABLE event_actions ADD COLUMN structured_output INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE event_actions ADD COLUMN structured_output INTEGER DEFAULT 0",
     "ALTER TABLE messages ADD COLUMN event_action_id TEXT",
     "ALTER TABLE topics ADD COLUMN veto_status TEXT",
     "ALTER TABLE topics ADD COLUMN veto_reason TEXT",

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -175,6 +175,8 @@ _MIGRATIONS = [
     "ALTER TABLE chunks ADD COLUMN agent_name TEXT",
     "ALTER TABLE event_actions ADD COLUMN structured_output INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE messages ADD COLUMN event_action_id TEXT",
+    "ALTER TABLE topics ADD COLUMN veto_status TEXT",
+    "ALTER TABLE topics ADD COLUMN veto_reason TEXT",
 ]
 
 

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -70,6 +70,7 @@ async def dispatch_to_staff(
     raw_text: str | None = None,
     attachments: list[dict] | None = None,
     event_action_id: str | None = None,
+    response_mode: str | None = None,
 ) -> str:
     """Insert a message row, build the MQTT dispatch payload, broadcast on the hub, and publish.
 
@@ -114,7 +115,7 @@ async def dispatch_to_staff(
     finally:
         conn.close()
 
-    payload = json.dumps({
+    payload_dict: dict = {
         "message_id": message_id,
         "agent_name": staff["name"],
         "adapter": staff["adapter"],
@@ -130,7 +131,10 @@ async def dispatch_to_staff(
         "system_prompt": staff["system_prompt"],
         "text": prompt_text,
         "attachments": attachments,
-    })
+    }
+    if response_mode is not None:
+        payload_dict["response_mode"] = response_mode
+    payload = json.dumps(payload_dict)
 
     disp_conn = get_connection(app_state.db_path)
     try:

--- a/src/master/event_actions.py
+++ b/src/master/event_actions.py
@@ -26,6 +26,7 @@ _VALID_EVENT_TYPES = {
     "topic_message_received",
     "topic_scheduler",
     "topic_archived",
+    "topic_archiving",
 }
 
 
@@ -43,6 +44,7 @@ class EventActionIn(BaseModel):
         "topic_message_received",
         "topic_scheduler",
         "topic_archived",
+        "topic_archiving",
     ]
     staff_name: str
     prompt_template: str
@@ -65,7 +67,7 @@ class EventActionIn(BaseModel):
                 raise ValueError("timing must be 'before' or 'after' for topic_message_sent")
             if self.cron_expr is not None:
                 raise ValueError("cron_expr must be null for topic_message_sent")
-        elif et in ("topic_message_received", "topic_archived"):
+        elif et in ("topic_message_received", "topic_archived", "topic_archiving"):
             if self.timing not in (None, "after"):
                 raise ValueError(f"timing must be null or 'after' for {et}")
             if self.cron_expr is not None:
@@ -139,7 +141,7 @@ def _validate_merged_state(
             raise HTTPException(422, "timing must be 'before' or 'after' for topic_message_sent")
         if cron_expr is not None:
             raise HTTPException(422, "cron_expr must be null for topic_message_sent")
-    elif event_type in ("topic_message_received", "topic_archived"):
+    elif event_type in ("topic_message_received", "topic_archived", "topic_archiving"):
         if timing not in (None, "after"):
             raise HTTPException(422, f"timing must be null or 'after' for {event_type}")
         if cron_expr is not None:

--- a/src/master/event_dispatcher.py
+++ b/src/master/event_dispatcher.py
@@ -450,7 +450,7 @@ async def veto_dispatch(
         if staff is None:
             LOGGER.warning("veto_dispatch.staff_missing id=%s staff=%s", row["id"], row["staff_name"])
             _record_run(
-                app_state,
+                app_state.db_path,
                 row["id"],
                 status="staff_missing",
                 output=f"staff_name={row['staff_name']!r} not resolvable at fire time",
@@ -461,7 +461,7 @@ async def veto_dispatch(
             prompt = render_template(row["prompt_template"], variables)
         except Exception as exc:
             LOGGER.exception("veto_dispatch.render_failed id=%s", row["id"])
-            _record_run(app_state, row["id"], status="render_error", output=str(exc))
+            _record_run(app_state.db_path, row["id"], status="render_error", output=str(exc))
             continue
 
         try:
@@ -481,7 +481,7 @@ async def veto_dispatch(
         except asyncio.TimeoutError:
             LOGGER.warning("veto_dispatch.dispatch_timeout id=%s", row["id"])
             _record_run(
-                app_state,
+                app_state.db_path,
                 row["id"],
                 status="dispatch_error",
                 output=f"timeout after {DISPATCH_TIMEOUT_S:.0f}s",
@@ -510,7 +510,7 @@ async def veto_dispatch(
         )
         for _mid, (fut, row) in pending.items():
             if fut in timed_out_set:
-                _record_run(app_state, row["id"], status="veto_timeout", output="no verdict received")
+                _record_run(app_state.db_path, row["id"], status="veto_timeout", output="no verdict received")
         return VetoResult(allowed=True, reason="", timed_out=True)
 
     # Scan completed futures; first deny wins
@@ -527,7 +527,7 @@ async def veto_dispatch(
             agent_name = verdict_data.get("agent_name", "")
             if verdict == "deny":
                 _record_run(
-                    app_state,
+                    app_state.db_path,
                     row["id"],
                     status="vetoed",
                     output=f"agent={agent_name!r} reason={reason[:200]!r}",
@@ -540,7 +540,7 @@ async def veto_dispatch(
                 )
                 return VetoResult(allowed=False, reason=reason, timed_out=False)
             _record_run(
-                app_state,
+                app_state.db_path,
                 row["id"],
                 status="ok",
                 output=f"agent={agent_name!r} verdict=allow",

--- a/src/master/event_dispatcher.py
+++ b/src/master/event_dispatcher.py
@@ -1,4 +1,4 @@
-"""Event dispatch infrastructure: queue, worker, watchdog, and emit_event helper.
+"""Event dispatch infrastructure: queue, worker, watchdog, emit_event, and veto_dispatch.
 
 A single asyncio.Queue is owned by app.state. Emit sites call emit_event() from
 any thread (FastAPI loop, MQTT thread, scheduler thread) and return immediately.
@@ -7,7 +7,11 @@ across events — calling _handle_event for each. Within a single event, all
 matching event_actions fire concurrently via asyncio.gather so a slow sibling
 does not delay its peers or the next queued event.
 
-See ADR-0013 and design doc §4 for the full rationale.
+veto_dispatch() is a separate synchronous-await path for pre-commit interceptors
+(e.g. topic_archiving). It bypasses the queue, dispatches staff, and awaits
+structured verdicts via asyncio.Future objects stored in app_state.veto_futures.
+
+See ADR-0013 (post-commit events) and ADR-0014 (pre-commit veto) for rationale.
 """
 from __future__ import annotations
 
@@ -15,6 +19,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timezone
+from typing import NamedTuple
 
 from .db import get_connection
 from .staffs import resolve_staff
@@ -25,6 +30,15 @@ LOGGER = logging.getLogger(__name__)
 # message row, broadcast on the WS hub, and publish to MQTT. NOT a budget for the agent's
 # LLM response, which is fully async (the agent reply arrives via MQTT minutes later).
 DISPATCH_TIMEOUT_S = 10.0
+
+# Budget for the agent to respond with a verdict. Covers LLM think time + MQTT round-trip.
+VETO_TIMEOUT_S = 30.0
+
+
+class VetoResult(NamedTuple):
+    allowed: bool
+    reason: str
+    timed_out: bool
 
 
 # ── Template rendering ────────────────────────────────────────────────────────
@@ -383,6 +397,156 @@ def _record_run(db_path: str, action_id: str, *, status: str, output: str) -> No
         conn.commit()
     finally:
         conn.close()
+
+
+# ── Veto dispatch — synchronous-await path for pre-commit interceptors ────────
+
+async def veto_dispatch(
+    *,
+    app_state,
+    workspace_id: str,
+    topic_id: str,
+    variables: dict[str, str],
+) -> VetoResult:
+    """Dispatch all enabled topic_archiving actions and await their verdicts.
+
+    Returns VetoResult(allowed, reason, timed_out):
+    - allowed=True, timed_out=False  → proceed with archive
+    - allowed=False, timed_out=False → at least one action denied; reason carries the text
+    - allowed=True,  timed_out=True  → no verdict received within VETO_TIMEOUT_S
+    - allowed=False, timed_out=True  → (not used; timeout is always returned as allowed=True)
+
+    Caller maps timed_out=True to HTTP 504 and allowed=False to HTTP 423.
+    """
+    from .dispatch import dispatch_to_staff  # local to avoid circular import at module load
+
+    conn = get_connection(app_state.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM event_actions"
+            " WHERE scope_type='topic'"
+            "   AND scope_id=?"
+            "   AND event_type='topic_archiving'"
+            "   AND enabled=1",
+            (topic_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return VetoResult(allowed=True, reason="", timed_out=False)
+
+    loop = asyncio.get_running_loop()
+    # message_id → (Future, action_row)
+    pending: dict[str, tuple[asyncio.Future, object]] = {}
+
+    for row in rows:
+        conn = get_connection(app_state.db_path)
+        try:
+            staff = resolve_staff(conn, row["staff_name"], workspace_id, topic_id)
+        finally:
+            conn.close()
+
+        if staff is None:
+            LOGGER.warning("veto_dispatch.staff_missing id=%s staff=%s", row["id"], row["staff_name"])
+            _record_run(
+                app_state,
+                row["id"],
+                status="staff_missing",
+                output=f"staff_name={row['staff_name']!r} not resolvable at fire time",
+            )
+            continue
+
+        try:
+            prompt = render_template(row["prompt_template"], variables)
+        except Exception as exc:
+            LOGGER.exception("veto_dispatch.render_failed id=%s", row["id"])
+            _record_run(app_state, row["id"], status="render_error", output=str(exc))
+            continue
+
+        try:
+            message_id = await asyncio.wait_for(
+                dispatch_to_staff(
+                    app_state=app_state,
+                    workspace_id=workspace_id,
+                    topic_id=topic_id,
+                    staff=staff,
+                    prompt_text=prompt,
+                    sender="event",
+                    raw_text=prompt,
+                    response_mode="verdict",
+                ),
+                timeout=DISPATCH_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            LOGGER.warning("veto_dispatch.dispatch_timeout id=%s", row["id"])
+            _record_run(
+                app_state,
+                row["id"],
+                status="dispatch_error",
+                output=f"timeout after {DISPATCH_TIMEOUT_S:.0f}s",
+            )
+            continue
+
+        fut: asyncio.Future = loop.create_future()
+        app_state.veto_futures[message_id] = fut
+        pending[message_id] = (fut, row)
+
+    if not pending:
+        return VetoResult(allowed=True, reason="", timed_out=False)
+
+    futures_list = [fut for fut, _row in pending.values()]
+    try:
+        done, timed_out_set = await asyncio.wait(futures_list, timeout=VETO_TIMEOUT_S)
+    finally:
+        for mid in list(pending):
+            app_state.veto_futures.pop(mid, None)
+
+    if timed_out_set:
+        LOGGER.warning(
+            "veto_dispatch.timeout topic_id=%s pending=%d",
+            topic_id,
+            len(timed_out_set),
+        )
+        for _mid, (fut, row) in pending.items():
+            if fut in timed_out_set:
+                _record_run(app_state, row["id"], status="veto_timeout", output="no verdict received")
+        return VetoResult(allowed=True, reason="", timed_out=True)
+
+    # Scan completed futures; first deny wins
+    for _mid, (fut, row) in pending.items():
+        if fut not in done:
+            continue
+        if fut.exception():
+            LOGGER.warning("veto_dispatch.future_exception mid=%s", _mid)
+            continue
+        verdict_data = fut.result()
+        if isinstance(verdict_data, dict):
+            verdict = verdict_data.get("verdict")
+            reason = verdict_data.get("reason", "")
+            agent_name = verdict_data.get("agent_name", "")
+            if verdict == "deny":
+                _record_run(
+                    app_state,
+                    row["id"],
+                    status="vetoed",
+                    output=f"agent={agent_name!r} reason={reason[:200]!r}",
+                )
+                LOGGER.info(
+                    "veto_dispatch.denied topic_id=%s agent=%s reason=%s",
+                    topic_id,
+                    agent_name,
+                    reason[:120],
+                )
+                return VetoResult(allowed=False, reason=reason, timed_out=False)
+            _record_run(
+                app_state,
+                row["id"],
+                status="ok",
+                output=f"agent={agent_name!r} verdict=allow",
+            )
+
+    return VetoResult(allowed=True, reason="", timed_out=False)
 
 
 # ── Stall watchdog ────────────────────────────────────────────────────────────

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -340,6 +340,7 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
     app.state.event_loop = asyncio.get_running_loop()
     app.state.event_worker_last_progress = None
     app.state.gate_futures = {}  # message_id → asyncio.Future; resolves gate actions
+    app.state.veto_futures = {}  # message_id → asyncio.Future; used by veto_dispatch
     event_worker_task = asyncio.create_task(event_worker(app.state))
     watchdog_task = asyncio.create_task(worker_watchdog(app.state))
     LOGGER.info("master.event_worker_start")

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -17,6 +17,7 @@ LOGGER = logging.getLogger(__name__)
 _RESPONSE_TOPIC = "codex-slack/workspace/+/topic/+/response"
 _STATUS_TOPIC = "codex-slack/workspace/+/topic/+/status"
 _CHUNK_TOPIC = "codex-slack/workspace/+/topic/+/chunk"
+_VERDICT_TOPIC = "codex-slack/workspace/+/topic/+/verdict"
 
 # Topic pattern: codex-slack/workspace/{wid}/topic/{tid}/{type}
 _TOPIC_PARTS = 6
@@ -297,7 +298,8 @@ def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -
     client.subscribe(_RESPONSE_TOPIC, qos=1)
     client.subscribe(_STATUS_TOPIC, qos=0)
     client.subscribe(_CHUNK_TOPIC, qos=0)
-    LOGGER.info("mqtt.subscribed topics=%s,%s,%s", _RESPONSE_TOPIC, _STATUS_TOPIC, _CHUNK_TOPIC)
+    client.subscribe(_VERDICT_TOPIC, qos=1)
+    LOGGER.info("mqtt.subscribed topics=%s,%s,%s,%s", _RESPONSE_TOPIC, _STATUS_TOPIC, _CHUNK_TOPIC, _VERDICT_TOPIC)
 
 
 def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
@@ -387,6 +389,24 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
                             }),
                         },
                     )
+    elif msg_type == "verdict":
+        reply_to = payload.get("reply_to")
+        if reply_to:
+            loop = userdata.get("loop")
+            app_state = userdata.get("app_state")
+            if loop and app_state:
+                def _resolve_verdict(mid=reply_to, data=payload):
+                    fut = getattr(app_state, "veto_futures", {}).get(mid)
+                    if fut is not None and not fut.done():
+                        fut.set_result(data)
+                loop.call_soon_threadsafe(_resolve_verdict)
+        LOGGER.info(
+            "mqtt.verdict topic_id=%s reply_to=%s verdict=%s",
+            topic_id,
+            reply_to,
+            payload.get("verdict"),
+        )
+        return
     else:
         return
 

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -182,7 +182,12 @@ def get_topic(workspace_id: str, topic_id: str, request: Request) -> TopicOut:
 
 
 @router.delete("/{topic_id}", status_code=204)
-def delete_topic(workspace_id: str, topic_id: str, request: Request) -> None:
+async def delete_topic(
+    workspace_id: str,
+    topic_id: str,
+    request: Request,
+    override: bool = False,
+) -> None:
     conn = get_connection(request.app.state.db_path)
     try:
         row = conn.execute(
@@ -195,6 +200,30 @@ def delete_topic(workspace_id: str, topic_id: str, request: Request) -> None:
             raise HTTPException(status_code=404, detail="topic not found")
         topic_name = row["subject"]
         workspace_name = row["workspace_name"]
+    finally:
+        conn.close()
+
+    if not override:
+        from .event_dispatcher import veto_dispatch
+        result = await veto_dispatch(
+            app_state=request.app.state,
+            workspace_id=workspace_id,
+            topic_id=topic_id,
+            variables={"topic_name": topic_name},
+        )
+        if result.timed_out:
+            raise HTTPException(
+                status_code=504,
+                detail={"reason": "veto staff did not respond in time"},
+            )
+        if not result.allowed:
+            raise HTTPException(
+                status_code=423,
+                detail={"reason": result.reason},
+            )
+
+    conn = get_connection(request.app.state.db_path)
+    try:
         conn.execute(
             "UPDATE topics SET archived_at = ? WHERE id = ?", (_now(), topic_id)
         )

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -22,6 +22,18 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _set_veto_status(db_path: str, topic_id: str, status: str, reason: str) -> None:
+    conn = get_connection(db_path)
+    try:
+        conn.execute(
+            "UPDATE topics SET veto_status = ?, veto_reason = ? WHERE id = ?",
+            (status, reason, topic_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _slugify(text: str) -> str:
     slug = text.lower().strip()
     slug = re.sub(r"[^\w\s-]", "", slug)
@@ -94,6 +106,8 @@ class TopicOut(BaseModel):
     worktree_path: str
     created_at: str
     archived_at: str | None
+    veto_status: str | None = None
+    veto_reason: str | None = None
 
 
 def _row_to_topic(row) -> TopicOut:
@@ -107,6 +121,8 @@ def _row_to_topic(row) -> TopicOut:
         worktree_path=row["worktree_path"],
         created_at=row["created_at"],
         archived_at=row["archived_at"],
+        veto_status=row["veto_status"] if "veto_status" in row.keys() else None,
+        veto_reason=row["veto_reason"] if "veto_reason" in row.keys() else None,
     )
 
 
@@ -212,11 +228,13 @@ async def delete_topic(
             variables={"topic_name": topic_name},
         )
         if result.timed_out:
+            _set_veto_status(request.app.state.db_path, topic_id, "timeout", "veto staff did not respond in time")
             raise HTTPException(
                 status_code=504,
                 detail={"reason": "veto staff did not respond in time"},
             )
         if not result.allowed:
+            _set_veto_status(request.app.state.db_path, topic_id, "vetoed", result.reason)
             raise HTTPException(
                 status_code=423,
                 detail={"reason": result.reason},
@@ -225,7 +243,8 @@ async def delete_topic(
     conn = get_connection(request.app.state.db_path)
     try:
         conn.execute(
-            "UPDATE topics SET archived_at = ? WHERE id = ?", (_now(), topic_id)
+            "UPDATE topics SET archived_at = ?, veto_status = NULL, veto_reason = NULL WHERE id = ?",
+            (_now(), topic_id),
         )
         conn.commit()
     finally:

--- a/tests/master/test_topic_archiving_veto.py
+++ b/tests/master/test_topic_archiving_veto.py
@@ -1,0 +1,503 @@
+"""Tests for the topic_archiving vetoable pre-commit interceptor (ADR-0014).
+
+Test plan: docs/test-plans/topic-archiving-veto.md
+Design doc: docs/design/vetoable-topic-archiving-event.md (ADR-0014)
+"""
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.agent.mqtt_loop import _extract_verdict
+from src.master.db import init_db, get_connection
+from src.master.event_dispatcher import VetoResult
+from src.master.main import app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """FastAPI TestClient with an isolated on-disk SQLite DB."""
+    monkeypatch.setenv("MASTER_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    monkeypatch.setenv("MASTER_DRY_RUN", "true")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def workspace_id(client):
+    r = client.post(
+        "/api/workspaces",
+        json={"name": "test-ws", "repo_url": "https://github.com/x/y"},
+    )
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+@pytest.fixture()
+def topic_id(client, workspace_id):
+    r = client.post(
+        f"/api/workspaces/{workspace_id}/topics",
+        json={"subject": "Fix the bug", "repo_ref": "main"},
+    )
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+@pytest.fixture()
+def ea_url(workspace_id, topic_id):
+    return f"/api/workspaces/{workspace_id}/topics/{topic_id}/event-actions"
+
+
+def _make_archiving_action(
+    *,
+    staff_name: str = "test-staff",
+    prompt_template: str = "Should topic {topic_name} be archived?",
+    enabled: bool = True,
+) -> dict:
+    return {
+        "event_type": "topic_archiving",
+        "staff_name": staff_name,
+        "prompt_template": prompt_template,
+        "timing": None,
+        "enabled": enabled,
+    }
+
+
+# ---------------------------------------------------------------------------
+# TC-01: No topic_archiving actions → 204, archived_at is set
+# ---------------------------------------------------------------------------
+
+
+def test_tc01_no_actions_returns_204(client, workspace_id, topic_id):
+    """DELETE with no topic_archiving actions proceeds immediately → 204."""
+    r = client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.status_code == 204
+
+
+def test_tc01_no_actions_sets_archived_at(client, workspace_id, topic_id):
+    """After 204 delete with no actions, archived_at is populated."""
+    client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    r = client.get(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.status_code == 200
+    assert r.json()["archived_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TC-02: Allow path → 204
+# ---------------------------------------------------------------------------
+
+
+def test_tc02_allow_returns_204(client, workspace_id, topic_id, ea_url):
+    """When veto_dispatch returns allowed=True, DELETE → 204."""
+    # Register a topic_archiving action so veto_dispatch would normally be called
+    r = client.post(ea_url, json=_make_archiving_action())
+    assert r.status_code == 201
+
+    allow_result = VetoResult(allowed=True, reason="", timed_out=False)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=allow_result)):
+        r = client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    assert r.status_code == 204
+
+
+def test_tc02_allow_sets_archived_at(client, workspace_id, topic_id, ea_url):
+    """After allowed veto, archived_at is populated."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    allow_result = VetoResult(allowed=True, reason="", timed_out=False)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=allow_result)):
+        client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    r = client.get(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.json()["archived_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TC-03: Deny path → 423
+# ---------------------------------------------------------------------------
+
+
+def test_tc03_deny_returns_423(client, workspace_id, topic_id, ea_url):
+    """When veto_dispatch returns allowed=False, DELETE → 423."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    deny_result = VetoResult(allowed=False, reason="open PRs", timed_out=False)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=deny_result)):
+        r = client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    assert r.status_code == 423
+
+
+def test_tc03_deny_body_contains_reason(client, workspace_id, topic_id, ea_url):
+    """423 response body carries the veto reason."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    deny_result = VetoResult(allowed=False, reason="open PRs", timed_out=False)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=deny_result)):
+        r = client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    body = r.json()
+    assert "reason" in body["detail"]
+    assert body["detail"]["reason"] == "open PRs"
+
+
+def test_tc03_deny_topic_not_archived(client, workspace_id, topic_id, ea_url):
+    """After a 423 veto, the topic is NOT archived."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    deny_result = VetoResult(allowed=False, reason="open PRs", timed_out=False)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=deny_result)):
+        client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    r = client.get(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.json()["archived_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# TC-04: Timeout → 504
+# ---------------------------------------------------------------------------
+
+
+def test_tc04_timeout_returns_504(client, workspace_id, topic_id, ea_url):
+    """When veto_dispatch times out, DELETE → 504."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    timeout_result = VetoResult(allowed=True, reason="", timed_out=True)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=timeout_result)):
+        r = client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    assert r.status_code == 504
+
+
+def test_tc04_timeout_topic_not_archived(client, workspace_id, topic_id, ea_url):
+    """After a 504 timeout, the topic is NOT archived."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    timeout_result = VetoResult(allowed=True, reason="", timed_out=True)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=timeout_result)):
+        client.delete(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+
+    r = client.get(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.json()["archived_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# TC-05: override=true → 204, veto_dispatch NOT called
+# ---------------------------------------------------------------------------
+
+
+def test_tc05_override_returns_204(client, workspace_id, topic_id, ea_url):
+    """DELETE ?override=true returns 204 regardless of what veto would return."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    deny_result = VetoResult(allowed=False, reason="would deny", timed_out=False)
+    mock_veto = AsyncMock(return_value=deny_result)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=mock_veto):
+        r = client.delete(
+            f"/api/workspaces/{workspace_id}/topics/{topic_id}",
+            params={"override": "true"},
+        )
+
+    assert r.status_code == 204
+
+
+def test_tc05_override_veto_dispatch_not_called(client, workspace_id, topic_id, ea_url):
+    """With override=true, veto_dispatch is never invoked."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    deny_result = VetoResult(allowed=False, reason="would deny", timed_out=False)
+    mock_veto = AsyncMock(return_value=deny_result)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=mock_veto):
+        client.delete(
+            f"/api/workspaces/{workspace_id}/topics/{topic_id}",
+            params={"override": "true"},
+        )
+
+    mock_veto.assert_not_called()
+
+
+def test_tc05_override_sets_archived_at(client, workspace_id, topic_id, ea_url):
+    """After override=true delete, archived_at is set."""
+    client.post(ea_url, json=_make_archiving_action())
+
+    deny_result = VetoResult(allowed=False, reason="would deny", timed_out=False)
+    with patch("src.master.event_dispatcher.veto_dispatch", new=AsyncMock(return_value=deny_result)):
+        client.delete(
+            f"/api/workspaces/{workspace_id}/topics/{topic_id}",
+            params={"override": "true"},
+        )
+
+    r = client.get(f"/api/workspaces/{workspace_id}/topics/{topic_id}")
+    assert r.json()["archived_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TC-06: event_actions CRUD for topic_archiving
+# ---------------------------------------------------------------------------
+
+
+def test_tc06_create_archiving_action_returns_201(client, ea_url):
+    """POST a valid topic_archiving action → 201."""
+    r = client.post(ea_url, json=_make_archiving_action())
+    assert r.status_code == 201
+
+
+def test_tc06_create_archiving_action_body(client, ea_url):
+    """Response body for a created topic_archiving action has correct fields."""
+    r = client.post(ea_url, json=_make_archiving_action(staff_name="my-staff"))
+    body = r.json()
+    assert body["event_type"] == "topic_archiving"
+    assert body["staff_name"] == "my-staff"
+    assert body["timing"] is None
+    assert body["cron_expr"] is None
+
+
+def test_tc06_create_archiving_with_cron_returns_422(client, ea_url):
+    """topic_archiving with cron_expr must be rejected (422)."""
+    action = _make_archiving_action()
+    action["cron_expr"] = "* * * * *"
+    r = client.post(ea_url, json=action)
+    assert r.status_code == 422
+
+
+def test_tc06_create_archiving_with_timing_before_returns_422(client, ea_url):
+    """topic_archiving with timing='before' must be rejected (422)."""
+    action = _make_archiving_action()
+    action["timing"] = "before"
+    r = client.post(ea_url, json=action)
+    assert r.status_code == 422
+
+
+def test_tc06_create_archiving_with_timing_after_returns_201(client, ea_url):
+    """topic_archiving with timing='after' is allowed (201)."""
+    action = _make_archiving_action()
+    action["timing"] = "after"
+    r = client.post(ea_url, json=action)
+    assert r.status_code == 201
+
+
+def test_tc06_create_archiving_appears_in_list(client, ea_url):
+    """A created topic_archiving action appears in the list endpoint."""
+    client.post(ea_url, json=_make_archiving_action())
+    r = client.get(ea_url)
+    assert r.status_code == 200
+    types = [a["event_type"] for a in r.json()]
+    assert "topic_archiving" in types
+
+
+# ---------------------------------------------------------------------------
+# TC-07: DB migration — old schema gets upgraded, INSERT succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_tc07_migration_old_schema_upgraded(tmp_path):
+    """init_db on a pre-migration DB (no topic_archiving in CHECK) upgrades schema
+    so that INSERT of a topic_archiving row succeeds."""
+    db_path = str(tmp_path / "old.db")
+
+    # Build the old schema without topic_archiving in the CHECK constraint
+    old_schema = """
+    CREATE TABLE event_actions (
+        id              TEXT PRIMARY KEY,
+        event_type      TEXT NOT NULL CHECK (event_type IN (
+                            'topic_message_sent',
+                            'topic_message_received',
+                            'topic_scheduler',
+                            'topic_archived'
+                        )),
+        scope_type      TEXT NOT NULL CHECK (scope_type IN ('topic')),
+        scope_id        TEXT NOT NULL,
+        staff_name      TEXT NOT NULL,
+        prompt_template TEXT NOT NULL,
+        timing          TEXT CHECK (timing IN ('before', 'after')),
+        cron_expr       TEXT,
+        last_fired_at   TEXT,
+        last_run_at     TEXT,
+        last_run_status TEXT CHECK (last_run_status IN (
+                            'ok',
+                            'staff_missing',
+                            'render_error',
+                            'dispatch_error'
+                        )),
+        last_run_output TEXT,
+        enabled         INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+        created_at      TEXT NOT NULL,
+        updated_at      TEXT NOT NULL,
+        CHECK (
+            (event_type = 'topic_scheduler'      AND cron_expr IS NOT NULL AND timing IS NULL)
+            OR
+            (event_type = 'topic_message_sent'   AND cron_expr IS NULL     AND timing IN ('before','after'))
+            OR
+            (event_type IN ('topic_message_received','topic_archived')
+                                                  AND cron_expr IS NULL     AND (timing IS NULL OR timing = 'after'))
+        )
+    );
+    CREATE TABLE workspaces (
+        id             TEXT PRIMARY KEY,
+        name           TEXT NOT NULL UNIQUE,
+        repo_url       TEXT NOT NULL,
+        container_name TEXT,
+        created_at     TEXT NOT NULL,
+        archived_at    TEXT
+    );
+    CREATE TABLE staffs (
+        id          TEXT PRIMARY KEY,
+        scope_type  TEXT NOT NULL CHECK (scope_type IN ('global', 'workspace', 'topic')),
+        scope_id    TEXT,
+        name        TEXT NOT NULL,
+        adapter     TEXT NOT NULL DEFAULT 'claude-code',
+        model       TEXT,
+        system_prompt TEXT,
+        agent       TEXT,
+        session_scope TEXT NOT NULL DEFAULT 'topic' CHECK (session_scope IN ('topic', 'workspace', 'global')),
+        is_default  INTEGER NOT NULL DEFAULT 0,
+        extra_flags TEXT,
+        created_at  TEXT NOT NULL,
+        updated_at  TEXT NOT NULL
+    );
+    CREATE TABLE topics (
+        id            TEXT PRIMARY KEY,
+        workspace_id  TEXT NOT NULL,
+        subject       TEXT NOT NULL,
+        branch_name   TEXT NOT NULL,
+        worktree_path TEXT NOT NULL,
+        created_at    TEXT NOT NULL,
+        archived_at   TEXT
+    );
+    """
+
+    # Create the old-schema DB
+    conn = sqlite3.connect(db_path)
+    conn.executescript(old_schema)
+    conn.commit()
+    conn.close()
+
+    # Running init_db should trigger _migrate_event_actions_v2
+    init_db(db_path)
+
+    # Now INSERT a topic_archiving row — should succeed
+    conn = get_connection(db_path)
+    try:
+        now = "2026-05-09T10:00:00Z"
+        action_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO event_actions"
+            " (id, event_type, scope_type, scope_id, staff_name, prompt_template,"
+            "  timing, cron_expr, enabled, created_at, updated_at)"
+            " VALUES (?, 'topic_archiving', 'topic', 'some-topic-id', 'bot',"
+            "         'Archive?', NULL, NULL, 1, ?, ?)",
+            (action_id, now, now),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT event_type FROM event_actions WHERE id = ?", (action_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["event_type"] == "topic_archiving"
+
+
+def test_tc07_migration_idempotent(tmp_path):
+    """Running init_db twice on a fresh DB does not raise."""
+    db_path = str(tmp_path / "idempotent.db")
+    init_db(db_path)
+    init_db(db_path)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# TC-08: _extract_verdict — inline JSON
+# ---------------------------------------------------------------------------
+
+
+def test_tc08_extract_verdict_inline_json_deny():
+    """Pure JSON payload with verdict=deny is returned as-is."""
+    result = _extract_verdict('{"verdict":"deny","reason":"open PRs"}')
+    assert result["verdict"] == "deny"
+    assert result["reason"] == "open PRs"
+
+
+def test_tc08_extract_verdict_inline_json_allow():
+    """Pure JSON payload with verdict=allow is returned as-is."""
+    result = _extract_verdict('{"verdict":"allow","reason":"looks good"}')
+    assert result["verdict"] == "allow"
+    assert result["reason"] == "looks good"
+
+
+# ---------------------------------------------------------------------------
+# TC-09: _extract_verdict — trailing JSON in prose
+# ---------------------------------------------------------------------------
+
+
+def test_tc09_extract_verdict_trailing_json():
+    """LLM prose with a trailing JSON object: verdict extracted correctly."""
+    text = (
+        "I have reviewed the topic. There are several open pull requests that "
+        "still need review, so archiving should be blocked at this time. "
+        '{"verdict":"deny","reason":"open PRs still need review"}'
+    )
+    result = _extract_verdict(text)
+    assert result["verdict"] == "deny"
+    assert "open PRs" in result["reason"]
+
+
+def test_tc09_extract_verdict_embedded_json():
+    """JSON object embedded mid-text: verdict extracted from it."""
+    text = (
+        'After careful consideration {"verdict":"allow","reason":"all clear"} I recommend proceeding.'
+    )
+    result = _extract_verdict(text)
+    assert result["verdict"] == "allow"
+
+
+def test_tc09_extract_verdict_last_json_wins():
+    """When multiple JSON objects are present, the last valid verdict wins."""
+    text = (
+        '{"verdict":"allow","reason":"first"} some text '
+        '{"verdict":"deny","reason":"second is last"}'
+    )
+    result = _extract_verdict(text)
+    # _extract_verdict scans in reversed order, so the last JSON object wins
+    assert result["verdict"] == "deny"
+    assert result["reason"] == "second is last"
+
+
+# ---------------------------------------------------------------------------
+# TC-10: _extract_verdict — no JSON → allow fallback
+# ---------------------------------------------------------------------------
+
+
+def test_tc10_extract_verdict_no_json_returns_allow():
+    """Plain text with no JSON object falls back to allow."""
+    result = _extract_verdict("Everything looks good, go ahead and archive it.")
+    assert result["verdict"] == "allow"
+    assert "no verdict found" in result["reason"]
+
+
+def test_tc10_extract_verdict_empty_string():
+    """Empty string falls back to allow."""
+    result = _extract_verdict("")
+    assert result["verdict"] == "allow"
+
+
+def test_tc10_extract_verdict_json_without_verdict_key():
+    """JSON object without a 'verdict' key falls back to allow."""
+    result = _extract_verdict('{"some":"other","keys":"here"}')
+    assert result["verdict"] == "allow"
+
+
+def test_tc10_extract_verdict_invalid_verdict_value():
+    """JSON object with an unrecognised verdict value falls back to allow."""
+    result = _extract_verdict('{"verdict":"maybe","reason":"unsure"}')
+    assert result["verdict"] == "allow"


### PR DESCRIPTION
## Summary

- Adds `topic_archiving` pre-commit event type to block archives before `archived_at` is committed
- Staff actions can deny veto (423 Locked) or timeout (504); operators can override with `?override=true`
- New MQTT `/verdict` subtopic for structured `{verdict, reason}` responses from agents
- Frontend shows veto dialog with "Override and archive anyway" button on denial/timeout

## Test plan

- [x] 29 new unit tests in `test_topic_archiving_veto.py` covering allow/deny/timeout/override paths, CRUD validation, DB migration, verdict extraction
- [x] All existing event/topics/db tests (119 tests) pass; no regressions
- [ ] Smoke test in dev env: configure a `topic_archiving` action; attempt archive; verify veto dialog appears on denial
- [ ] Verify agent publishes on `/verdict` MQTT topic when `response_mode=verdict` is in prompt payload

🤖 Generated with repository automation

Closes #156