### PR TITLE
fix(ui): restore streaming bubble lost on topic switch before first chunk

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -410,7 +410,7 @@ function handleChunk({ message_id, agent_name, seq, event }) {
 
   let live = liveStreams.value[message_id]
   if (!live) {
-    live = { rows: [], text: '' }
+    live = { rows: [], text: '', agent_name: agent_name || null }
     liveStreams.value[message_id] = live
     messages.value.push({
       id: message_id, sender: 'agent',
@@ -492,6 +492,23 @@ async function load() {
       traceOpen: false,
       streaming: false,
     }))
+    // Re-apply any streaming bubbles that arrived via chunk_replay before load() finished.
+    // Also clean up liveStreams entries for messages that finalized while we were away.
+    for (const [mid, live] of Object.entries(liveStreams.value)) {
+      const existing = messages.value.find(m => m.id === mid)
+      if (!existing) {
+        messages.value.push({
+          id: mid, sender: 'agent',
+          agent_name: live.agent_name,
+          text: live.text, rows: live.rows,
+          streaming: true, traceOpen: false,
+          created_at: new Date().toISOString(),
+        })
+      } else if (!existing.streaming) {
+        delete liveStreams.value[mid]
+        seenSeq.delete(mid)
+      }
+    }
     if (wsRes.ok) workspace.value = await wsRes.json()
     if (tzRes.ok) {
       const tz = await tzRes.json()
@@ -714,6 +731,8 @@ watch(
     topicId = newTopicId
     topic.value = null
     messages.value = []
+    liveStreams.value = {}
+    seenSeq.clear()
     agentStatus.value = ''
     load()
     if (!isArchived.value) connectWs()


### PR DESCRIPTION
## Summary

- Race condition: `load()` and `connectWs()` run concurrently on topic switch; `load()` unconditionally overwrites `messages.value`, erasing any streaming bubble that `chunk_replay` pushed before the fetch completed
- Clears `liveStreams` and `seenSeq` on topic switch to eliminate stale state from prior visits
- Merges live-stream entries back into `messages.value` after `load()` sets it, so bubbles that arrived during the fetch are never lost

## Root cause

In the watch handler, `load()` (async, not awaited) and `connectWs()` start concurrently. When switching back to a topic before the first streaming chunk has arrived, `liveStreams[mid]` is empty — so `handleChunk` from `chunk_replay` both creates the entry **and** pushes the bubble to `messages.value`. If `load()` finishes afterward it wipes the bubble. Fix: store `agent_name` in `live`, clear `liveStreams`/`seenSeq` on switch, and re-apply surviving live-stream entries at the end of `load()`.

## Test plan

- [ ] Trigger message A on topic1, switch to topic2 before any chunk arrives, switch back — streaming bubble appears
- [ ] Trigger message A on topic1, wait for stream to start, switch to topic2, switch back — stream resumes correctly
- [ ] Stream that finalized while away loads as a completed message (not a streaming bubble)

🤖 Generated with [Claude Code](https://claude.com/claude-code)