### PR TITLE
fix(workspaces): branch listing and topic creation honor UI-configured GH_TOKEN

### DIFF
--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from .db import get_connection
+from .runtime_config import load_agent_env
 
 router = APIRouter(prefix="/workspaces/{workspace_id}/topics", tags=["topics"])
 recent_router = APIRouter(prefix="/topics", tags=["topics"])
@@ -152,7 +153,12 @@ def create_topic(workspace_id: str, body: TopicCreate, request: Request) -> Topi
     finally:
         conn.close()
 
-    base_sha = _fetch_ref_sha(ws_row["repo_url"], repo_ref, request.app.state.settings.gh_token)
+    # Honor UI-configured GH_TOKEN (runtime_config) when env is empty,
+    # otherwise base_sha lookup silently fails on private repos.
+    settings = request.app.state.settings
+    db_cfg = load_agent_env(request.app.state.db_path, workspace_id)
+    gh_token = settings.gh_token or db_cfg.get("GH_TOKEN")
+    base_sha = _fetch_ref_sha(ws_row["repo_url"], repo_ref, gh_token)
     if base_sha:
         conn2 = get_connection(request.app.state.db_path)
         try:

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -384,11 +384,15 @@ def list_workspace_branches(workspace_id: str, request: Request) -> list[str]:
         raise HTTPException(status_code=404, detail="workspace not found")
     repo_url: str = row["repo_url"]
     settings = request.app.state.settings
+    # Honor the UI-configured token (stored in runtime_config) when the
+    # process env doesn't carry GH_TOKEN. Matches refresh-auth's resolution.
+    db_cfg = load_agent_env(request.app.state.db_path, workspace_id)
+    gh_token = settings.gh_token or db_cfg.get("GH_TOKEN")
     parsed = _parse_github_repo(repo_url)
     if parsed is not None:
         owner, repo = parsed
         try:
-            return _fetch_github_branches(owner, repo, settings.gh_token)
+            return _fetch_github_branches(owner, repo, gh_token)
         except Exception:
             LOGGER.warning(
                 "workspaces.github_branches_failed owner=%s repo=%s, falling back to git ls-remote",
@@ -396,7 +400,7 @@ def list_workspace_branches(workspace_id: str, request: Request) -> list[str]:
                 repo,
             )
     try:
-        return _fetch_git_branches(repo_url, settings.gh_token)
+        return _fetch_git_branches(repo_url, gh_token)
     except Exception:
         LOGGER.exception("workspaces.git_branches_failed repo_url=%s", repo_url)
         raise HTTPException(status_code=502, detail="failed to fetch branches")

--- a/tests/master/test_workspaces.py
+++ b/tests/master/test_workspaces.py
@@ -138,3 +138,68 @@ def test_agent_status_dry_run(client):
 def test_agent_status_not_found(client):
     r = client.get("/api/workspaces/does-not-exist/agent-status")
     assert r.status_code == 404
