### PR TITLE
refactor: unify agent container SSH socket path with master

### DIFF
--- a/docs/design/agent-container-runtime-design.md
+++ b/docs/design/agent-container-runtime-design.md
@@ -85,7 +85,7 @@ One of the following adapter credentials, depending on what the operator configu
 Optional, set only when the operator opts in:
 
 - `GITHUB_TOKEN` — additional GitHub credential injected via DB-stored runtime config
-- `SSH_AUTH_SOCK=/run/secrets/ssh-auth.sock` — when master forwards an SSH agent socket
+- `SSH_AUTH_SOCK=/run/ssh-agent.sock` — when master forwards an SSH agent socket
 - `GIT_SSH_COMMAND` — set when SSH forwarding is in use
 
 Set inside the agent image / by the entrypoint, not by master:

--- a/docs/design/containers/agent-container-design.md
+++ b/docs/design/containers/agent-container-design.md
@@ -117,7 +117,7 @@ The master typically mounts:
 
 - workspace volume at `/workspace`
 - Codex auth seed at `/run/secrets/codex_auth.json`
-- SSH agent socket at `/run/secrets/ssh-auth.sock`
+- SSH agent socket at `/run/ssh-agent.sock`
 - transient request data under `/workspace/message/...`
 
 ## Storage Layout

--- a/docs/design/containers/environment-variable-passdown-design.md
+++ b/docs/design/containers/environment-variable-passdown-design.md
@@ -123,7 +123,7 @@ vars or mount points.
 | `MASTER_CODEX_AUTH_JSON_PATH` | `agent_codex_auth_json_path` | host path | none | mount at `/run/secrets/codex_auth.json` |
 | `MASTER_CODEX_CONFIG_DIR_PATH` | `agent_codex_config_dir_path` | host path | none | deprecated legacy setting; no longer passed into agents |
 | `MASTER_CLAUDE_CONFIG_DIR_PATH` | `agent_claude_config_dir_path` | host path | none | deprecated legacy setting; no longer passed into agents |
-| `MASTER_SSH_AUTH_SOCK_PATH` | `agent_ssh_auth_sock_path` | host path | `SSH_AUTH_SOCK` | env value `/run/secrets/ssh-auth.sock` plus matching mount |
+| `MASTER_SSH_AUTH_SOCK_PATH` | `agent_ssh_auth_sock_path` | host path | `SSH_AUTH_SOCK` | env value `/run/ssh-agent.sock` plus matching mount |
 | `MASTER_SSH_KNOWN_HOSTS_PATH` | `agent_ssh_known_hosts_path` | host path | `GIT_SSH_COMMAND` | env embeds mounted in-container path `/run/secrets/ssh_known_hosts` if configured |
 | `MASTER_GIT_USER_NAME` | `git_user_name` | not a path | `AGENT_GIT_USER_NAME` | string passed through |
 | `MASTER_GIT_USER_EMAIL` | `git_user_email` | not a path | `AGENT_GIT_USER_EMAIL` | string passed through |
@@ -250,7 +250,7 @@ Mount-path translation is just as important as env translation:
 | Host path env | In-container mounted path |
 |---|---|
 | `MASTER_CODEX_AUTH_JSON_PATH` | `/run/secrets/codex_auth.json` |
-| `MASTER_SSH_AUTH_SOCK_PATH` | `/run/secrets/ssh-auth.sock` |
+| `MASTER_SSH_AUTH_SOCK_PATH` | `/run/ssh-agent.sock` |
 
 ## 6. Observability
 

--- a/docs/guides/runbooks/master-agent.md
+++ b/docs/guides/runbooks/master-agent.md
@@ -98,7 +98,7 @@ Master will respawn the container on next startup if the workspace is not archiv
    - `workspace_prepare`: filesystem permission error.
 3. Fix the env/auth and archive+recreate the workspace if needed (or manually remove the container and restart master to trigger respawn).
 
-### Agent exits with `ssh-auth.sock` error
+### Agent exits with SSH agent socket error
 
 If the mounted SSH auth sock becomes stale (e.g. agent was restarted with a new `SSH_AUTH_SOCK`):
 ```bash

--- a/docs/guides/tutorials.md
+++ b/docs/guides/tutorials.md
@@ -148,7 +148,7 @@ Reference: [`docs/references/config.md`](../references/config.md).
 | Symptom | First check | Reference |
 |---|---|---|
 | Agent container won't start | `docker logs codex-agent-<wsid>` for stage failure (preflight, repo_sync, workspace_prepare) | [`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md) |
-| `ssh-auth.sock` errors | Confirm `MASTER_SSH_AUTH_SOCK_PATH` points to a live socket on the host | [`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md) |
+| SSH agent socket errors | Confirm `MASTER_SSH_AUTH_SOCK_PATH` points to a live socket on the host | [`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md) |
 | Claude session expired | Self-healing — agent retries without `--resume` and stores the new session ID | [`docs/manuals/user-manual.md`](../manuals/user-manual.md) |
 | MQTT not delivering prompts | Tail `mosquitto` logs; check that master logs `master.mqtt_loop_start host=mosquitto port=1883` | [`docs/guides/runbooks/master-agent.md`](runbooks/master-agent.md) |
 | Production reports `version: vX.Y-rcN` | Expected — promotion retags the RC image without rebuilding | [`docs/manuals/ops-manual.md`](../manuals/ops-manual.md) |

--- a/src/master/agent_runner.py
+++ b/src/master/agent_runner.py
@@ -73,10 +73,10 @@ def spawn_agent(
         codex_volume: {"bind": "/home/appuser/.codex", "mode": "rw"},
     }
     if ssh_auth_sock_path:
