### PR TITLE
Reduce CI build time with pre-built base image and GHA cache

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,0 +1,44 @@
+name: Build base image
+
+# Rebuild and push the pre-built base image whenever Dockerfile.base changes.
+# This image is consumed by Dockerfile.test (CI) to avoid reinstalling heavy
+# system packages on every test run.
+#
+# First-time setup: trigger manually via workflow_dispatch to bootstrap the
+# base image before any CI run that depends on it.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - Dockerfile.base
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-base:
+    name: Build and push base image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.base
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/codex-slack-base:latest
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -9,7 +9,6 @@ name: Build base image
 
 on:
   push:
-    branches: [master]
     paths:
       - Dockerfile.base
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build test image
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml build master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,13 @@
-FROM python:3.11-slim AS prod
+FROM ghcr.io/pandazxx/codex-slack-base:latest AS prod
 
 ARG CODEX_NPM_PACKAGE=@openai/codex
 ARG CLAUDE_NPM_PACKAGE=@anthropic-ai/claude-code
 ARG APP_VERSION=dev
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    APP_VERSION=${APP_VERSION}
-
-# Add Docker's official apt repo so we get docker-ce-cli + compose plugin.
-# The podman package on Debian installs a podman-docker shim that shadows
-# /usr/bin/docker; real Docker CLI must come first to avoid Podman being
-# invoked when DOCKER_HOST points to a socket (CD daemon, master runtime).
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl gnupg \
-    && install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg \
-       -o /etc/apt/keyrings/docker.asc \
-    && chmod a+r /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
-       https://download.docker.com/linux/debian \
-       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-       > /etc/apt/sources.list.d/docker.list \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    curl \
-    docker-ce-cli \
-    docker-compose-plugin \
-    git \
-    gh \
-    jq \
-    less \
-    make \
-    openssh-client \
-    poppler-utils \
-    tini \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
+ENV APP_VERSION=${APP_VERSION}
 
 RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
 
-RUN useradd -m -u 1000 -s /bin/bash appuser \
-    && mkdir -p /workspace/home /home/appuser/.claude /home/appuser/.codex /opt/codex-slack/data/master \
-    && chown -R appuser:appuser /workspace /home/appuser/.claude /home/appuser/.codex /opt/codex-slack
 USER appuser
 WORKDIR /opt/codex-slack
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -41,3 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN useradd -m -u 1000 -s /bin/bash appuser \
     && mkdir -p /workspace/home /home/appuser/.claude /home/appuser/.codex /opt/codex-slack/data/master \
     && chown -R appuser:appuser /workspace /home/appuser/.claude /home/appuser/.codex /opt/codex-slack
+
+# npm globals (@openai/codex, @anthropic-ai/claude-code) are intentionally
+# NOT installed here — they update daily and are installed in each consumer
+# Dockerfile so every build picks up the latest version.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,45 @@
+FROM python:3.11-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install Docker CLI from Docker's official repo.
+# Podman ships a /usr/bin/docker shim on Debian that would shadow the real CLI;
+# installing docker-ce-cli from Docker's repo first prevents that.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+       https://download.docker.com/linux/debian \
+       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    docker-ce-cli \
+    docker-compose-plugin \
+    git \
+    gh \
+    jq \
+    less \
+    make \
+    mosquitto-clients \
+    openssh-client \
+    poppler-utils \
+    tini \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @openai/codex @anthropic-ai/claude-code
+
+RUN useradd -m -u 1000 -s /bin/bash appuser \
+    && mkdir -p /workspace/home /home/appuser/.claude /home/appuser/.codex /opt/codex-slack/data/master \
+    && chown -R appuser:appuser /workspace /home/appuser/.claude /home/appuser/.codex /opt/codex-slack

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -38,8 +38,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex @anthropic-ai/claude-code
-
 RUN useradd -m -u 1000 -s /bin/bash appuser \
     && mkdir -p /workspace/home /home/appuser/.claude /home/appuser/.codex /opt/codex-slack/data/master \
     && chown -R appuser:appuser /workspace /home/appuser/.claude /home/appuser/.codex /opt/codex-slack

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,10 @@
 FROM ghcr.io/pandazxx/codex-slack-base:latest
 