+
+
+# --- list_workspace_branches: GH_TOKEN resolution ---
+
+
+def test_branches_uses_env_gh_token_when_set(client, monkeypatch):
+    """If GH_TOKEN is in env, list_workspace_branches passes it to the fetcher."""
+    monkeypatch.setenv("GH_TOKEN", "env-token")
+    # Rebuild settings to pick up the env var (the client fixture started
+    # the app before this monkeypatch).
+    from src.master.config import load_master_settings
+
+    client.app.state.settings = load_master_settings()
+
+    ws_id = create_ws(client, name="env-token-ws", repo_url="https://github.com/x/y").json()["id"]
+    with patch("src.master.workspaces._fetch_github_branches", return_value=["main"]) as m:
+        r = client.get(f"/api/workspaces/{ws_id}/branches")
+    assert r.status_code == 200
+    assert r.json() == ["main"]
+    m.assert_called_once_with("x", "y", "env-token")
+
+
+def test_branches_falls_back_to_db_gh_token(client, monkeypatch):
+    """Regression: when GH_TOKEN is unset in env but configured via the UI
+    (runtime_config DB), list_workspace_branches must use the DB value
+    instead of calling the GitHub API unauthenticated. Without this fix,
+    private repos return 502."""
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    from src.master.config import load_master_settings
+
+    client.app.state.settings = load_master_settings()
+    assert client.app.state.settings.gh_token is None
+
+    ws_id = create_ws(client, name="db-token-ws", repo_url="https://github.com/x/y").json()["id"]
+
+    # Configure GH_TOKEN via the global runtime-config endpoint (mirrors the UI path).
+    cfg_resp = client.patch("/api/config", json={"set": {"GH_TOKEN": "db-token"}})
+    assert cfg_resp.status_code == 200, cfg_resp.text
+
+    with patch("src.master.workspaces._fetch_github_branches", return_value=["main"]) as m:
+        r = client.get(f"/api/workspaces/{ws_id}/branches")
+    assert r.status_code == 200, r.text
+    m.assert_called_once_with("x", "y", "db-token")
+
+
+def test_branches_db_token_used_in_git_lsremote_fallback(client, monkeypatch):
+    """If the REST API fetcher raises, the git ls-remote fallback must
+    also receive the DB-resolved token (so a private repo can still
+    succeed via the fallback if the API path fails for any reason)."""
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    from src.master.config import load_master_settings
+
+    client.app.state.settings = load_master_settings()
+    ws_id = create_ws(
+        client, name="lsremote-ws", repo_url="https://github.com/x/y"
+    ).json()["id"]
+    cfg_resp = client.patch("/api/config", json={"set": {"GH_TOKEN": "db-token"}})
+    assert cfg_resp.status_code == 200, cfg_resp.text
+
+    with patch(
+        "src.master.workspaces._fetch_github_branches", side_effect=RuntimeError("api down")
+    ), patch("src.master.workspaces._fetch_git_branches", return_value=["main"]) as m:
+        r = client.get(f"/api/workspaces/{ws_id}/branches")
+    assert r.status_code == 200, r.text
+    m.assert_called_once_with("https://github.com/x/y", "db-token")


### PR DESCRIPTION
## Symptom

`GET /api/workspaces/<id>/branches` returns 502 (`{\"detail\":\"failed to fetch branches\"}`) for private repos *even when* the user has configured `GH_TOKEN` through the UI / runtime-config.

`POST /api/workspaces/<id>/topics` silently created topics with `base_sha = NULL` in the same scenario.

## Root cause

`GH_TOKEN` lives in two places:

- process env (`os.getenv(\"GH_TOKEN\")`, loaded into `settings.gh_token`)
- DB `config` table, written by the UI's `PATCH /api/config` endpoint

Most code paths resolve effective token as `settings.gh_token or db_cfg.get(\"GH_TOKEN\")` — see e.g. `workspaces.refresh-auth` at line 239. The branch-listing and topic-creation endpoints didn't follow that convention and read `settings.gh_token` only.

When prod (or any deployment) keeps the token in the UI config rather than env, those endpoints fall through to:

1. `api.github.com/.../branches` → 404 (no auth on a private repo)
2. fallback `git ls-remote https://github.com/...` → `fatal: could not read Username for 'https://github.com'`
3. HTTP 502

Reproduced against `https://github.com/pandazxx/gee-study.git` on dev with the UI-configured token. After fix: 200 OK.

## Fix

Two call sites updated to resolve the same way as `refresh-auth`:

- `workspaces.list_workspace_branches` — both the REST-API and `git ls-remote` paths now receive `settings.gh_token or db_cfg.get(\"GH_TOKEN\")`.
- `topics.create_topic` — `_fetch_ref_sha` now receives the resolved token, so `base_sha` is populated for private repos.

No other code paths need updating: `spawn_agent` calls (`create_workspace`, `restart-agent`, `_respawn_agents`) already pass `extra_env=load_agent_env(...)`, which `agent_runner.py` merges into the agent's env (line 58) — so the agent sees the right token even when master's settings doesn't.

## Test plan

- [x] `test_branches_uses_env_gh_token_when_set` — env-set token reaches the fetcher.
- [x] `test_branches_falls_back_to_db_gh_token` — DB-set token reaches the fetcher when env is empty.
- [x] `test_branches_db_token_used_in_git_lsremote_fallback` — fallback path also receives the resolved token.
- [x] `pytest -k 'workspaces or topics'` — 38 passed, 0 failed.
- [x] Live verification in dev env (`investigate-private-repo-branches`) against the real private repo `pandazxx/gee-study`: `GET /api/workspaces/<id>/branches` returns `200 [\"master\"]` with `GH_TOKEN` set only via UI.

🤖 Generated with repository automation