### PR TITLE
Retain message trace when interrupted

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -34,7 +34,11 @@
         :class="m.sender === 'user' ? 'user' : 'agent'"
       >
         <span class="label">{{ m.sender === 'user' ? 'You' : (m.agent_name ? `@${m.agent_name}` : 'Agent') }}</span>
-        <div class="bubble" :class="{'bubble-streaming': m.sender === 'agent' && m.streaming, 'bubble-done': m.sender === 'agent' && !m.streaming}">
+        <div class="bubble" :class="{
+          'bubble-streaming': m.sender === 'agent' && m.streaming,
+          'bubble-interrupted': m.sender === 'agent' && !m.streaming && m.text === '(message interrupted)',
+          'bubble-done': m.sender === 'agent' && !m.streaming && m.text !== '(message interrupted)'
+        }">
           <template v-if="m.sender === 'agent'">
             <template v-if="m.streaming && m.rows?.length">
               <div class="trace-row" v-for="(row, i) in m.rows" :key="i">
@@ -103,7 +107,10 @@
                 </div>
               </details>
             </template>
-            <MarkdownMessage :text="m.text" />
+            <div v-if="m.text === '(message interrupted)'" class="interrupted-notice">
+              <span class="tr-badge tr-badge-interrupted">interrupted</span>
+            </div>
+            <MarkdownMessage v-else :text="m.text" />
             <span v-if="m.streaming" class="cursor">▍</span>
           </template>
           <template v-else><MarkdownMessage :text="m.text" /></template>
@@ -741,6 +748,9 @@ onUnmounted(() => {
 .message.agent .bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 3px; max-width: 100%; overflow: hidden; transition: border-color 0.3s; }
 .bubble-streaming { border-color: #f97316 !important; box-shadow: 0 0 0 1px #f9731640; }
 .bubble-done { border-color: #22c55e !important; }
+.bubble-interrupted { border-color: #f59e0b !important; }
+.tr-badge-interrupted { background: #fef3c7; color: #92400e; }
+.interrupted-notice { padding: 2px 0; }
 .ts { font-size: 0.7em; color: #94a3b8; margin-top: 2px; }
 .detail-panel { margin-top: 4px; max-width: 100%; }
 .detail-toggle { font-size: 0.72em; color: #94a3b8; cursor: pointer; user-select: none; display: flex; align-items: center; gap: 0.5rem; }

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -172,16 +172,30 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
             message_id, topic_id, container_running, chunk_age,
         )
 
+        transcript_json = None
         try:
             conn = sqlite3.connect(db_path)
             try:
                 now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                chunk_rows = conn.execute(
+                    "SELECT event FROM chunks WHERE message_id = ? ORDER BY seq",
+                    (message_id,),
+                ).fetchall()
+                if chunk_rows:
+                    events = []
+                    for r in chunk_rows:
+                        try:
+                            events.append(json.loads(r[0]))
+                        except Exception:
+                            pass
+                    if events:
+                        transcript_json = json.dumps(events)
                 with conn:
                     conn.execute(
                         "INSERT OR IGNORE INTO messages"
-                        " (id, topic_id, sender, agent_name, text, created_at)"
-                        " VALUES (?, ?, 'agent', ?, ?, ?)",
-                        (message_id, topic_id, agent_name, "(message interrupted)", now_str),
+                        " (id, topic_id, sender, agent_name, text, transcript, created_at)"
+                        " VALUES (?, ?, 'agent', ?, ?, ?, ?)",
+                        (message_id, topic_id, agent_name, "(message interrupted)", transcript_json, now_str),
                     )
                     conn.execute("DELETE FROM chunks WHERE message_id = ?", (message_id,))
             finally:
@@ -200,6 +214,7 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
                     "sender": "agent",
                     "agent_name": agent_name,
                     "last_response": "(message interrupted)",
+                    "transcript": transcript_json,
                 },
                 loop,
             )

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -112,6 +112,20 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
             llm_session_id = payload.get("session_id")
             agent_name = payload.get("agent_name")
             message_id = payload.get("message_id") or str(uuid.uuid4())
+            if transcript is None and text == "(message interrupted)":
+                chunk_rows = conn.execute(
+                    "SELECT event FROM chunks WHERE message_id = ? ORDER BY seq",
+                    (message_id,),
+                ).fetchall()
+                if chunk_rows:
+                    events = []
+                    for r in chunk_rows:
+                        try:
+                            events.append(json.loads(r["event"]))
+                        except Exception:
+                            pass
+                    if events:
+                        transcript = json.dumps(events)
             usage_json = _extract_usage(transcript)
             with conn:
                 conn.execute(


### PR DESCRIPTION
## Summary
- Backend now preserves message chunks as transcript before deletion during interruption
- Handles both stale stream detection and SIGTERM abort cases
- Frontend displays trace, details panel, and "interrupted" badge with amber border
- Users can now see what work was completed before message was interrupted

## Test plan
- [ ] Trigger a stale stream interruption (e.g., agent timeout) and verify trace is shown
- [ ] Cancel a message and verify partial progress is visible with interrupted badge
- [ ] Verify "Show trace" and "Details" panels are functional for interrupted messages
- [ ] Check that trace rows display correct step information
- [ ] Verify interrupted messages use amber border color for visual distinction

Closes #193

🤖 Generated with Claude Code