### PR TITLE
feat: ping/pong liveness check and SIGTERM abort for stale message detection

### DIFF
--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import signal
 import subprocess
 import tempfile
 import threading
@@ -24,7 +25,11 @@ _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="agent-llm")
 
 # Tracks active claude subprocesses by reply_message_id so they can be killed on cancel.
 _active_procs: dict[str, subprocess.Popen] = {}  # type: ignore[type-arg]
+_active_contexts: dict[str, dict] = {}  # message_id → {workspace_id, topic_id, agent_name}
 _active_procs_lock = threading.Lock()
+
+# Module-level reference to the MQTT client, used by the SIGTERM handler.
+_mqtt_client_ref: mqtt.Client | None = None
 
 
 def _now() -> str:
@@ -41,6 +46,21 @@ def _parse_prompt_topic(raw: str) -> tuple[str, str] | None:
 def _parse_cancel_topic(raw: str) -> tuple[str, str] | None:
     parts = raw.split("/")
     if len(parts) != _TOPIC_PARTS or parts[5] != "cancel":
+        return None
+    return parts[2], parts[4]  # workspace_id, topic_id
+
+
+def _ping_topic(workspace_id: str, topic_id: str) -> str:
+    return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/ping"
+
+
+def _pong_topic(workspace_id: str, topic_id: str) -> str:
+    return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/pong"
+
+
+def _parse_ping_topic(raw: str) -> tuple[str, str] | None:
+    parts = raw.split("/")
+    if len(parts) != _TOPIC_PARTS or parts[5] != "ping":
         return None
     return parts[2], parts[4]  # workspace_id, topic_id
 
@@ -169,6 +189,11 @@ def _stream_claude_once(
         )
         with _active_procs_lock:
             _active_procs[reply_message_id] = proc
+            _active_contexts[reply_message_id] = {
+                "workspace_id": workspace_id,
+                "topic_id": topic_id,
+                "agent_name": agent_name,
+            }
         try:
             for line in proc.stdout:
                 line = line.strip()
