### PR TITLE
feat(ui): add copy button to copy raw message text

### DIFF
--- a/frontend/src/components/MarkdownMessage.vue
+++ b/frontend/src/components/MarkdownMessage.vue
@@ -73,7 +73,18 @@ const expanded = ref(false)
 const copied = ref(false)
 
 async function copyText() {
-  await navigator.clipboard.writeText(props.text)
+  try {
+    await navigator.clipboard.writeText(props.text)
+  } catch {
+    // Fallback for non-secure (HTTP) contexts where clipboard API is unavailable
+    const ta = document.createElement('textarea')
+    ta.value = props.text
+    ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none'
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    ta.remove()
+  }
   copied.value = true
   setTimeout(() => { copied.value = false }, 1500)
 }

--- a/frontend/src/components/MarkdownMessage.vue
+++ b/frontend/src/components/MarkdownMessage.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="md-wrap">
     <div class="md-body" ref="container" v-html="rendered"></div>
-    <button class="expand-btn" @click="expanded = true" title="Expand message">⛶</button>
+    <div class="msg-actions">
+      <button class="action-btn" @click="copyText" :title="copied ? 'Copied!' : 'Copy raw text'">{{ copied ? '✓' : '⎘' }}</button>
+      <button class="action-btn" @click="expanded = true" title="Expand message">⛶</button>
+    </div>
   </div>
   <Teleport to="body">
     <div v-if="expanded" class="md-overlay" @click.self="expanded = false">
@@ -67,6 +70,13 @@ const props = defineProps({
 const container = ref(null)
 const dialogContainer = ref(null)
 const expanded = ref(false)
+const copied = ref(false)
+
+async function copyText() {
+  await navigator.clipboard.writeText(props.text)
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 1500)
+}
 
 const rendered = computed(() => marked.parse(props.text || ''))
 
@@ -112,9 +122,16 @@ onUnmounted(() => document.removeEventListener('keydown', onEsc))
 
 <style scoped>
 .md-wrap { position: relative; }
-.expand-btn {
+.msg-actions {
   position: absolute;
   top: 0; right: 0;
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.md-wrap:hover .msg-actions { opacity: 1; }
+.action-btn {
   background: rgba(255, 255, 255, 0.92);
   border: 1px solid #e2e8f0;
   border-radius: 4px;
@@ -123,11 +140,8 @@ onUnmounted(() => document.removeEventListener('keydown', onEsc))
   line-height: 1.5;
   cursor: pointer;
   color: #64748b;
-  opacity: 0;
-  transition: opacity 0.15s;
 }
-.md-wrap:hover .expand-btn { opacity: 1; }
-.expand-btn:hover { background: #f1f5f9; color: #1e293b; }
+.action-btn:hover { background: #f1f5f9; color: #1e293b; }
 
 /* ── fullscreen overlay ── */
 .md-overlay {


### PR DESCRIPTION
## Summary
- Adds a copy (⎘) button next to the expand (⛶) button on every message bubble in `MarkdownMessage.vue`
- Clicking the button writes the raw markdown text to the clipboard via `navigator.clipboard.writeText()`
- Briefly shows a ✓ confirmation for 1.5 s, then reverts to the ⎘ icon
- Refactors the single `expand-btn` into a shared `.msg-actions` group with a common `.action-btn` style so both buttons animate in together on hover

## Test plan
- [ ] Hover over any message bubble — both ⎘ and ⛶ buttons appear
- [ ] Click ⎘ — button briefly shows ✓, then returns to ⎘
- [ ] Paste clipboard contents elsewhere — verify raw markdown (not rendered HTML) was copied
- [ ] Click ⛶ — fullscreen expand still works as before
- [ ] Verify hover reveal and hover highlight still animate correctly

Closes #185

🤖 Generated with repository automation