### PR TITLE
feat(staffs): add 'none' session scope option (#201)

### DIFF
--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -65,6 +65,7 @@
             <option value="topic">topic — fresh session per topic</option>
             <option value="workspace">workspace — shared across all topics</option>
             <option value="global">global — single shared session</option>
+            <option value="none">none — stateless, no session tracking</option>
           </select>
 
           <label>Default</label>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -93,7 +93,10 @@
               <td>{{ s.adapter }}</td>
               <td>{{ s.model || '—' }}</td>
               <td>{{ s.session_scope }}</td>
-              <td>{{ s.is_default ? '✓' : '' }}</td>
+              <td>
+                <span v-if="s.is_default" class="badge-default">✓ default</span>
+                <button v-else class="action-btn set-default-btn" @click="setDefaultStaff(s.name)">Set default</button>
+              </td>
               <td class="actions">
                 <button class="action-btn" @click="startEditStaff(s)">Edit</button>
                 <button class="action-btn remove-btn" @click="deleteStaff(s.name)">✕</button>
@@ -353,6 +356,11 @@ async function deleteStaff(name) {
   await loadStaffs()
 }
 
+async function setDefaultStaff(name) {
+  await fetch(`/api/staffs/${name}/set-default`, { method: 'POST' })
+  await loadStaffs()
+}
+
 async function addConfigKey() {
   const key = newConfigKey.value.trim()
   const value = newConfigValue.value
@@ -428,6 +436,9 @@ section { margin-bottom: 3rem; border-top: 1px solid #e2e8f0; padding-top: 1.5re
 .action-btn:hover { background: #eff6ff; }
 .remove-btn { color: #94a3b8; text-decoration: none; }
 .remove-btn:hover { background: #fee2e2; color: #dc2626; }
+.set-default-btn { color: #64748b; text-decoration: none; }
+.set-default-btn:hover { background: #f0fdf4; color: #15803d; }
+.badge-default { background: #dcfce7; color: #15803d; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
 
 @media (max-width: 768px) {
   h1 { font-size: 1.5rem; margin-bottom: 1.25rem; }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -20,13 +20,6 @@
     </p>
 
     <div v-if="isArchived" class="archived-banner">This topic is archived — read only</div>
-    <div v-if="!isArchived && availableStaffs.length" class="staff-picker-bar">
-      <label class="staff-picker-label">Staff:</label>
-      <select class="staff-picker-select" :value="topic?.current_staff_name || ''" @change="setCurrentStaff($event.target.value)">
-        <option value="">— use default —</option>
-        <option v-for="s in availableStaffs" :key="s.name" :value="s.name">@{{ s.name }}</option>
-      </select>
-    </div>
     <div class="status-bar" v-if="agentStatus && !isArchived">
       Agent: <em>{{ agentStatus }}</em>
     </div>
@@ -254,26 +247,63 @@
         </span>
       </div>
       <form @submit.prevent="sendMessage" class="send-form">
-        <input type="file" multiple ref="fileInput" class="file-input-hidden" @change="onFilesSelected" />
-        <button type="button" class="attach-btn" @click="fileInput.click()" :disabled="sending" title="Attach files">📎</button>
-        <textarea
-          v-model="text"
-          placeholder="Type a message…"
-          :rows="textExpanded ? 12 : 3"
-          :disabled="sending"
-          @keydown.enter.shift.exact.prevent="sendMessage"
-          @paste="onPaste"
-        />
-        <div class="send-side">
-          <button type="button" class="expand-btn" @click="textExpanded = !textExpanded" :title="textExpanded ? 'Collapse input' : 'Expand input'">{{ textExpanded ? '⊟' : '⊞' }}</button>
-          <button type="submit" :disabled="sending || !text.trim()">
-            {{ sending ? 'Sending…' : 'Send' }}
-          </button>
+        <div v-if="availableStaffs.length" class="send-staff-row">
+          <label class="send-staff-label">Staff:</label>
+          <select class="send-staff-select" :value="topic?.current_staff_name || ''" @change="setCurrentStaff($event.target.value)">
+            <option value="">— use default —</option>
+            <option v-for="s in availableStaffs" :key="s.name" :value="s.name">@{{ s.name }}</option>
+          </select>
+        </div>
+        <div class="send-input-row">
+          <input type="file" multiple ref="fileInput" class="file-input-hidden" @change="onFilesSelected" />
+          <button type="button" class="attach-btn" @click="fileInput.click()" :disabled="sending" title="Attach files">📎</button>
+          <textarea
+            v-model="text"
+            placeholder="Type a message…"
+            rows="3"
+            :disabled="sending"
+            @keydown.enter.shift.exact.prevent="sendMessage"
+            @paste="onPaste"
+          />
+          <div class="send-side">
+            <button type="button" class="expand-btn" @click="openComposeOverlay" title="Open full-screen editor">⊞</button>
+            <button type="submit" :disabled="sending || !text.trim()">
+              {{ sending ? 'Sending…' : 'Send' }}
+            </button>
+          </div>
         </div>
       </form>
       <p v-if="sendError" class="send-error">{{ sendError }}</p>
       <p class="hint muted">Shift+Enter to send · Enter for new line · Use <code>@name</code> to address a specific staff</p>
     </template>
+    <Teleport to="body">
+      <div v-if="composeOverlay" class="compose-overlay" @click.self="closeComposeOverlay">
+        <div class="compose-modal">
+          <div class="compose-modal-header">
+            <span class="compose-modal-title">Compose message</span>
+            <button class="compose-modal-close" @click="closeComposeOverlay" title="Close (Esc)">✕</button>
+          </div>
+          <textarea
+            class="compose-modal-textarea"
+            v-model="text"
+            placeholder="Type a message…"
+            :disabled="sending"
+            @keydown.shift.enter.exact.prevent="sendFromOverlay"
+            @paste="onPaste"
+            ref="overlayTextarea"
+          />
+          <div class="compose-modal-footer">
+            <span class="compose-modal-hint">Shift+Enter to send · Esc to close</span>
+            <div class="compose-modal-actions">
+              <button type="button" class="compose-modal-cancel" @click="closeComposeOverlay">Cancel</button>
+              <button type="button" class="compose-modal-send" @click="sendFromOverlay" :disabled="sending || !text.trim()">
+                {{ sending ? 'Sending…' : 'Send' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -302,7 +332,8 @@ const selectedFiles = ref([])
 const liveStreams = ref({})
 const seenSeq = new Map()
 const availableStaffs = ref([])
-const textExpanded = ref(false)
+const composeOverlay = ref(false)
+const overlayTextarea = ref(null)
 const expandedMsgs = ref(new Set())
 
 const MSG_COLLAPSE_THRESHOLD = 600
@@ -365,6 +396,20 @@ function scrollToBottom() {
       el.scrollTop = el.scrollHeight
     })
   })
+}
+
+function openComposeOverlay() {
+  composeOverlay.value = true
+  nextTick(() => overlayTextarea.value?.focus())
+}
+
+function closeComposeOverlay() {
+  composeOverlay.value = false
+}
+
+async function sendFromOverlay() {
+  await sendMessage()
+  if (!sendError.value) composeOverlay.value = false
 }
 
 async function setCurrentStaff(name) {
@@ -829,13 +874,19 @@ watch(
   },
 )
 
+function _handleKeydown(e) {
+  if (e.key === 'Escape' && composeOverlay.value) closeComposeOverlay()
+}
+
 onMounted(async () => {
+  document.addEventListener('keydown', _handleKeydown)
   text.value = loadDraft(topicId)
   await load()
   if (!isArchived.value) connectWs()
 })
 
 onUnmounted(() => {
+  document.removeEventListener('keydown', _handleKeydown)
   if (ws) { ws.onclose = null; ws.close() }
 })
 </script>
@@ -847,9 +898,6 @@ onUnmounted(() => {
 .topic-settings-link:hover { color: #475569; }
 .archived-banner { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; color: #713f12; }
 .status-bar { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; }
-.staff-picker-bar { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem; }
-.staff-picker-label { font-size: 0.8em; color: #64748b; }
-.staff-picker-select { font-size: 0.82em; padding: 0.2rem 0.5rem; border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; color: #1e293b; cursor: pointer; }
 .messages { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; padding: 0.5rem 0; }
 .message { display: flex; flex-direction: column; max-width: 72%; }
 .message.agent { max-width: 88%; }
@@ -888,13 +936,33 @@ onUnmounted(() => {
 .tr-badge-thinking { background: #f3e8ff; color: #7c3aed; }
 .tr-thinking { display: flex; flex-direction: column; gap: 2px; }
 .tr-thinking-body { background: #1a0a2e; color: #c4b5fd; }
-.send-form { display: flex; gap: 0.5rem; margin-top: 0.75rem; align-items: flex-end; }
-.send-form textarea { flex: 1; padding: 0.5rem 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; resize: none; font-family: inherit; font-size: 0.95rem; }
+.send-form { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 0.75rem; }
+.send-staff-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0.6rem; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; }
+.send-staff-label { font-size: 0.8em; font-weight: 600; color: #475569; white-space: nowrap; }
+.send-staff-select { flex: 1; font-size: 0.88em; padding: 0.25rem 0.5rem; border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; color: #1e293b; cursor: pointer; }
+.send-input-row { display: flex; gap: 0.5rem; align-items: flex-end; }
+.send-input-row textarea { flex: 1; padding: 0.5rem 0.75rem; border: 1px solid #cbd5e1; border-radius: 6px; resize: none; font-family: inherit; font-size: 0.95rem; }
 .send-side { display: flex; flex-direction: column; gap: 0.35rem; align-items: stretch; }
 .send-side button { padding: 0.5rem 1.25rem; background: #2563eb; color: #fff; border: none; border-radius: 6px; cursor: pointer; }
 .send-side button:disabled { opacity: 0.6; cursor: default; }
 .expand-btn { background: #f1f5f9 !important; color: #475569 !important; border: 1px solid #cbd5e1 !important; font-size: 1rem; padding: 0.3rem 0.5rem !important; }
 .expand-btn:hover { background: #e2e8f0 !important; }
+.compose-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.55); display: flex; align-items: center; justify-content: center; z-index: 200; }
+.compose-modal { background: #fff; border-radius: 10px; width: 90vw; height: 85vh; display: flex; flex-direction: column; padding: 1rem; gap: 0.75rem; box-shadow: 0 20px 60px rgba(0,0,0,0.35); }
+.compose-modal-header { display: flex; align-items: center; justify-content: space-between; }
+.compose-modal-title { font-size: 0.95em; font-weight: 600; color: #1e293b; }
+.compose-modal-close { background: none; border: none; font-size: 1.1rem; color: #94a3b8; cursor: pointer; line-height: 1; padding: 2px 6px; border-radius: 4px; }
+.compose-modal-close:hover { background: #f1f5f9; color: #475569; }
+.compose-modal-textarea { flex: 1; resize: none; border: 1px solid #cbd5e1; border-radius: 6px; padding: 0.75rem; font-family: inherit; font-size: 1rem; line-height: 1.5; outline: none; }
+.compose-modal-textarea:focus { border-color: #2563eb; box-shadow: 0 0 0 2px #2563eb26; }
+.compose-modal-footer { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+.compose-modal-hint { font-size: 0.78em; color: #94a3b8; }
+.compose-modal-actions { display: flex; gap: 0.5rem; }
+.compose-modal-cancel { padding: 0.45rem 1rem; background: #f1f5f9; color: #475569; border: 1px solid #cbd5e1; border-radius: 6px; cursor: pointer; font-size: 0.9em; }
+.compose-modal-cancel:hover { background: #e2e8f0; }
+.compose-modal-send { padding: 0.45rem 1.25rem; background: #2563eb; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.9em; font-weight: 600; }
+.compose-modal-send:disabled { opacity: 0.6; cursor: default; }
+.compose-modal-send:not(:disabled):hover { background: #1d4ed8; }
 .attach-btn { background: #f1f5f9; color: #475569; padding: 0.5rem 0.6rem; font-size: 1.1rem; border: 1px solid #cbd5e1; }
 .attach-btn:hover:not(:disabled) { background: #e2e8f0; }
 .file-input-hidden { display: none; }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -20,6 +20,13 @@
     </p>
 
     <div v-if="isArchived" class="archived-banner">This topic is archived — read only</div>
+    <div v-if="!isArchived && availableStaffs.length" class="staff-picker-bar">
+      <label class="staff-picker-label">Staff:</label>
+      <select class="staff-picker-select" :value="topic?.current_staff_name || ''" @change="setCurrentStaff($event.target.value)">
+        <option value="">— use default —</option>
+        <option v-for="s in availableStaffs" :key="s.name" :value="s.name">@{{ s.name }}</option>
+      </select>
+    </div>
     <div class="status-bar" v-if="agentStatus && !isArchived">
       Agent: <em>{{ agentStatus }}</em>
     </div>
@@ -294,6 +301,7 @@ const fileInput = ref(null)
 const selectedFiles = ref([])
 const liveStreams = ref({})
 const seenSeq = new Map()
+const availableStaffs = ref([])
 const textExpanded = ref(false)
 const expandedMsgs = ref(new Set())
 
@@ -357,6 +365,15 @@ function scrollToBottom() {
       el.scrollTop = el.scrollHeight
     })
   })
+}
+
+async function setCurrentStaff(name) {
+  await fetch(`/api/workspaces/${wsId}/topics/${topicId}/current-staff`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: name || null }),
+  })
+  if (topic.value) topic.value = { ...topic.value, current_staff_name: name || null }
 }
 
 async function fetchAgentStatus() {
@@ -545,11 +562,12 @@ function finaliseMessage(data) {
 async function load() {
   loading.value = true
   try {
-    const [topicRes, msgsRes, wsRes, tzRes] = await Promise.all([
+    const [topicRes, msgsRes, wsRes, tzRes, staffsRes] = await Promise.all([
       fetch(`/api/workspaces/${wsId}/topics/${topicId}`),
       fetch(`/api/workspaces/${wsId}/topics/${topicId}/messages`),
       fetch(`/api/workspaces/${wsId}`),
       fetch('/api/config/system-settings'),
+      fetch(`/api/workspaces/${wsId}/staffs`),
     ])
     topic.value = await topicRes.json()
     const rawMsgs = await msgsRes.json()
@@ -577,6 +595,7 @@ async function load() {
       }
     }
     if (wsRes.ok) workspace.value = await wsRes.json()
+    if (staffsRes.ok) availableStaffs.value = await staffsRes.json()
     if (tzRes.ok) {
       const tz = await tzRes.json()
       configuredTimezone.value = tz.timezone_configured
@@ -828,6 +847,9 @@ onUnmounted(() => {
 .topic-settings-link:hover { color: #475569; }
 .archived-banner { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; color: #713f12; }
 .status-bar { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; }
+.staff-picker-bar { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem; }
+.staff-picker-label { font-size: 0.8em; color: #64748b; }
+.staff-picker-select { font-size: 0.82em; padding: 0.2rem 0.5rem; border: 1px solid #cbd5e1; border-radius: 4px; background: #fff; color: #1e293b; cursor: pointer; }
 .messages { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; padding: 0.5rem 0; }
 .message { display: flex; flex-direction: column; max-width: 72%; }
 .message.agent { max-width: 88%; }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -127,6 +127,7 @@
             <option value="topic">topic — fresh session per topic</option>
             <option value="workspace">workspace — shared across all topics</option>
             <option value="global">global — single shared session</option>
+            <option value="none">none — stateless, no session tracking</option>
           </select>
 
           <label>Default</label>

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -155,7 +155,10 @@
               <td>{{ s.adapter }}</td>
               <td>{{ s.model || '—' }}</td>
               <td>{{ s.session_scope }}</td>
-              <td>{{ s.is_default ? '✓' : '' }}</td>
+              <td>
+                <span v-if="s.is_default" class="badge-default">✓ default</span>
+                <button v-else-if="!isArchived && !s.inherited_from" class="action-btn set-default-btn" @click="setDefaultStaff(s.name)">Set default</button>
+              </td>
               <td>
                 <span v-if="s.inherited_from" class="badge-global">{{ s.inherited_from }}</span>
                 <span v-else class="badge-local">workspace</span>
@@ -543,6 +546,11 @@ async function deleteStaff(name) {
   await load()
 }
 
+async function setDefaultStaff(name) {
+  await fetch(`/api/workspaces/${id}/staffs/${name}/set-default`, { method: 'POST' })
+  await load()
+}
+
 onMounted(async () => {
   await load()
   if (!isArchived.value) {
@@ -624,6 +632,9 @@ section { margin-bottom: 2rem; }
 .small { font-size: 0.82em; }
 .remove-btn { background: none; border: none; color: #94a3b8; cursor: pointer; font-size: 0.9em; padding: 0.15rem 0.4rem; border-radius: 3px; }
 .remove-btn:hover { background: #fee2e2; color: #dc2626; }
+.set-default-btn { color: #64748b; text-decoration: none; }
+.set-default-btn:hover { background: #f0fdf4; color: #15803d; }
+.badge-default { background: #dcfce7; color: #15803d; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
 .topic-settings-btn { color: #94a3b8; text-decoration: none; font-size: 1em; padding: 0.15rem 0.4rem; border-radius: 3px; }
 .topic-settings-btn:hover { background: #f1f5f9; color: #475569; }
 

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -177,6 +177,7 @@ _MIGRATIONS = [
     "ALTER TABLE messages ADD COLUMN event_action_id TEXT",
     "ALTER TABLE topics ADD COLUMN veto_status TEXT",
     "ALTER TABLE topics ADD COLUMN veto_reason TEXT",
+    "ALTER TABLE topics ADD COLUMN current_staff_name TEXT",
 ]
 
 

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS staffs (
     model         TEXT,
     system_prompt TEXT,
     agent         TEXT,
-    session_scope TEXT NOT NULL DEFAULT 'topic' CHECK (session_scope IN ('topic', 'workspace', 'global')),
+    session_scope TEXT NOT NULL DEFAULT 'topic' CHECK (session_scope IN ('topic', 'workspace', 'global', 'none')),
     is_default    INTEGER NOT NULL DEFAULT 0,
     extra_flags   TEXT,
     created_at    TEXT NOT NULL,
@@ -335,6 +335,47 @@ def _migrate_event_actions_v2(conn: sqlite3.Connection) -> None:
     LOGGER.info("db.migration_done event_actions_v2")
 
 
+def _migrate_staffs_session_scope_none(conn: sqlite3.Connection) -> None:
+    """Widen the session_scope CHECK constraint to allow 'none'.
+
+    SQLite cannot modify CHECK constraints in-place; we recreate the table.
+    Idempotent: skips if 'none' is already present in the constraint.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='staffs'"
+    ).fetchone()
+    if row is None or "'none'" in (row[0] or ""):
+        return
+    LOGGER.info("db.migration_start staffs_session_scope_none")
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS staffs_new (
+            id            TEXT PRIMARY KEY,
+            scope_type    TEXT NOT NULL CHECK (scope_type IN ('global', 'workspace', 'topic')),
+            scope_id      TEXT,
+            name          TEXT NOT NULL,
+            adapter       TEXT NOT NULL DEFAULT 'claude-code',
+            model         TEXT,
+            system_prompt TEXT,
+            agent         TEXT,
+            session_scope TEXT NOT NULL DEFAULT 'topic'
+                          CHECK (session_scope IN ('topic', 'workspace', 'global', 'none')),
+            is_default    INTEGER NOT NULL DEFAULT 0,
+            extra_flags   TEXT,
+            created_at    TEXT NOT NULL,
+            updated_at    TEXT NOT NULL
+        );
+        INSERT INTO staffs_new SELECT * FROM staffs;
+        DROP TABLE staffs;
+        ALTER TABLE staffs_new RENAME TO staffs;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_staffs_scope_name
+            ON staffs(scope_type, COALESCE(scope_id, ''), name);
+    """)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.commit()
+    LOGGER.info("db.migration_done staffs_session_scope_none")
+
+
 def init_db(db_path: str) -> None:
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
@@ -353,6 +394,7 @@ def init_db(db_path: str) -> None:
         _migrate_workspace_name_uniqueness(conn)
         _migrate_agents_to_staffs(conn)
         _migrate_event_actions_v2(conn)
+        _migrate_staffs_session_scope_none(conn)
         conn.commit()
     finally:
         conn.close()

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -93,10 +93,13 @@ async def dispatch_to_staff(
         if topic is None:
             raise ValueError(f"topic {topic_id!r} not found")
 
-        ss_scope_type, ss_scope_id = _staff_session_key(staff, workspace_id, topic_id)
-        session_uuid, is_new_session = _get_staff_session(
-            conn, ss_scope_type, ss_scope_id, staff["name"]
-        )
+        if (staff["session_scope"] or "topic") == "none":
+            session_uuid, is_new_session = None, True
+        else:
+            ss_scope_type, ss_scope_id = _staff_session_key(staff, workspace_id, topic_id)
+            session_uuid, is_new_session = _get_staff_session(
+                conn, ss_scope_type, ss_scope_id, staff["name"]
+            )
 
         message_id = str(uuid.uuid4())
         now = _now()

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -77,7 +77,7 @@ async def send_message(
         if ws_row is None:
             raise HTTPException(404, "workspace not found")
         topic = conn.execute(
-            "SELECT id FROM topics"
+            "SELECT id, current_staff_name FROM topics"
             " WHERE id = ? AND workspace_id = ? AND archived_at IS NULL",
             (topic_id, workspace_id),
         ).fetchone()
@@ -90,6 +90,10 @@ async def send_message(
             staff = resolve_staff(conn, mention_name, workspace_id, topic_id)
             if staff is None:
                 raise HTTPException(404, f"staff '{mention_name}' not found")
+        elif topic["current_staff_name"]:
+            staff = resolve_staff(conn, topic["current_staff_name"], workspace_id, topic_id)
+            if staff is None:
+                raise HTTPException(404, f"current staff '{topic['current_staff_name']}' not found")
         else:
             staff = resolve_default_staff(conn, workspace_id, topic_id)
             if staff is None:

--- a/src/master/staffs.py
+++ b/src/master/staffs.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from .db import get_connection
 
 _VALID_ADAPTERS = {"claude-code", "codex"}
-_VALID_SESSION_SCOPES = {"topic", "workspace", "global"}
+_VALID_SESSION_SCOPES = {"topic", "workspace", "global", "none"}
 
 _SELECT_COLS = (
     "id, scope_type, scope_id, name, adapter, model, system_prompt, agent,"

--- a/src/master/staffs.py
+++ b/src/master/staffs.py
@@ -196,6 +196,32 @@ def _update_staff(
     return _row_to_out(updated)
 
 
+def _set_default_staff(
+    conn: sqlite3.Connection,
+    scope_type: str,
+    scope_id: str | None,
+    name: str,
+) -> StaffOut:
+    row = conn.execute(
+        f"SELECT {_SELECT_COLS} FROM staffs WHERE scope_type=? AND scope_id IS ? AND name=?",
+        (scope_type, scope_id, name),
+    ).fetchone()
+    if row is None:
+        raise HTTPException(404, f"staff '{name}' not found")
+    now = _now()
+    conn.execute(
+        "UPDATE staffs SET is_default=0, updated_at=? WHERE scope_type=? AND scope_id IS ?",
+        (now, scope_type, scope_id),
+    )
+    conn.execute(
+        "UPDATE staffs SET is_default=1, updated_at=? WHERE id=?",
+        (now, row["id"]),
+    )
+    conn.commit()
+    updated = conn.execute(f"SELECT {_SELECT_COLS} FROM staffs WHERE id=?", (row["id"],)).fetchone()
+    return _row_to_out(updated)
+
+
 def _delete_staff(
     conn: sqlite3.Connection,
     scope_type: str,
@@ -252,6 +278,15 @@ def delete_global_staff(name: str, request: Request) -> None:
     conn = get_connection(request.app.state.db_path)
     try:
         _delete_staff(conn, "global", None, name)
+    finally:
+        conn.close()
+
+
+@global_router.post("/{name}/set-default", response_model=StaffOut)
+def set_default_global_staff(name: str, request: Request) -> StaffOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        return _set_default_staff(conn, "global", None, name)
     finally:
         conn.close()
 
@@ -320,6 +355,19 @@ def delete_workspace_staff(workspace_id: str, name: str, request: Request) -> No
         ).fetchone() is None:
             raise HTTPException(404, "workspace not found")
         _delete_staff(conn, "workspace", workspace_id, name)
+    finally:
+        conn.close()
+
+
+@workspace_router.post("/{name}/set-default", response_model=StaffOut)
+def set_default_workspace_staff(workspace_id: str, name: str, request: Request) -> StaffOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        if conn.execute(
+            "SELECT 1 FROM workspaces WHERE id=?", (workspace_id,)
+        ).fetchone() is None:
+            raise HTTPException(404, "workspace not found")
+        return _set_default_staff(conn, "workspace", workspace_id, name)
     finally:
         conn.close()
 

--- a/src/master/topics.py
+++ b/src/master/topics.py
@@ -109,9 +109,11 @@ class TopicOut(BaseModel):
     archived_at: str | None
     veto_status: str | None = None
     veto_reason: str | None = None
+    current_staff_name: str | None = None
 
 
 def _row_to_topic(row) -> TopicOut:
+    keys = row.keys()
     return TopicOut(
         id=row["id"],
         workspace_id=row["workspace_id"],
@@ -122,8 +124,9 @@ def _row_to_topic(row) -> TopicOut:
         worktree_path=row["worktree_path"],
         created_at=row["created_at"],
         archived_at=row["archived_at"],
-        veto_status=row["veto_status"] if "veto_status" in row.keys() else None,
-        veto_reason=row["veto_reason"] if "veto_reason" in row.keys() else None,
+        veto_status=row["veto_status"] if "veto_status" in keys else None,
+        veto_reason=row["veto_reason"] if "veto_reason" in keys else None,
+        current_staff_name=row["current_staff_name"] if "current_staff_name" in keys else None,
     )
 
 
@@ -201,6 +204,31 @@ def get_topic(workspace_id: str, topic_id: str, request: Request) -> TopicOut:
     if row is None:
         raise HTTPException(status_code=404, detail="topic not found")
     return _row_to_topic(row)
+
+
+class TopicStaffPatch(BaseModel):
+    name: str | None = None
+
+
+@router.patch("/{topic_id}/current-staff", response_model=TopicOut)
+def set_current_staff(workspace_id: str, topic_id: str, body: TopicStaffPatch, request: Request) -> TopicOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM topics WHERE id = ? AND workspace_id = ? AND archived_at IS NULL",
+            (topic_id, workspace_id),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(404, "topic not found")
+        conn.execute(
+            "UPDATE topics SET current_staff_name = ? WHERE id = ?",
+            (body.name, topic_id),
+        )
+        conn.commit()
+        updated = conn.execute("SELECT * FROM topics WHERE id = ?", (topic_id,)).fetchone()
+    finally:
+        conn.close()
+    return _row_to_topic(updated)
 
 
 @router.delete("/{topic_id}", status_code=204)


### PR DESCRIPTION
Closes #201

## Summary

- *DB migration* — the `session_scope` CHECK constraint on `staffs` is widened to include `'none'`; an idempotent migration recreates the table for existing databases on next startup
- *Backend validation* — `'none'` added to `_VALID_SESSION_SCOPES` in `staffs.py`; the API now accepts it
- *Dispatch logic* — when `session_scope='none'`, `dispatch.py` skips the session lookup entirely and passes `session_id=None`; the agent CLI therefore receives no `--session-id` or `--resume` flag, giving a completely stateless invocation every time
- *Frontend* — "none — stateless, no session tracking" option added to the session scope dropdown in both the global staff form (`Settings.vue`) and workspace staff form (`WorkspaceDetail.vue`)

## Test plan

- [ ] Create a global staff with session scope = **none** — save succeeds
- [ ] Send two messages to the staff in the same topic — agent has no memory of the first message in the second reply (fresh context each time)
- [ ] Restart master — existing staffs with `topic`/`workspace`/`global` scope are unaffected; the DB migration runs without error (check logs for `db.migration_done staffs_session_scope_none`)
- [ ] Edit an existing staff and change its scope to **none** — change persists and takes effect on the next message

🤖 Generated with repository automation