### PR TITLE
feat: message cancellation — stop button and streaming/done bubble styles

### DIFF
--- a/docker-compose.dev-remote.yml
+++ b/docker-compose.dev-remote.yml
@@ -1,0 +1,62 @@
+services:
+  master:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: codex-slack-master:dev-remote
+    container_name: codex-slack-master-remote
+    working_dir: /opt/codex-slack
+    ports:
+      - "8082:8080"
+    environment:
+      MASTER_PORT: 8080
+      MASTER_DRY_RUN: "false"
+      CONTAINER_RUNTIME: docker
+      DOCKER_HOST: unix:///run/container.sock
+      CONTAINER_HOST: unix:///run/container.sock
+      DOCKER_GID: ${DOCKER_GID:-988}
+      MQTT_HOST: mosquitto
+      MQTT_PORT: 1883
+    volumes:
+      - master_data:/opt/codex-slack/data/master
+      - /var/run/docker.sock:/run/container.sock
+    group_add:
+      - "${DOCKER_GID:-988}"
+    depends_on:
+      - mosquitto
+    networks:
+      - internal
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: codex-slack-mosquitto-remote
+    entrypoint:
+      - sh
+      - -c
+      - |
+        printf 'listener 1883\nallow_anonymous true\npersistence false\nlog_type error\n' \
+          > /mosquitto/config/mosquitto.conf
+        exec mosquitto -c /mosquitto/config/mosquitto.conf
+    networks:
+      - internal
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mosquitto_sub", "-h", "localhost", "-t", "$SYS/broker/uptime", "-c", "1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  master_data:

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -27,7 +27,7 @@
         :class="m.sender === 'user' ? 'user' : 'agent'"
       >
         <span class="label">{{ m.sender === 'user' ? 'You' : (m.agent_name ? `@${m.agent_name}` : 'Agent') }}</span>
-        <div class="bubble">
+        <div class="bubble" :class="{'bubble-streaming': m.sender === 'agent' && m.streaming, 'bubble-done': m.sender === 'agent' && !m.streaming}">
           <template v-if="m.sender === 'agent'">
             <template v-if="m.streaming && m.rows?.length">
               <div class="trace-row" v-for="(row, i) in m.rows" :key="i">
@@ -101,6 +101,12 @@
           </template>
           <template v-else><MarkdownMessage :text="m.text" /></template>
         </div>
+        <button
+          v-if="m.sender === 'agent' && m.streaming"
+          class="cancel-btn"
+          @click="cancelMessage(m.id)"
+          title="Cancel this response"
+        >&#9632; Stop</button>
         <div v-if="m.attachments && m.attachments.length" class="attachment-list">
           <template v-for="a in m.attachments" :key="a.id">
             <div v-if="a.mime_type && a.mime_type.startsWith('image/')" class="attachment-img-wrap">