@@ -198,6 +223,7 @@ def _stream_claude_once(
         finally:
             with _active_procs_lock:
                 _active_procs.pop(reply_message_id, None)
+                _active_contexts.pop(reply_message_id, None)
         output = "\n\n---\n\n".join(outputs) if outputs else None
         if not output:
             err = (proc.stderr.read() or "").strip()
@@ -218,6 +244,7 @@ def _stream_claude_once(
                 pass
         with _active_procs_lock:
             _active_procs.pop(reply_message_id, None)
+            _active_contexts.pop(reply_message_id, None)
         return f"(claude error: {exc})", None, None, True
 
 
@@ -508,17 +535,69 @@ def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -
     workspace_id = userdata["workspace_id"]
     prompt_sub = f"codex-slack/workspace/{workspace_id}/topic/+/prompt"
     cancel_sub = f"codex-slack/workspace/{workspace_id}/topic/+/cancel"
+    ping_sub = f"codex-slack/workspace/{workspace_id}/topic/+/ping"
     client.subscribe(prompt_sub, qos=1)
     client.subscribe(cancel_sub, qos=1)
-    LOGGER.info("agent.mqtt_connected subscribed=%s,%s", prompt_sub, cancel_sub)
+    client.subscribe(ping_sub, qos=0)
+    LOGGER.info("agent.mqtt_connected subscribed=%s,%s,%s", prompt_sub, cancel_sub, ping_sub)
 
 
 def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
     LOGGER.warning("agent.mqtt_disconnected reason=%s", reason_code)
 
 
+def _publish_interrupted_all(client: mqtt.Client) -> None:
+    """Kill active subprocesses and publish an interrupted response for each."""
+    with _active_procs_lock:
+        contexts = dict(_active_contexts)
+        procs = dict(_active_procs)
+    for message_id, ctx in contexts.items():
+        proc = procs.get(message_id)
+        if proc is not None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        try:
+            client.publish(
+                _response_topic(ctx["workspace_id"], ctx["topic_id"]),
+                json.dumps({
+                    "message_id": message_id,
+                    "agent_name": ctx["agent_name"],
+                    "reply_to": None,
+                    "last_response": "(message interrupted)",
+                    "transcript": None,
+                    "session_id": None,
+                }),
+                qos=1,
+            )
+            LOGGER.info("agent.sigterm_abort message_id=%s", message_id)
+        except Exception:
+            LOGGER.exception("agent.sigterm_abort_failed message_id=%s", message_id)
+
+
 def _on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
     LOGGER.info("agent.mqtt_message topic=%s bytes=%d", msg.topic, len(msg.payload))
+
+    parsed_ping = _parse_ping_topic(msg.topic)
+    if parsed_ping is not None:
+        workspace_id_ping, topic_id_ping = parsed_ping
+        try:
+            payload = json.loads(msg.payload)
+            message_id = payload.get("message_id")
+        except Exception:
+            message_id = None
+        if message_id:
+            with _active_procs_lock:
+                proc = _active_procs.get(message_id)
+            alive = proc is not None and proc.poll() is None
+            client.publish(
+                _pong_topic(workspace_id_ping, topic_id_ping),
+                json.dumps({"message_id": message_id, "alive": alive}),
+                qos=0,
+            )
+            LOGGER.info("agent.pong message_id=%s alive=%s", message_id, alive)
+        return
 
     parsed_cancel = _parse_cancel_topic(msg.topic)
     if parsed_cancel is not None:
@@ -578,4 +657,16 @@ def run_mqtt_loop(
     client.on_message = _on_message
     client.connect(mqtt_host, mqtt_port, keepalive=60)
     LOGGER.info("agent.mqtt_loop_start workspace_id=%s host=%s port=%s", workspace_id, mqtt_host, mqtt_port)
+
+    global _mqtt_client_ref
+    _mqtt_client_ref = client
+
+    def _sigterm_handler(signum, frame):
+        LOGGER.info("agent.sigterm_received active=%d", len(_active_procs))
+        _publish_interrupted_all(client)
+        import time
+        time.sleep(1)  # allow MQTT to flush QoS-1 messages
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, _sigterm_handler)
     client.loop_forever()

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -7,6 +7,7 @@ import sqlite3
 import threading
 import time
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -65,6 +66,111 @@ def _active_workspaces(db_path: str) -> list[dict]:  # type: ignore[type-arg]
         conn.close()
 
 
+_STALE_STREAM_TIMEOUT_SECONDS = 600  # 10 minutes
+
+
+def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
+    """Find orphaned chunk streams and mark them as interrupted.
+
+    A stream is stale when its chunks have no corresponding final message AND
+    either the agent container is not running or the chunks are older than
+    _STALE_STREAM_TIMEOUT_SECONDS.
+    """
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            orphaned = conn.execute(
+                "SELECT c.message_id, c.topic_id, c.agent_name,"
+                " MAX(c.created_at) AS last_chunk_at"
+                " FROM chunks c"
+                " LEFT JOIN messages m ON m.id = c.message_id"
+                " WHERE m.id IS NULL"
+                " GROUP BY c.message_id"
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        LOGGER.exception("master.stale_stream_query_failed")
+        return
+
+    if not orphaned:
+        return
+
+    now = time.time()
+    hub = getattr(app_state, "hub", None) if app_state else None
+    loop = getattr(app_state, "event_loop", None) if app_state else None
+
+    for row in orphaned:
+        message_id = row["message_id"]
+        topic_id = row["topic_id"]
+        agent_name = row["agent_name"]
+        last_chunk_at = row["last_chunk_at"] or 0.0
+
+        chunk_age = now - last_chunk_at
+        container_running = True
+
+        try:
+            conn = sqlite3.connect(db_path)
+            conn.row_factory = sqlite3.Row
+            try:
+                ws_row = conn.execute(
+                    "SELECT w.container_name FROM workspaces w"
+                    " JOIN topics t ON t.workspace_id = w.id"
+                    " WHERE t.id = ?",
+                    (topic_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+            if ws_row and ws_row["container_name"]:
+                status = get_container_status(name=ws_row["container_name"], dry_run=settings.dry_run)
+                container_running = status["status"] == "running"
+        except Exception:
+            LOGGER.exception("master.stale_stream_container_check_failed message_id=%s", message_id)
+
+        is_stale = not container_running or chunk_age > _STALE_STREAM_TIMEOUT_SECONDS
+        if not is_stale:
+            continue
+
+        LOGGER.warning(
+            "master.stale_stream_interrupted message_id=%s topic_id=%s"
+            " container_running=%s chunk_age_s=%.0f",
+            message_id, topic_id, container_running, chunk_age,
+        )
+
+        try:
+            conn = sqlite3.connect(db_path)
+            try:
+                now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                with conn:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO messages"
+                        " (id, topic_id, sender, agent_name, text, created_at)"
+                        " VALUES (?, ?, 'agent', ?, ?, ?)",
+                        (message_id, topic_id, agent_name, "(message interrupted)", now_str),
+                    )
+                    conn.execute("DELETE FROM chunks WHERE message_id = ?", (message_id,))
+            finally:
+                conn.close()
+        except Exception:
+            LOGGER.exception("master.stale_stream_close_failed message_id=%s", message_id)
+            continue
+
+        if hub is not None and loop is not None:
+            hub.broadcast_threadsafe(
+                "_global",
+                {
+                    "type": "message",
+                    "topic_id": topic_id,
+                    "message_id": message_id,
+                    "sender": "agent",
+                    "agent_name": agent_name,
+                    "last_response": "(message interrupted)",
+                },
+                loop,
+            )
+
+
 def _background_tasks(settings, db_path: str, stop_event: threading.Event, app_state=None) -> None:
     """Background loop: scheduler tick, idle auto-stop, health-check respawn, and auth auto-refresh."""
     idle_timeout = settings.agent_idle_timeout_seconds
@@ -80,6 +186,12 @@ def _background_tasks(settings, db_path: str, stop_event: threading.Event, app_s
                 _scheduler_tick(db_path, app_state, datetime.now(_tz.utc))
             except Exception:
                 LOGGER.exception("master.scheduler_tick_failed")
+
+        # Stale stream detection — runs once per tick across all workspaces
+        try:
+            _close_stale_streams(db_path, settings, app_state)
+        except Exception:
+            LOGGER.exception("master.stale_stream_check_failed")
 
         try:
             workspaces = _active_workspaces(db_path)

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -67,6 +67,27 @@ def _active_workspaces(db_path: str) -> list[dict]:  # type: ignore[type-arg]
 
 
 _STALE_STREAM_TIMEOUT_SECONDS = 600  # 10 minutes
+_PING_TIMEOUT_SECONDS = 10
+
+
+def _ping_for_alive(mqtt_client, app_state, workspace_id: str, topic_id: str, message_id: str) -> bool:
+    """Publish a ping and wait up to _PING_TIMEOUT_SECONDS for a pong. Returns True if alive."""
+    pending: dict = {"event": threading.Event(), "alive": None}
+    pending_pings = getattr(app_state, "pending_pings", {})
+    pending_pings[message_id] = pending
+    try:
+        ping_topic = f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/ping"
+        mqtt_client.publish(ping_topic, json.dumps({"message_id": message_id}), qos=0)
+        fired = pending["event"].wait(timeout=_PING_TIMEOUT_SECONDS)
+        if not fired:
+            LOGGER.warning("master.ping_timeout message_id=%s topic_id=%s", message_id, topic_id)
+            return False
+        return pending["alive"] is True
+    except Exception:
+        LOGGER.exception("master.ping_failed message_id=%s", message_id)
+        return False
+    finally:
+        pending_pings.pop(message_id, None)
 
 
 def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
@@ -109,13 +130,16 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
 
         chunk_age = now - last_chunk_at
         container_running = True
+        ws_row = None
+
+        mqtt_client = getattr(app_state, "mqtt", None) if app_state else None
 
         try:
             conn = sqlite3.connect(db_path)
             conn.row_factory = sqlite3.Row
             try:
                 ws_row = conn.execute(
-                    "SELECT w.container_name FROM workspaces w"
+                    "SELECT w.id AS workspace_id, w.container_name FROM workspaces w"
                     " JOIN topics t ON t.workspace_id = w.id"
                     " WHERE t.id = ?",
                     (topic_id,),
@@ -128,7 +152,17 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
         except Exception:
             LOGGER.exception("master.stale_stream_container_check_failed message_id=%s", message_id)
 
-        is_stale = not container_running or chunk_age > _STALE_STREAM_TIMEOUT_SECONDS
+        if container_running:
+            if mqtt_client is not None and ws_row:
+                workspace_id = ws_row["workspace_id"]
+                alive = _ping_for_alive(mqtt_client, app_state, workspace_id, topic_id, message_id)
+                is_stale = not alive
+            else:
+                # No mqtt client available — fall back to age timeout
+                is_stale = chunk_age > _STALE_STREAM_TIMEOUT_SECONDS
+        else:
+            is_stale = True  # container not running → definitely stale
+
         if not is_stale:
             continue
 
@@ -453,6 +487,7 @@ async def lifespan(app: FastAPI):  # type: ignore[type-arg]
     app.state.event_worker_last_progress = None
     app.state.gate_futures = {}  # message_id → asyncio.Future; resolves gate actions
     app.state.veto_futures = {}  # message_id → asyncio.Future; used by veto_dispatch
+    app.state.pending_pings = {}  # message_id → {"event": threading.Event, "alive": bool|None}
     event_worker_task = asyncio.create_task(event_worker(app.state))
     watchdog_task = asyncio.create_task(worker_watchdog(app.state))
     LOGGER.info("master.event_worker_start")

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -18,6 +18,7 @@ _RESPONSE_TOPIC = "codex-slack/workspace/+/topic/+/response"
 _STATUS_TOPIC = "codex-slack/workspace/+/topic/+/status"
 _CHUNK_TOPIC = "codex-slack/workspace/+/topic/+/chunk"
 _VERDICT_TOPIC = "codex-slack/workspace/+/topic/+/verdict"
+_PONG_TOPIC = "codex-slack/workspace/+/topic/+/pong"
 
 # Topic pattern: codex-slack/workspace/{wid}/topic/{tid}/{type}
 _TOPIC_PARTS = 6
@@ -299,7 +300,11 @@ def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -
     client.subscribe(_STATUS_TOPIC, qos=0)
     client.subscribe(_CHUNK_TOPIC, qos=0)
     client.subscribe(_VERDICT_TOPIC, qos=1)
-    LOGGER.info("mqtt.subscribed topics=%s,%s,%s,%s", _RESPONSE_TOPIC, _STATUS_TOPIC, _CHUNK_TOPIC, _VERDICT_TOPIC)
+    client.subscribe(_PONG_TOPIC, qos=0)
+    LOGGER.info(
+        "mqtt.subscribed topics=%s,%s,%s,%s,%s",
+        _RESPONSE_TOPIC, _STATUS_TOPIC, _CHUNK_TOPIC, _VERDICT_TOPIC, _PONG_TOPIC,
+    )
 
 
 def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
@@ -406,6 +411,20 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
             reply_to,
             payload.get("verdict"),
         )
+    elif msg_type == "pong":
+        try:
+            app_state = userdata.get("app_state")
+            if app_state:
+                message_id = payload.get("message_id")
+                alive = payload.get("alive", False)
+                pending_pings = getattr(app_state, "pending_pings", {})
+                pending = pending_pings.get(message_id)
+                if pending is not None:
+                    pending["alive"] = alive
+                    pending["event"].set()
+                    LOGGER.info("mqtt.pong_received message_id=%s alive=%s", message_id, alive)
+        except Exception:
+            LOGGER.exception("mqtt.pong_handler_error")
         return
     else:
         return

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -5,10 +5,12 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+import src.agent.mqtt_loop as mqtt_loop_module
 from src.agent.mqtt_loop import (
     _fetch_attachment,
     _parse_prompt_topic,
     _process_prompt,
+    _publish_interrupted_all,
     _run_claude,
     _run_codex,
     _ensure_worktree,
@@ -546,3 +548,98 @@ def test_process_prompt_no_attachments_no_note(tmp_path):
             )
 
     assert captured_text["text"] == "plain prompt"
+
+
+# ---------------------------------------------------------------------------
+# Ping / pong tests
+# ---------------------------------------------------------------------------
+
+def _make_ping_msg(workspace_id: str, topic_id: str, message_id: str) -> MagicMock:
+    msg = MagicMock()
+    msg.topic = f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/ping"
+    msg.payload = json.dumps({"message_id": message_id}).encode()
+    return msg
+
+
+def test_pong_alive_true_when_proc_running():
+    """Ping for a message whose process is actively running → pong with alive=True."""
+    client = MagicMock()
+    userdata = {"workspace_id": "ws1", "repo_dir": ""}
+
+    proc = MagicMock()
+    proc.poll.return_value = None  # process still running
+
+    with patch.dict(mqtt_loop_module._active_procs, {"msg-run": proc}, clear=True):
+        with patch.dict(mqtt_loop_module._active_contexts, {}, clear=True):
+            msg = _make_ping_msg("ws1", "t1", "msg-run")
+            _on_message(client, userdata, msg)
+
+    publish_calls = client.publish.call_args_list
+    pong_call = next((c for c in publish_calls if "pong" in c.args[0]), None)
+    assert pong_call is not None, "no pong published"
+    payload = json.loads(pong_call.args[1])
+    assert payload["message_id"] == "msg-run"
+    assert payload["alive"] is True
+
+
+def test_pong_alive_false_when_proc_not_found():
+    """Ping for an unknown message_id → pong with alive=False."""
+    client = MagicMock()
+    userdata = {"workspace_id": "ws1", "repo_dir": ""}
+
+    with patch.dict(mqtt_loop_module._active_procs, {}, clear=True):
+        with patch.dict(mqtt_loop_module._active_contexts, {}, clear=True):
+            msg = _make_ping_msg("ws1", "t1", "msg-unknown")
+            _on_message(client, userdata, msg)
+
+    pong_call = next((c for c in client.publish.call_args_list if "pong" in c.args[0]), None)
+    assert pong_call is not None
+    payload = json.loads(pong_call.args[1])
+    assert payload["alive"] is False
+
+
+def test_pong_alive_false_when_proc_exited():
+    """Ping for a message whose process has already exited → pong with alive=False."""
+    client = MagicMock()
+    userdata = {"workspace_id": "ws1", "repo_dir": ""}
+
+    proc = MagicMock()
+    proc.poll.return_value = 0  # process exited with code 0
+
+    with patch.dict(mqtt_loop_module._active_procs, {"msg-done": proc}, clear=True):
+        with patch.dict(mqtt_loop_module._active_contexts, {}, clear=True):
+            msg = _make_ping_msg("ws1", "t1", "msg-done")
+            _on_message(client, userdata, msg)
+
+    pong_call = next((c for c in client.publish.call_args_list if "pong" in c.args[0]), None)
+    assert pong_call is not None
+    payload = json.loads(pong_call.args[1])
+    assert payload["alive"] is False
+
+
+def test_publish_interrupted_all():
+    """_publish_interrupted_all kills procs and publishes interrupted response for each."""
+    client = MagicMock()
+
+    proc = MagicMock()
+    procs = {"msg-abc": proc}
+    contexts = {
+        "msg-abc": {
+            "workspace_id": "ws1",
+            "topic_id": "t1",
+            "agent_name": "claude",
+        }
+    }
+
+    with patch.dict(mqtt_loop_module._active_procs, procs, clear=True):
+        with patch.dict(mqtt_loop_module._active_contexts, contexts, clear=True):
+            _publish_interrupted_all(client)
+
+    proc.kill.assert_called_once()
+
+    response_calls = [c for c in client.publish.call_args_list if "response" in c.args[0]]
+    assert len(response_calls) == 1
+    payload = json.loads(response_calls[0].args[1])
+    assert payload["message_id"] == "msg-abc"
+    assert payload["last_response"] == "(message interrupted)"
+    assert payload["agent_name"] == "claude"

--- a/tests/master/test_main.py
+++ b/tests/master/test_main.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import sqlite3
+import time
 import os
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from src.master.main import app, _db_path, _STATIC_DIR
+from src.master.db import init_db
+from src.master.main import app, _db_path, _STATIC_DIR, _close_stale_streams, _STALE_STREAM_TIMEOUT_SECONDS
 
 
 @pytest.fixture()
@@ -80,3 +84,170 @@ def test_spa_serves_index_when_built(tmp_path, monkeypatch):
         r = c.get("/any/spa/path")
         assert r.status_code == 200
         assert "html" in r.text
+
+
+# ---------------------------------------------------------------------------
+# _close_stale_streams tests
+# ---------------------------------------------------------------------------
+
+_SEED_SQL = """
+INSERT OR IGNORE INTO workspaces
+    (id, name, repo_url, container_name, created_at)
+VALUES ('ws1', 'WS', 'https://github.com/x/y', 'agent-ws1', '2026-01-01T00:00:00Z');
+
+INSERT OR IGNORE INTO topics
+    (id, workspace_id, subject, branch_name, worktree_path, created_at)
+VALUES ('t1', 'ws1', 'Topic', 'feat/t1', '/tmp/wt1', '2026-01-01T00:00:00Z');
+"""
+
+
+@pytest.fixture()
+def stale_db(tmp_path):
+    path = str(tmp_path / "stale_test.db")
+    init_db(path)
+    conn = sqlite3.connect(path)
+    conn.executescript(_SEED_SQL)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _seed_chunks(db_path, message_id, topic_id="t1", agent_name="claude", age_seconds=0):
+    """Insert two chunks for message_id with created_at set to now - age_seconds."""
+    created_at = time.time() - age_seconds
+    conn = sqlite3.connect(db_path)
+    for seq in range(2):
+        conn.execute(
+            "INSERT INTO chunks (message_id, topic_id, seq, event, agent_name, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (message_id, topic_id, seq, '{"type":"assistant"}', agent_name, created_at),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _count_chunks(db_path, message_id):
+    conn = sqlite3.connect(db_path)
+    n = conn.execute("SELECT COUNT(*) FROM chunks WHERE message_id=?", (message_id,)).fetchone()[0]
+    conn.close()
+    return n
+
+
+def _get_message(db_path, message_id):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM messages WHERE id=?", (message_id,)).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def _make_settings(dry_run=True):
+    return SimpleNamespace(dry_run=dry_run)
+
+
+def test_close_stale_streams_no_orphans(stale_db):
+    """No chunks in DB → function exits cleanly with no DB changes."""
+    settings = _make_settings()
+    _close_stale_streams(stale_db, settings)
+    # No messages should have been inserted
+    conn = sqlite3.connect(stale_db)
+    count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    conn.close()
+    assert count == 0
+
+
+def test_close_stale_streams_container_stopped_marks_interrupted(stale_db):
+    """Orphaned chunks with a stopped container → message inserted as interrupted."""
+    _seed_chunks(stale_db, "msg-dead")
+    settings = _make_settings(dry_run=False)
+
+    with patch("src.master.main.get_container_status", return_value={"status": "exited", "exit_code": 1}):
+        _close_stale_streams(stale_db, settings)
+
+    msg = _get_message(stale_db, "msg-dead")
+    assert msg is not None
+    assert msg["text"] == "(message interrupted)"
+    assert msg["sender"] == "agent"
+    assert _count_chunks(stale_db, "msg-dead") == 0
+
+
+def test_close_stale_streams_container_running_recent_chunks_skipped(stale_db):
+    """Orphaned chunks with a running container and recent chunks → not stale."""
+    _seed_chunks(stale_db, "msg-live", age_seconds=30)  # very recent
+    settings = _make_settings(dry_run=False)
+
+    with patch("src.master.main.get_container_status", return_value={"status": "running"}):
+        _close_stale_streams(stale_db, settings)
+
+    assert _get_message(stale_db, "msg-live") is None
+    assert _count_chunks(stale_db, "msg-live") == 2
+
+
+def test_close_stale_streams_timeout_marks_interrupted_even_when_running(stale_db):
+    """Chunks older than STALE_STREAM_TIMEOUT_SECONDS are stale even if container is running."""
+    old_age = _STALE_STREAM_TIMEOUT_SECONDS + 60
+    _seed_chunks(stale_db, "msg-old", age_seconds=old_age)
+    settings = _make_settings(dry_run=False)
+
+    with patch("src.master.main.get_container_status", return_value={"status": "running"}):
+        _close_stale_streams(stale_db, settings)
+
+    msg = _get_message(stale_db, "msg-old")
+    assert msg is not None
+    assert msg["text"] == "(message interrupted)"
+    assert _count_chunks(stale_db, "msg-old") == 0
+
+
+def test_close_stale_streams_broadcasts_ws_message(stale_db):
+    """When a stale stream is closed, a WS message event is broadcast."""
+    _seed_chunks(stale_db, "msg-bcast")
+    settings = _make_settings(dry_run=False)
+
+    hub = MagicMock()
+    loop = MagicMock()
+    app_state = SimpleNamespace(hub=hub, event_loop=loop)
+
+    with patch("src.master.main.get_container_status", return_value={"status": "exited", "exit_code": 1}):
+        _close_stale_streams(stale_db, settings, app_state)
+
+    hub.broadcast_threadsafe.assert_called_once()
+    call_args = hub.broadcast_threadsafe.call_args
+    payload = call_args[0][1]
+    assert payload["type"] == "message"
+    assert payload["message_id"] == "msg-bcast"
+    assert payload["last_response"] == "(message interrupted)"
+
+
+def test_close_stale_streams_already_finalized_not_duplicated(stale_db):
+    """If a message row already exists, INSERT OR IGNORE prevents a duplicate."""
+    _seed_chunks(stale_db, "msg-dup")
+    # Pre-insert a final message to simulate a race where the agent responded
+    conn = sqlite3.connect(stale_db)
+    conn.execute(
+        "INSERT INTO messages (id, topic_id, sender, agent_name, text, created_at)"
+        " VALUES ('msg-dup', 't1', 'agent', 'claude', 'The real answer', '2026-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    conn.close()
+
+    # The LEFT JOIN in the query means this message_id won't appear as orphaned
+    settings = _make_settings(dry_run=False)
+    with patch("src.master.main.get_container_status", return_value={"status": "exited", "exit_code": 1}):
+        _close_stale_streams(stale_db, settings)
+
+    msg = _get_message(stale_db, "msg-dup")
+    assert msg["text"] == "The real answer"  # original text preserved
+
+
+def test_close_stale_streams_dry_run_uses_dry_run_status(stale_db):
+    """In dry_run mode get_container_status returns 'dry_run' status — treated as not running."""
+    _seed_chunks(stale_db, "msg-dry")
+    settings = _make_settings(dry_run=True)
+
+    # dry_run=True means get_container_status returns {"status": "dry_run", ...}
+    # That is not "running", so should be treated as stale
+    _close_stale_streams(stale_db, settings)
+
+    msg = _get_message(stale_db, "msg-dry")
+    assert msg is not None
+    assert msg["text"] == "(message interrupted)"

--- a/tests/master/test_main.py
+++ b/tests/master/test_main.py
@@ -11,7 +11,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.master.db import init_db
-from src.master.main import app, _db_path, _STATIC_DIR, _close_stale_streams, _STALE_STREAM_TIMEOUT_SECONDS
+from src.master.main import (
+    app,
+    _db_path,
+    _STATIC_DIR,
+    _close_stale_streams,
+    _ping_for_alive,
+    _STALE_STREAM_TIMEOUT_SECONDS,
+    _PING_TIMEOUT_SECONDS,
+)
 
 
 @pytest.fixture()
@@ -251,3 +259,74 @@ def test_close_stale_streams_dry_run_uses_dry_run_status(stale_db):
     msg = _get_message(stale_db, "msg-dry")
     assert msg is not None
     assert msg["text"] == "(message interrupted)"
+
+
+# ---------------------------------------------------------------------------
+# Ping-based staleness tests
+# ---------------------------------------------------------------------------
+
+def _make_app_state_with_mqtt(mqtt_client):
+    """Build a minimal app_state SimpleNamespace with the given mqtt client."""
+    import threading
+    state = SimpleNamespace(
+        hub=MagicMock(),
+        event_loop=MagicMock(),
+        mqtt=mqtt_client,
+        pending_pings={},
+    )
+    return state
+
+
+def test_close_stale_streams_ping_alive_skips(stale_db):
+    """Container running + ping returns alive=True → stream NOT closed."""
+    _seed_chunks(stale_db, "msg-live-ping", age_seconds=30)
+    settings = _make_settings(dry_run=False)
+
+    mqtt_client = MagicMock()
+
+    with patch("src.master.main.get_container_status", return_value={"status": "running"}):
+        with patch("src.master.main._ping_for_alive", return_value=True):
+            app_state = _make_app_state_with_mqtt(mqtt_client)
+            _close_stale_streams(stale_db, settings, app_state)
+
+    assert _get_message(stale_db, "msg-live-ping") is None
+    assert _count_chunks(stale_db, "msg-live-ping") == 2
+
+
+def test_close_stale_streams_ping_dead_closes(stale_db):
+    """Container running + ping returns alive=False → stream closed."""
+    _seed_chunks(stale_db, "msg-dead-ping", age_seconds=30)
+    settings = _make_settings(dry_run=False)
+
+    mqtt_client = MagicMock()
+
+    with patch("src.master.main.get_container_status", return_value={"status": "running"}):
+        with patch("src.master.main._ping_for_alive", return_value=False):
+            app_state = _make_app_state_with_mqtt(mqtt_client)
+            _close_stale_streams(stale_db, settings, app_state)
+
+    msg = _get_message(stale_db, "msg-dead-ping")
+    assert msg is not None
+    assert msg["text"] == "(message interrupted)"
+    assert _count_chunks(stale_db, "msg-dead-ping") == 0
+
+
+def test_close_stale_streams_ping_timeout_closes(stale_db):
+    """Container running + no pong within timeout → stream closed."""
+    import src.master.main as main_module
+
+    _seed_chunks(stale_db, "msg-timeout-ping", age_seconds=30)
+    settings = _make_settings(dry_run=False)
+
+    mqtt_client = MagicMock()
+
+    with patch("src.master.main.get_container_status", return_value={"status": "running"}):
+        with patch.object(main_module, "_PING_TIMEOUT_SECONDS", 0.1):
+            # mqtt_client.publish does nothing; no pong arrives → event never set → timeout
+            app_state = _make_app_state_with_mqtt(mqtt_client)
+            _close_stale_streams(stale_db, settings, app_state)
+
+    msg = _get_message(stale_db, "msg-timeout-ping")
+    assert msg is not None
+    assert msg["text"] == "(message interrupted)"
+    assert _count_chunks(stale_db, "msg-timeout-ping") == 0

--- a/tests/master/test_mqtt_client.py
+++ b/tests/master/test_mqtt_client.py
@@ -10,6 +10,7 @@ from src.master.config import MasterSettings
 from src.master.mqtt_client import (
     _RESPONSE_TOPIC,
     _STATUS_TOPIC,
+    _PONG_TOPIC,
     _on_connect,
     _on_disconnect,
     _on_message,
@@ -156,6 +157,68 @@ def test_record_agent_response_sets_last_responded_at(tmp_path):
     conn.close()
     assert row[0] is not None
     assert row[0] != "2000-01-01T00:00:00Z"
+
+
+# --- pong handling ---
+
+def test_pong_resolves_pending_ping(tmp_path):
+    """A pong message sets the pending_ping event and records the alive value."""
+    import threading
+    from types import SimpleNamespace
+
+    db = _make_db(tmp_path)
+    message_id = "msg-ping-1"
+
+    event = threading.Event()
+    pending = {"event": event, "alive": None}
+    app_state = SimpleNamespace(pending_pings={message_id: pending})
+
+    msg = _make_msg(
+        "codex-slack/workspace/ws1/topic/t1/pong",
+        {"message_id": message_id, "alive": True},
+    )
+    settings = _make_settings()
+    _on_message(MagicMock(), {"db_path": db, "settings": settings, "app_state": app_state}, msg)
+
+    assert event.is_set(), "event should be set after pong"
+    assert pending["alive"] is True
+
+
+def test_pong_not_broadcast_to_websocket(tmp_path):
+    """Pong messages must not be forwarded to the WebSocket hub."""
+    import threading
+    from types import SimpleNamespace
+
+    db = _make_db(tmp_path)
+    message_id = "msg-ping-2"
+
+    event = threading.Event()
+    pending = {"event": event, "alive": False}
+    app_state = SimpleNamespace(pending_pings={message_id: pending})
+    hub = MagicMock()
+
+    msg = _make_msg(
+        "codex-slack/workspace/ws1/topic/t1/pong",
+        {"message_id": message_id, "alive": False},
+    )
+    settings = _make_settings()
+    _on_message(
+        MagicMock(),
+        {"db_path": db, "settings": settings, "app_state": app_state, "hub": hub, "loop": MagicMock()},
+        msg,
+    )
+
+    hub.broadcast_threadsafe.assert_not_called()
+
+
+def test_on_connect_subscribes_to_pong():
+    """Master _on_connect must subscribe to the pong wildcard topic."""
+    client = MagicMock()
+    reason_code = MagicMock()
+    reason_code.is_failure = False
+    _on_connect(client, None, None, reason_code, None)
+    subscribed_topics = {c.args[0] for c in client.subscribe.call_args_list}
+    assert _PONG_TOPIC in subscribed_topics
 
 
 # --- lifespan integration ---


### PR DESCRIPTION
## Summary

- Adds a ping/pong protocol between master and agent to confirm whether a subprocess is still alive before marking an orphaned chunk stream as interrupted. Replaces the naive age-only fallback when the container is running.
- Adds a SIGTERM handler in the agent that kills active subprocesses and publishes a `(message interrupted)` response for each, so master receives a final message even during graceful Docker stop.
- Initialises `app.state.pending_pings` in master lifespan; the master MQTT client subscribes to the pong wildcard topic and resolves pending ping futures on receipt.

## Test plan

- [x] `test_pong_alive_true_when_proc_running` — ping for a running process → pong alive=True
- [x] `test_pong_alive_false_when_proc_not_found` — ping for unknown message_id → alive=False
- [x] `test_pong_alive_false_when_proc_exited` — ping for exited process → alive=False
- [x] `test_publish_interrupted_all` — kills procs and publishes interrupted response
- [x] `test_close_stale_streams_ping_alive_skips` — container running + ping alive → stream not closed
- [x] `test_close_stale_streams_ping_dead_closes` — container running + ping dead → stream closed
- [x] `test_close_stale_streams_ping_timeout_closes` — no pong within timeout → stream closed
- [x] `test_pong_resolves_pending_ping` — pong message sets event and records alive value
- [x] `test_pong_not_broadcast_to_websocket` — pong never forwarded to hub
- [x] `test_on_connect_subscribes_to_pong` — master subscribes to pong wildcard on connect
- [x] All 538 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)