+ARG CODEX_NPM_PACKAGE=@openai/codex
+ARG CLAUDE_NPM_PACKAGE=@anthropic-ai/claude-code
+
+RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
+
 WORKDIR /opt/codex-slack
 
 # Install Python deps globally so pytest and other entrypoints land in

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,55 +1,9 @@
-FROM python:3.11-slim
-
-ARG CODEX_NPM_PACKAGE=@openai/codex
-ARG CLAUDE_NPM_PACKAGE=@anthropic-ai/claude-code
-
-ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
-
-# Add Docker's official apt repo so we get docker-ce-cli + compose plugin.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl gnupg \
-    && install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg \
-       -o /etc/apt/keyrings/docker.asc \
-    && chmod a+r /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
-       https://download.docker.com/linux/debian \
-       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-       > /etc/apt/sources.list.d/docker.list \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash \
-    ca-certificates \
-    curl \
-    docker-ce-cli \
-    docker-compose-plugin \
-    git \
-    gh \
-    jq \
-    less \
-    make \
-    mosquitto-clients \
-    openssh-client \
-    poppler-utils \
-    tini \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g ${CODEX_NPM_PACKAGE} ${CLAUDE_NPM_PACKAGE}
-
-RUN useradd -m -u 1000 -s /bin/bash appuser \
-    && mkdir -p /workspace/home /home/appuser/.claude /opt/codex-slack/data/master \
-    && chown -R appuser:appuser /workspace /home/appuser/.claude /opt/codex-slack
+FROM ghcr.io/pandazxx/codex-slack-base:latest
 
 WORKDIR /opt/codex-slack
 
-# Install Python deps globally (before USER switch) so pytest and other
-# entrypoints land in /usr/local/bin and resolve under tini, which does not
-# extend PATH for the exec'd command.
+# Install Python deps globally so pytest and other entrypoints land in
+# /usr/local/bin and resolve under tini (which does not extend PATH).
 COPY requirements.txt ./requirements.txt
 RUN python -m pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
@@ -67,6 +21,5 @@ COPY --chown=appuser:appuser config ./config
 COPY --chown=appuser:appuser Dockerfile.agent-minimal ./
 COPY --chown=appuser:appuser docker ./docker
 
-# Default command runs pytest; override in compose for other test commands
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["pytest", "-vv", "tests/", "--tb=short"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -10,6 +10,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.test
+      cache_from:
+        - type=gha,scope=test
+      cache_to:
+        - type=gha,mode=max,scope=test
     image: codex-slack:test
     working_dir: /opt/codex-slack
     environment:


### PR DESCRIPTION
## Summary

- Extract heavy, rarely-changing system layers (Docker CLI, nodejs, npm globals) into a pre-built `Dockerfile.base` image pushed to GHCR
- Add GitHub Actions layer caching to `docker-compose.ci.yml` with `type=gha` to cache pip/npm/source layers across CI runs
- Simplify `Dockerfile.test` by inheriting from the pre-built base, reducing it from 73 → 30 lines
- Add GHCR login to `ci.yml` to pull the base image

Expected build time reduction:
- **Warm cache hit** (typical PR): 2+ min → **15–30 sec**
- **Cold build** (cache evicted): 2+ min → **45–60 sec**

## Test plan

- [ ] Manually trigger `.github/workflows/build-base.yml` via workflow_dispatch to push the base image to GHCR (required one-time setup)
- [ ] Push a test commit to this branch and verify `ci.yml` test job succeeds and completes in <2 min
- [ ] Verify the base image is pulled successfully from `ghcr.io/pandazxx/codex-slack-base:latest`
- [ ] Run a second test commit without changing deps — confirm GHA cache hit and build time is <45 sec
- [ ] Verify `docker compose run` still starts the `mosquitto` service and tests execute correctly

🤖 Generated with repository automation