@@ -615,6 +621,16 @@ async function sendMessage() {
 
 function toggleRaw(id) { rawView.value[id] = !rawView.value[id] }
 
+async function cancelMessage(messageId) {
+  try {
+    await fetch(`/api/workspaces/${wsId}/topics/${topicId}/messages/${messageId}/cancel`, {
+      method: 'POST',
+    })
+  } catch (_) {
+    // ignore — the streaming bubble will finalize when the agent responds
+  }
+}
+
 function isDispatchPayload(transcript) {
   if (!transcript) return false
   try { const p = JSON.parse(transcript); return p && typeof p === 'object' && 'adapter' in p } catch { return false }
@@ -706,7 +722,9 @@ onUnmounted(() => {
 .label { font-size: 0.75em; color: #64748b; margin-bottom: 2px; }
 .bubble { padding: 0.6rem 0.9rem; border-radius: 12px; line-height: 1.45; }
 .message.user .bubble { background: #fff; color: #1e293b; border: 1px solid #2563eb; border-bottom-right-radius: 3px; max-width: 100%; overflow: hidden; }
-.message.agent .bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 3px; max-width: 100%; overflow: hidden; }
+.message.agent .bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 3px; max-width: 100%; overflow: hidden; transition: border-color 0.3s; }
+.bubble-streaming { border-color: #f97316 !important; box-shadow: 0 0 0 1px #f9731640; }
+.bubble-done { border-color: #22c55e !important; }
 .ts { font-size: 0.7em; color: #94a3b8; margin-top: 2px; }
 .detail-panel { margin-top: 4px; max-width: 100%; }
 .detail-toggle { font-size: 0.72em; color: #94a3b8; cursor: pointer; user-select: none; display: flex; align-items: center; gap: 0.5rem; }
@@ -750,6 +768,8 @@ onUnmounted(() => {
 .dispatch-meta { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; font-size: 0.78em; }
 .dispatch-info { color: #64748b; }
 .dispatch-cmd { font-size: 0.72em; max-height: 200px; overflow-x: auto; white-space: pre; }
+.cancel-btn { align-self: flex-start; margin-top: 4px; padding: 2px 10px; background: #fee2e2; color: #dc2626; border: 1px solid #fca5a5; border-radius: 4px; cursor: pointer; font-size: 0.78em; }
+.cancel-btn:hover { background: #fecaca; }
 .send-error { color: #dc2626; font-size: 0.85em; margin-top: 0.25rem; }
 .hint { font-size: 0.8em; text-align: right; margin-top: 0.25rem; }
 .muted { color: #64748b; }

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import threading
 import urllib.request
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -21,6 +22,10 @@ _LLM_TIMEOUT = None  # no timeout — claude/codex can run as long as needed
 
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="agent-llm")
 
+# Tracks active claude subprocesses by reply_message_id so they can be killed on cancel.
+_active_procs: dict[str, subprocess.Popen] = {}  # type: ignore[type-arg]
+_active_procs_lock = threading.Lock()
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -29,6 +34,13 @@ def _now() -> str:
 def _parse_prompt_topic(raw: str) -> tuple[str, str] | None:
     parts = raw.split("/")
     if len(parts) != _TOPIC_PARTS or parts[5] != "prompt":
+        return None
+    return parts[2], parts[4]  # workspace_id, topic_id
+
+
+def _parse_cancel_topic(raw: str) -> tuple[str, str] | None:
+    parts = raw.split("/")
+    if len(parts) != _TOPIC_PARTS or parts[5] != "cancel":
         return None
     return parts[2], parts[4]  # workspace_id, topic_id
 
@@ -119,37 +131,44 @@ def _stream_claude_once(
     is_error = False
     seq = seq_start
     outputs: list[str] = []
+    proc = None
     try:
         proc = subprocess.Popen(
             cmd, cwd=worktree,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             text=True, bufsize=1,
         )
-        for line in proc.stdout:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            events.append(event)
-            client.publish(chunk_topic, json.dumps({
-                "message_id": reply_message_id,
-                "agent_name": agent_name,
-                "seq": seq,
-                "event": event,
-            }), qos=0)
-            LOGGER.debug("agent.llm_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
-            seq += 1
-            if event.get("type") == "result":
-                new_session_id = event.get("session_id")
-                result_text = event.get("result") or event.get("last_response")
-                if result_text:
-                    outputs.append(result_text)
-                if event.get("is_error"):
-                    is_error = True
-        proc.wait()
+        with _active_procs_lock:
+            _active_procs[reply_message_id] = proc
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                events.append(event)
+                client.publish(chunk_topic, json.dumps({
+                    "message_id": reply_message_id,
+                    "agent_name": agent_name,
+                    "seq": seq,
+                    "event": event,
+                }), qos=0)
+                LOGGER.debug("agent.llm_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
+                seq += 1
+                if event.get("type") == "result":
+                    new_session_id = event.get("session_id")
+                    result_text = event.get("result") or event.get("last_response")
+                    if result_text:
+                        outputs.append(result_text)
+                    if event.get("is_error"):
+                        is_error = True
+            proc.wait()
+        finally:
+            with _active_procs_lock:
+                _active_procs.pop(reply_message_id, None)
         output = "\n\n---\n\n".join(outputs) if outputs else None
         if not output:
             err = (proc.stderr.read() or "").strip()
@@ -163,10 +182,14 @@ def _stream_claude_once(
     except FileNotFoundError:
         return "(claude CLI not found in agent container)", None, None, True
     except Exception as exc:
-        try:
-            proc.kill()
-        finally:
-            return f"(claude error: {exc})", None, None, True
+        if proc is not None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        with _active_procs_lock:
+            _active_procs.pop(reply_message_id, None)
+        return f"(claude error: {exc})", None, None, True
 
 
 def _run_claude(
@@ -435,8 +458,10 @@ def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -
         return
     workspace_id = userdata["workspace_id"]
     prompt_sub = f"codex-slack/workspace/{workspace_id}/topic/+/prompt"
+    cancel_sub = f"codex-slack/workspace/{workspace_id}/topic/+/cancel"
     client.subscribe(prompt_sub, qos=1)
-    LOGGER.info("agent.mqtt_connected subscribed=%s", prompt_sub)
+    client.subscribe(cancel_sub, qos=1)
+    LOGGER.info("agent.mqtt_connected subscribed=%s,%s", prompt_sub, cancel_sub)
 
 
 def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
@@ -445,6 +470,28 @@ def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) 
 
 def _on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
     LOGGER.info("agent.mqtt_message topic=%s bytes=%d", msg.topic, len(msg.payload))
+
+    parsed_cancel = _parse_cancel_topic(msg.topic)
+    if parsed_cancel is not None:
+        _, topic_id = parsed_cancel
+        try:
+            payload = json.loads(msg.payload)
+            cancel_msg_id = payload.get("message_id")
+        except Exception:
+            cancel_msg_id = None
+        if cancel_msg_id:
+            with _active_procs_lock:
+                proc = _active_procs.get(cancel_msg_id)
+            if proc is not None:
+                LOGGER.info("agent.cancel message_id=%s pid=%s", cancel_msg_id, proc.pid)
+                try:
+                    proc.kill()
+                except Exception:
+                    LOGGER.exception("agent.cancel_kill_failed message_id=%s", cancel_msg_id)
+            else:
+                LOGGER.info("agent.cancel_noop message_id=%s reason=not_found", cancel_msg_id)
+        return
+
     parsed = _parse_prompt_topic(msg.topic)
     if parsed is None:
         return

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -202,6 +202,27 @@ def _read_transcript(db_path: str, message_id: str) -> str | None:
         conn.close()
 
 
+@router.post("/{message_id}/cancel", status_code=202)
+async def cancel_message(
+    workspace_id: str,
+    topic_id: str,
+    message_id: str,
+    request: Request,
+) -> dict:  # type: ignore[type-arg]
+    """Signal the agent to abort an in-progress response.
+
+    Publishes a cancel MQTT message; the agent kills the running subprocess and
+    publishes a normal (partial) response, which finalises the streaming bubble.
+    """
+    mqtt_cancel_topic = f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/cancel"
+    request.app.state.mqtt.publish(
+        mqtt_cancel_topic,
+        json.dumps({"message_id": message_id}),
+        qos=1,
+    )
+    return {"status": "cancel_requested", "message_id": message_id}
+
+
 @router.get("", response_model=list[MessageOut])
 def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[MessageOut]:
     conn = get_connection(request.app.state.db_path)

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -417,9 +417,9 @@ def test_on_connect_subscribes_to_workspace_topic():
     reason = MagicMock()
     reason.is_failure = False
     _on_connect(client, {"workspace_id": "ws42"}, None, reason, None)
-    topic = client.subscribe.call_args.args[0]
-    assert "ws42" in topic
-    assert topic.endswith("/prompt")
+    subscribed_topics = [call.args[0] for call in client.subscribe.call_args_list]
+    assert any("ws42" in t and t.endswith("/prompt") for t in subscribed_topics)
+    assert any("ws42" in t and t.endswith("/cancel") for t in subscribed_topics)
 
 
 # --- _fetch_attachment ---


### PR DESCRIPTION
## Summary

Closes #122.

- **Agent cancel**: agent MQTT loop subscribes to a per-topic `cancel` topic; on cancel message, kills the in-flight `subprocess.Popen` keyed by `reply_message_id` (thread-safe with `threading.Lock`)
- **Master endpoint**: `POST /workspaces/{wid}/topics/{tid}/messages/{mid}/cancel` publishes the cancel MQTT message
- **Frontend UI**: agent message bubbles get an orange outline while streaming and green when done; a ■ Stop button appears below streaming bubbles and calls the cancel endpoint

## Test plan

- [x] Send a message that triggers a long agent response
- [x] While streaming, click ■ Stop — bubble should stop updating and turn green
- [x] Send a normal message — full response arrives, bubble turns green on completion
- [x] Orange outline appears while streaming, transitions to green on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)