### PR TITLE
fix(ui): clear seenSeq and liveStreams on topic switch

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -707,6 +707,8 @@ watch(
     topicId = newTopicId
     topic.value = null
     messages.value = []
+    liveStreams.value = {}
+    seenSeq.clear()
     agentStatus.value = ''
     load()
     if (!isArchived.value) connectWs()


### PR DESCRIPTION
## Summary

- `seenSeq` (a `Map` tracking seen chunk sequence numbers) was never cleared on topic switch, causing server-replayed chunks (`chunk_replay`) to be silently dropped by the `seq <= maxSeen` dedup guard when returning to a topic
- `liveStreams` was similarly not reset, leaving stale stream state from the previous visit
- Net effect: an in-progress streaming message was invisible after switching topics; only a full browser refresh (which re-instantiates both structures) would restore it
- Fix: reset both `liveStreams.value = {}` and `seenSeq.clear()` in the topic-switch watcher, so replayed chunks are processed cleanly on re-entry

## Test plan

- [ ] Open a topic and trigger a long agent response (so it streams for several seconds)
- [ ] While the message is still streaming, switch to a different topic
- [ ] Switch back to the original topic — the streaming message should be visible and continuing to update (no refresh needed)
- [ ] Confirm the message finalises correctly once the agent finishes
- [ ] Confirm switching topics while no stream is active still works normally

Fixes #192

🤖 Generated with repository automation