-        env["SSH_AUTH_SOCK"] = "/run/secrets/ssh-auth.sock"
+        env["SSH_AUTH_SOCK"] = "/run/ssh-agent.sock"
         # Disable strict host checking so the container doesn't need a pre-seeded known_hosts
         env.setdefault("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null")
-        volumes[ssh_auth_sock_path] = {"bind": "/run/secrets/ssh-auth.sock", "mode": "ro"}
+        volumes[ssh_auth_sock_path] = {"bind": "/run/ssh-agent.sock", "mode": "ro"}
     if ssh_known_hosts_path:
         # If an explicit known_hosts is provided, prefer it over the no-check fallback
         env["GIT_SSH_COMMAND"] = f"ssh -o UserKnownHostsFile=/run/secrets/known_hosts"

--- a/src/master/service.py
+++ b/src/master/service.py
@@ -523,7 +523,7 @@ class MasterService:
         if self._git_user_email:
             env["AGENT_GIT_USER_EMAIL"] = self._git_user_email
         if self._agent_ssh_auth_sock_path:
-            env["SSH_AUTH_SOCK"] = "/run/secrets/ssh-auth.sock"
+            env["SSH_AUTH_SOCK"] = "/run/ssh-agent.sock"
             env["GIT_SSH_COMMAND"] = self._agent_git_ssh_command()
         # CLAUDE_CONFIG_DIR is intentionally NOT set here. The entrypoint seeds
         # baked-in Claude config into a writable ~/.claude/ inside the workspace
@@ -565,7 +565,7 @@ class MasterService:
         if self._agent_codex_auth_json_path:
             mounts.append(f"{self._agent_codex_auth_json_path}:/run/secrets/codex_auth.json:ro")
         if self._agent_ssh_auth_sock_path:
-            mounts.append(f"{self._agent_ssh_auth_sock_path}:/run/secrets/ssh-auth.sock")
+            mounts.append(f"{self._agent_ssh_auth_sock_path}:/run/ssh-agent.sock")
         if self._agent_ssh_known_hosts_path:
             mounts.append(f"{self._agent_ssh_known_hosts_path}:/run/secrets/ssh_known_hosts:ro")
         return mounts

--- a/tests/master/test_master_service.py
+++ b/tests/master/test_master_service.py
@@ -344,10 +344,10 @@ def test_start_agent_mounts_ssh_forwarding_and_sets_env(tmp_path) -> None:
     assert runtime.calls[1][0] == "create_or_update_agent"
     env = runtime.calls[1][1]["env"]
     mounts = runtime.calls[1][1]["mounts"]
-    assert env["SSH_AUTH_SOCK"] == "/run/secrets/ssh-auth.sock"
+    assert env["SSH_AUTH_SOCK"] == "/run/ssh-agent.sock"
     assert env["GIT_SSH_COMMAND"] == "ssh -o UserKnownHostsFile=/run/secrets/ssh_known_hosts"
     assert mounts == [
-        "/run/user/1000/keyring/ssh:/run/secrets/ssh-auth.sock",
+        "/run/user/1000/keyring/ssh:/run/ssh-agent.sock",
         "/home/tester/.ssh/known_hosts:/run/secrets/ssh_known_hosts:ro",
     ]
 
@@ -372,9 +372,9 @@ def test_start_agent_sets_insecure_default_ssh_config_without_known_hosts(tmp_pa
     assert runtime.calls[0][0] == "pull_image"
     env = runtime.calls[1][1]["env"]
     mounts = runtime.calls[1][1]["mounts"]
-    assert env["SSH_AUTH_SOCK"] == "/run/secrets/ssh-auth.sock"
+    assert env["SSH_AUTH_SOCK"] == "/run/ssh-agent.sock"
     assert env["GIT_SSH_COMMAND"] == "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    assert mounts == ["/run/user/1000/keyring/ssh:/run/secrets/ssh-auth.sock"]
+    assert mounts == ["/run/user/1000/keyring/ssh:/run/ssh-agent.sock"]
 
 
 def test_run_git_uses_insecure_default_ssh_config_without_known_hosts(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

Master and spawned agent containers used different paths for the same underlying host SSH agent socket:

| Container | Old path | New path |
|---|---|---|
| master | `/run/ssh-agent.sock` | `/run/ssh-agent.sock` (unchanged) |
| agent | `/run/secrets/ssh-auth.sock` | `/run/ssh-agent.sock` |

The dual paths added cognitive overhead with no functional benefit. The `/run/secrets/` location also implied a Docker secrets convention that wasn't actually in use.

**What changed:** four literal swaps in master source (`agent_runner.py:76,79`, `service.py:526,568`) plus the test assertions and design-doc/runbook prose that referenced the old path.

**What didn't change:** host source path, the socket itself, master's own mount, the ``MASTER_SSH_AUTH_SOCK_PATH`` env var that propagates the host path through to master.

## Test plan

- [x] `pytest -k 'ssh or agent_runner or spawn'` — 15/15 pass.
- [x] Spawned an agent in dev env (`codex-agent-eaba96ed-...`) and verified inside the container:
  - `SSH_AUTH_SOCK=/run/ssh-agent.sock` ✓
  - `ls -la /run/ssh-agent.sock` shows the unix socket ✓
  - `ssh-add -l` returns the host's loaded ED25519 key — agent connection functional ✓
- [ ] Sanity check on next dev env spin-up after merge: agent still spawns and SSH operations still work.

🤖 Generated with repository automation