### PR TITLE
fix(ci): unblock GHCR push + extend agent image

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,7 @@ Full details in `docs/sre.md`. Summary:
 | `DOCKER_GID` | Docker socket group on dev host | `988` | Set |
 | `STAGING_DOCKER_HOST` | Staging deploys, UAT | `ssh://ubuntu@<staging-ip>` | Requires human to set |
 | `REGISTRY` | Building/pushing images | `ghcr.io/pandazxx` | Requires human to set |
-| `REGISTRY_TOKEN` | Pushing images | (from secret manager) | Requires human to set |
+| `REGISTRY_TOKEN` | Pushing images to non-GHCR registries | (from secret manager) | Optional — GHCR uses `GITHUB_TOKEN` |
 
 No fallback to local Docker — `DEV_DOCKER_HOST` must always be set explicitly.
 Never run `docker`, `docker compose`, or deploy commands directly — always delegate to `sre` or `senior-sre`.

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           registry: ${{ vars.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/Dockerfile.agent-minimal
+++ b/Dockerfile.agent-minimal
@@ -28,13 +28,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     docker-ce-cli \
+    docker-compose-plugin \
     gh \
     git \
     openssh-client \
     poppler-utils \
+    silversearcher-ag \
     tini \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
+    && printf '#!/bin/sh\nexec docker compose "$@"\n' > /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}

--- a/docs/sre.md
+++ b/docs/sre.md
@@ -10,7 +10,7 @@ This document is the authoritative reference for infrastructure operations on th
 | `DOCKER_GID` | Docker socket group on host | `988` | Set |
 | `STAGING_DOCKER_HOST` | Staging deploys, UAT, post-merge cleanup | `ssh://ubuntu@<staging-ip>` | **Requires human to set** |
 | `REGISTRY` | Building and pushing images | `ghcr.io/pandazxx` | **Requires human to set** |
-| `REGISTRY_TOKEN` | Pushing images (CI secret) | (from secret manager) | **Requires human to set** |
+| `REGISTRY_TOKEN` | Pushing images to non-GHCR registries | (from secret manager) | Optional — GHCR uses `GITHUB_TOKEN` |
 
 No fallback to local Docker. `DEV_DOCKER_HOST` must always be set. For local Docker, set `DEV_DOCKER_HOST=unix:///var/run/docker.sock` explicitly.
 
@@ -103,7 +103,7 @@ All runbooks are in `.sre/operations/`. Operators read the runbook for the reque
 
 1. Set `STAGING_DOCKER_HOST` in dotenv/direnv.
 2. Set `REGISTRY` in dotenv/direnv and as a GitHub Actions variable (`vars.REGISTRY`).
-3. Set `REGISTRY_TOKEN` as a GitHub Actions secret (`secrets.REGISTRY_TOKEN`).
+3. Set `REGISTRY_TOKEN` as a GitHub Actions secret only if `REGISTRY` is not GHCR. For GHCR, `build-push.yml` uses the workflow's auto-provided `GITHUB_TOKEN` (the job already declares `packages: write`).
 4. Bootstrap `sre-host-infra` on `STAGING_DOCKER_HOST` (same command as dev bootstrap above, with `STAGING_DOCKER_HOST`).
 5. Verify `Dockerfile` has `prod`, `dev`, and `test` stages — all three are present; confirm they have adequate tooling for your workload.
 6. Verify Traefik digest in `.sre/host-infra/docker-compose.yml` before first bootstrap.


### PR DESCRIPTION
## Summary

- **Fix CI build-push auth:** swap `secrets.REGISTRY_TOKEN` (unset on the repo, caused "Password required" failures) for `secrets.GITHUB_TOKEN`, which every workflow gets for free and works against GHCR with the existing `packages: write` permission.
- **Reframe `REGISTRY_TOKEN` in docs** (`docs/sre.md`, `.claude/CLAUDE.md`): no longer required for GHCR; only needed for non-GHCR registries.
- **Extend agent worker image** (`Dockerfile.agent-minimal`): install `docker-compose-plugin` (v2) and `silversearcher-ag`; add a `/usr/local/bin/docker-compose` shim execing `docker compose "\$@"` so the legacy invocation form works without the deprecated v1 standalone.

## Test plan

- [ ] CI build-push workflow succeeds on this PR (the failing run that motivated the fix: https://github.com/pandazxx/codex-slack/actions/runs/25603693847).
- [ ] Image pushed to `ghcr.io/pandazxx/codex-slack-master` with the expected tags after merge.
- [ ] Inside a freshly rebuilt agent container: `docker compose version` and `docker-compose version` both print the same v2 version string.
- [ ] Inside a freshly rebuilt agent container: `ag --version` works.
- [ ] No regressions in master env-up against the dev host.

🤖 Generated with repository automation