### PR TITLE
feat(dev): show branch + sha + dirty state in dev APP_VERSION

### DIFF
--- a/.sre/env-up.sh
+++ b/.sre/env-up.sh
@@ -27,11 +27,26 @@ MASTER_SSH_AUTH_SOCK_PATH="${MASTER_SSH_AUTH_SOCK_PATH:-/run/user/1000/ssh-agent
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Compute APP_VERSION from local git state so dev images reflect the
+# branch + short SHA the build was made from.
+# Format: <branch>:<short-sha>(dirty)? — e.g. feat/foo:a1b2c3d(dirty)
+if git -C "$PROJECT_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  GIT_BRANCH="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD)"
+  GIT_SHA="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+  GIT_DIRTY=""
+  [ -n "$(git -C "$PROJECT_ROOT" status --porcelain)" ] && GIT_DIRTY="(dirty)"
+  APP_VERSION="${GIT_BRANCH}:${GIT_SHA}${GIT_DIRTY}"
+else
+  APP_VERSION="dev-unknown"
+fi
+echo "==> APP_VERSION=${APP_VERSION}"
+
 export DOCKER_HOST="$DEV_DOCKER_HOST"
 export BRANCH_SLUG
 export HOST_IP_DASHED
 export DOCKER_GID
 export MASTER_SSH_AUTH_SOCK_PATH
+export APP_VERSION
 # Branch-scoped image name so agent containers never pick up a stale
 # cross-branch :latest tag from a different dev build on the same host.
 export MASTER_RUNTIME_IMAGE="${BRANCH_SLUG}-master:dev"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,6 +8,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: dev
+      args:
+        APP_VERSION: "${APP_VERSION:-dev}"
     environment:
       MASTER_AGENT_NETWORK: "${BRANCH_SLUG:-dev}_internal"
     deploy:


### PR DESCRIPTION
## Summary

Dev image's `APP_VERSION` (already surfaced in startup logs and `/health` from the prior version-bake commit) now reflects the local git state at build time.

**Format:** `<branch>:<short-sha>(dirty)?`

| State | Example |
|---|---|
| clean | `feat/sre-change:a1b2c3d` |
| dirty (unstaged, staged, or untracked) | `feat/sre-change:a1b2c3d(dirty)` |

**Implementation (two files):**

- `.sre/env-up.sh` — computes the version string from `git rev-parse --abbrev-ref HEAD` + `git rev-parse --short HEAD` + `git status --porcelain`, exports `APP_VERSION`, prints `==> APP_VERSION=…` to stdout. Falls back to `dev-unknown` if not in a git work tree.
- `docker-compose.override.yml` — passes `APP_VERSION` to `master.build.args`, defaulting to `dev` so a manual `docker compose build` outside `env-up.sh` still works.

CI (`build-push.yml`) continues to use the tag name (e.g. `v4.11-rc2`) as `APP_VERSION` — staging is unaffected.

## Test plan

- [x] `.sre/env-up.sh <branch>` prints `==> APP_VERSION=<branch>:<short-sha>(dirty)?`. Verified: `feat/restore-rc-pipeline:a70d56d(dirty)`.
- [x] `docker image inspect <built-image>` shows `ENV APP_VERSION` matches.
- [x] `docker compose exec master env | grep APP_VERSION` inside the running container matches.
- [ ] CI builds (tag `v*`) still produce `APP_VERSION=v*` (no regression).

🤖 Generated with repository automation