### PR TITLE
feat(event-actions): workspace-level event actions (#202)

### DIFF
--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -176,6 +176,113 @@
       </div>
     </section>
 
+    <!-- ── Workspace Event Actions ──────────────────────────────────── -->
+    <section v-if="!isArchived" class="event-actions-section">
+      <div class="header-row">
+        <h2>Workspace Event Actions</h2>
+        <button v-if="!showActionForm" class="btn-add" @click="startCreateAction">+ Add action</button>
+      </div>
+      <p class="muted hint">Trigger configured staff on events in <em>any</em> topic of this workspace. Applied in addition to per-topic event actions.</p>
+
+      <!-- Create / Edit form -->
+      <div v-if="showActionForm" class="card">
+        <h3>{{ editingActionId ? 'Edit action' : 'New workspace action' }}</h3>
+        <div class="form-grid">
+          <label>Event type <span class="req">*</span></label>
+          <select v-model="actionForm.event_type" :disabled="!!editingActionId">
+            <option value="topic_message_sent">topic_message_sent — user sends a message</option>
+            <option value="topic_message_received">topic_message_received — agent replies</option>
+            <option value="topic_archived">topic_archived — topic is archived</option>
+            <option value="topic_archiving">topic_archiving — before topic is archived (veto)</option>
+          </select>
+
+          <label>Staff <span class="req">*</span></label>
+          <select v-model="actionForm.staff_name">
+            <option value="" disabled>— select staff —</option>
+            <template v-for="group in actionStaffGroups" :key="group.label">
+              <optgroup :label="group.label">
+                <option v-for="s in group.items" :key="s.name" :value="s.name">{{ s.name }}</option>
+              </optgroup>
+            </template>
+          </select>
+
+          <label>Prompt template <span class="req">*</span></label>
+          <div>
+            <textarea v-model="actionForm.prompt_template" rows="4" placeholder="e.g. Summarise {topic_name}" />
+            <p class="form-hint">
+              Available variables for <strong>{{ actionForm.event_type }}</strong>:
+              {{ actionVariableHint }}.<br>
+              Escape literal braces as <code>&#123;&#123;</code> / <code>&#125;&#125;</code>.
+            </p>
+          </div>
+
+          <template v-if="actionForm.event_type === 'topic_message_sent'">
+            <label>Timing <span class="req">*</span></label>
+            <select v-model="actionForm.timing">
+              <option value="before">before — fires before the user message is dispatched</option>
+              <option value="after">after — fires after the user message is dispatched</option>
+            </select>
+          </template>
+
+          <label>Enabled</label>
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="actionForm.enabled" />
+            Fire this action when the event occurs
+          </label>
+
+          <label>Structured output</label>
+          <div>
+            <label class="checkbox-label">
+              <input type="checkbox" v-model="actionForm.structured_output" />
+              Expect JSON response from staff
+            </label>
+            <p v-if="actionForm.structured_output" class="form-hint">
+              Staff must reply with one of:<br>
+              <code>{"message": "text to post in topic"}</code><br>
+              <code>{"break": true, "message": "reason"}</code><br>
+              <code>{"silent": true, "log": "optional log"}</code>
+            </p>
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn-primary" @click="saveAction" :disabled="savingAction">{{ savingAction ? 'Saving…' : 'Save' }}</button>
+          <button class="btn-secondary" @click="cancelActionForm">Cancel</button>
+          <span v-if="actionError" class="error">{{ actionError }}</span>
+        </div>
+      </div>
+
+      <!-- Action list -->
+      <p v-if="!actions.length && !showActionForm" class="muted">No workspace event actions configured.</p>
+      <div v-else-if="actions.length" class="action-list">
+        <div v-for="a in actions" :key="a.id" class="action-card">
+          <div class="action-header">
+            <span class="action-toggle">
+              <input type="checkbox" :checked="a.enabled" @change="toggleAction(a)" :title="a.enabled ? 'Disable' : 'Enable'" />
+            </span>
+            <span class="action-type-badge" :class="actionTypeBadgeClass(a.event_type)">{{ a.event_type }}</span>
+            <span v-if="a.timing" class="timing-badge">{{ a.timing }}</span>
+            <span v-if="a.structured_output" class="structured-badge" title="Expects JSON response">JSON</span>
+            <span class="action-staff">@{{ a.staff_name }}</span>
+            <span class="action-preview muted">{{ a.prompt_template.slice(0, 60) }}{{ a.prompt_template.length > 60 ? '…' : '' }}</span>
+            <div class="action-btns">
+              <button class="action-btn" @click="startEditAction(a)">Edit</button>
+              <button class="action-btn remove-btn" @click="deleteAction(a.id)">✕</button>
+            </div>
+          </div>
+          <div class="action-run-info">
+            <span class="muted small">Last run: {{ actionRelativeTime(a.last_run_at) }}</span>
+            <span v-if="a.last_run_status" :class="['run-status-badge', actionRunStatusClass(a.last_run_status)]">{{ a.last_run_status }}</span>
+            <span v-if="a.last_run_output" class="run-output-toggle">
+              <button class="link-btn" @click="toggleActionOutput(a.id)">{{ expandedActionOutputs[a.id] ? 'hide' : 'details' }}</button>
+            </span>
+          </div>
+          <div v-if="a.last_run_output && expandedActionOutputs[a.id]" class="run-output">
+            {{ a.last_run_output }}
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- ── Veto dialog ──────────────────────────────────────────────── -->
     <div v-if="vetoDialog" class="veto-overlay">
       <div class="veto-dialog card">
@@ -237,11 +344,40 @@ const savingStaff = ref(false)
 const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
 
+// Workspace event actions state
+const actions = ref([])
+const showActionForm = ref(false)
+const editingActionId = ref(null)
+const savingAction = ref(false)
+const actionError = ref('')
+const expandedActionOutputs = ref({})
+const actionStaffGroups = ref([])
+
+const emptyActionForm = () => ({
+  event_type: 'topic_message_sent',
+  staff_name: '',
+  prompt_template: '',
+  timing: 'after',
+  enabled: true,
+  structured_output: false,
+})
+const actionForm = ref(emptyActionForm())
+
 const archivingTopics = ref({})  // topicId → true while DELETE is in flight
 const vetoResults = ref({})     // topicId → { topicId, subject, status, reason } — mirrors DB
 const vetoDialog = ref(null)    // null | entry from vetoResults (shown when user clicks the button)
 
 const isArchived = computed(() => !!workspace.value?.archived_at)
+
+const actionVariableHint = computed(() => {
+  const m = {
+    topic_message_sent: '{msgbody}, {message_json}, {topic_name}, {topic_json}',
+    topic_message_received: '{msgbody}, {response_json}, {topic_name}, {topic_json}',
+    topic_archived: '{topic_name}, {topic_json}',
+    topic_archiving: '{topic_name}, {topic_json}',
+  }
+  return m[actionForm.value.event_type] || ''
+})
 
 const statusClass = computed(() => {
   const s = agentStatus.value?.status
@@ -365,12 +501,26 @@ async function load() {
         : Intl.DateTimeFormat().resolvedOptions().timeZone
     }
     const topicsParam = workspace.value.archived_at ? '?archived=true' : ''
-    const [topicsRes, staffsRes] = await Promise.all([
+    const [topicsRes, staffsRes, actionsRes, globalStaffRes] = await Promise.all([
       fetch(`/api/workspaces/${id}/topics${topicsParam}`),
       fetch(`/api/workspaces/${id}/staffs`),
+      fetch(`/api/workspaces/${id}/event-actions`),
+      fetch('/api/staffs'),
     ])
     topics.value = await topicsRes.json()
     staffs.value = await staffsRes.json()
+    if (actionsRes.ok) actions.value = await actionsRes.json()
+    // Build staff groups for event action form
+    const groups = []
+    if (staffsRes.ok) {
+      const items = staffs.value.filter(s => !s.inherited_from)
+      if (items.length) groups.push({ label: 'Workspace', items })
+    }
+    if (globalStaffRes.ok) {
+      const items = (await globalStaffRes.json()).filter(s => !s.inherited_from)
+      if (items.length) groups.push({ label: 'Global', items })
+    }
+    actionStaffGroups.value = groups
     // Rebuild vetoResults from DB-backed topic fields
     const vr = {}
     for (const t of topics.value) {
@@ -480,6 +630,120 @@ async function overrideTopic() {
     delete next[topicId]
     archivingTopics.value = next
   }
+}
+
+function startCreateAction() {
+  editingActionId.value = null
+  actionForm.value = emptyActionForm()
+  showActionForm.value = true
+  actionError.value = ''
+}
+
+function startEditAction(a) {
+  editingActionId.value = a.id
+  actionForm.value = {
+    event_type: a.event_type,
+    staff_name: a.staff_name,
+    prompt_template: a.prompt_template,
+    timing: a.timing ?? null,
+    enabled: a.enabled,
+    structured_output: a.structured_output,
+  }
+  showActionForm.value = true
+  actionError.value = ''
+}
+
+function cancelActionForm() {
+  showActionForm.value = false
+  editingActionId.value = null
+  actionError.value = ''
+}
+
+async function saveAction() {
+  savingAction.value = true
+  actionError.value = ''
+  try {
+    const isEdit = !!editingActionId.value
+    const body = {
+      staff_name: actionForm.value.staff_name.trim(),
+      prompt_template: actionForm.value.prompt_template,
+      enabled: actionForm.value.enabled,
+      structured_output: actionForm.value.structured_output,
+    }
+    if (!isEdit) {
+      body.event_type = actionForm.value.event_type
+    }
+    if (actionForm.value.event_type === 'topic_message_sent') {
+      body.timing = actionForm.value.timing
+    }
+    if (actionForm.value.event_type === 'topic_message_received') {
+      body.timing = 'after'
+    }
+
+    const url = isEdit
+      ? `/api/workspaces/${id}/event-actions/${editingActionId.value}`
+      : `/api/workspaces/${id}/event-actions`
+    const method = isEdit ? 'PATCH' : 'POST'
+    const r = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!r.ok) {
+      const err = await r.json()
+      const detail = err.detail
+      actionError.value = Array.isArray(detail)
+        ? detail.map(d => d.msg).join(', ')
+        : (typeof detail === 'string' ? detail : `Error ${r.status}`)
+      return
+    }
+    showActionForm.value = false
+    editingActionId.value = null
+    await load()
+  } finally {
+    savingAction.value = false
+  }
+}
+
+async function toggleAction(a) {
+  await fetch(`/api/workspaces/${id}/event-actions/${a.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled: !a.enabled }),
+  })
+  await load()
+}
+
+async function deleteAction(actionId) {
+  if (!confirm('Delete this workspace event action?')) return
+  await fetch(`/api/workspaces/${id}/event-actions/${actionId}`, { method: 'DELETE' })
+  await load()
+}
+
+function toggleActionOutput(actionId) {
+  expandedActionOutputs.value[actionId] = !expandedActionOutputs.value[actionId]
+}
+
+function actionRelativeTime(iso) {
+  if (!iso) return 'never'
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (diff < 60) return `${Math.round(diff)}s ago`
+  if (diff < 3600) return `${Math.round(diff / 60)} min ago`
+  if (diff < 86400) return `${Math.round(diff / 3600)} hr ago`
+  return `${Math.round(diff / 86400)} days ago`
+}
+
+function actionTypeBadgeClass(eventType) {
+  return {
+    'badge-sent': eventType === 'topic_message_sent',
+    'badge-received': eventType === 'topic_message_received',
+    'badge-archived': eventType === 'topic_archived',
+    'badge-archiving': eventType === 'topic_archiving',
+  }
+}
+
+function actionRunStatusClass(status) {
+  return status === 'ok' ? 'status-ok' : 'status-error'
 }
 
 function startCreateStaff() {
@@ -673,6 +937,29 @@ section { margin-bottom: 2rem; }
   .form-grid label + .checkbox-label { margin-bottom: 0.5rem; }
   .form-actions { flex-wrap: wrap; }
 }
+.event-actions-section { border-top: 1px solid #e2e8f0; padding-top: 1.5rem; }
+.action-list { display: flex; flex-direction: column; gap: 0.75rem; }
+.action-card { background: #fff; border: 1px solid #e2e8f0; border-radius: 6px; padding: 0.75rem 1rem; }
+.action-header { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.action-toggle input { cursor: pointer; }
+.action-type-badge { border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.badge-sent { background: #dbeafe; color: #1d4ed8; }
+.badge-received { background: #dcfce7; color: #15803d; }
+.badge-archived { background: #fef9c3; color: #713f12; }
+.badge-archiving { background: #fee2e2; color: #991b1b; }
+.timing-badge { background: #f1f5f9; color: #475569; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; }
+.structured-badge { background: #ecfdf5; color: #065f46; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.action-staff { font-weight: 600; font-size: 0.9em; }
+.action-preview { font-size: 0.82em; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.action-btns { margin-left: auto; display: flex; gap: 0.25rem; white-space: nowrap; }
+.action-run-info { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.4rem; font-size: 0.82em; }
+.run-status-badge { border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.status-ok { background: #dcfce7; color: #15803d; }
+.status-error { background: #fee2e2; color: #dc2626; }
+.run-output-toggle { margin-left: 0.25rem; }
+.link-btn { background: none; border: none; color: #2563eb; cursor: pointer; font-size: 0.82em; text-decoration: underline; padding: 0; }
+.run-output { margin-top: 0.35rem; background: #1e293b; color: #e2e8f0; padding: 0.5rem 0.75rem; border-radius: 4px; font-size: 0.78em; font-family: monospace; white-space: pre-wrap; word-break: break-all; }
+
 .veto-rejected-btn { background: #fef2f2 !important; color: #dc2626 !important; border: 1px solid #fecaca !important; }
 .veto-rejected-btn:hover { background: #fee2e2 !important; }
 .veto-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 100; }

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS event_actions (
                         'topic_archived',
                         'topic_archiving'
                     )),
-    scope_type      TEXT NOT NULL CHECK (scope_type IN ('topic')),
+    scope_type      TEXT NOT NULL CHECK (scope_type IN ('topic', 'workspace')),
     scope_id        TEXT NOT NULL,
     staff_name      TEXT NOT NULL,
     prompt_template TEXT NOT NULL,
@@ -336,6 +336,73 @@ def _migrate_event_actions_v2(conn: sqlite3.Connection) -> None:
     LOGGER.info("db.migration_done event_actions_v2")
 
 
+def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
+    """Widen event_actions scope_type CHECK constraint to allow 'workspace'.
+
+    SQLite cannot modify CHECK constraints in-place; we recreate the table.
+    Idempotent: skips if 'workspace' is already present in the constraint.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='event_actions'"
+    ).fetchone()
+    if row is None or "'workspace'" in (row[0] or ""):
+        return
+    LOGGER.info("db.migration_start event_actions_v3")
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS event_actions_new (
+            id              TEXT PRIMARY KEY,
+            event_type      TEXT NOT NULL CHECK (event_type IN (
+                                'topic_message_sent',
+                                'topic_message_received',
+                                'topic_scheduler',
+                                'topic_archived',
+                                'topic_archiving'
+                            )),
+            scope_type      TEXT NOT NULL CHECK (scope_type IN ('topic', 'workspace')),
+            scope_id        TEXT NOT NULL,
+            staff_name      TEXT NOT NULL,
+            prompt_template TEXT NOT NULL,
+            timing          TEXT CHECK (timing IN ('before', 'after')),
+            cron_expr       TEXT,
+            last_fired_at   TEXT,
+            last_run_at     TEXT,
+            last_run_status TEXT CHECK (last_run_status IN (
+                                'ok',
+                                'staff_missing',
+                                'render_error',
+                                'dispatch_error',
+                                'vetoed',
+                                'veto_timeout'
+                            )),
+            last_run_output   TEXT,
+            enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+            structured_output INTEGER NOT NULL DEFAULT 0 CHECK (structured_output IN (0, 1)),
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL,
+            CHECK (
+                (event_type = 'topic_scheduler'      AND cron_expr IS NOT NULL AND timing IS NULL)
+                OR
+                (event_type = 'topic_message_sent'   AND cron_expr IS NULL     AND timing IN ('before','after'))
+                OR
+                (event_type IN ('topic_message_received','topic_archived','topic_archiving')
+                                                      AND cron_expr IS NULL     AND (timing IS NULL OR timing = 'after'))
+            )
+        );
+        INSERT OR IGNORE INTO event_actions_new
+            SELECT * FROM event_actions;
+        DROP TABLE event_actions;
+        ALTER TABLE event_actions_new RENAME TO event_actions;
+        CREATE INDEX IF NOT EXISTS idx_event_actions_scope_event
+            ON event_actions (scope_type, scope_id, event_type, enabled);
+        CREATE INDEX IF NOT EXISTS idx_event_actions_scheduler
+            ON event_actions (event_type, enabled) WHERE event_type = 'topic_scheduler';
+    """)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.commit()
+    LOGGER.info("db.migration_done event_actions_v3")
+
+
 def _migrate_staffs_session_scope_none(conn: sqlite3.Connection) -> None:
     """Widen the session_scope CHECK constraint to allow 'none'.
 
@@ -395,6 +462,7 @@ def init_db(db_path: str) -> None:
         _migrate_workspace_name_uniqueness(conn)
         _migrate_agents_to_staffs(conn)
         _migrate_event_actions_v2(conn)
+        _migrate_event_actions_v3(conn)
         _migrate_staffs_session_scope_none(conn)
         conn.commit()
     finally:

--- a/src/master/event_actions.py
+++ b/src/master/event_actions.py
@@ -1,9 +1,9 @@
-"""CRUD API for event_actions — topic-scoped event trigger configurations.
+"""CRUD API for event_actions — topic- and workspace-scoped event trigger configurations.
 
-Endpoints live under /api/workspaces/{wid}/topics/{tid}/event-actions following
-the existing router pattern in staffs.py. Validation mirrors the DB CHECK
-constraints with friendly HTTP errors; the CHECK constraints provide defence in
-depth.
+Topic-scoped endpoints live under /api/workspaces/{wid}/topics/{tid}/event-actions.
+Workspace-scoped endpoints live under /api/workspaces/{wid}/event-actions.
+Validation mirrors the DB CHECK constraints with friendly HTTP errors; the CHECK
+constraints provide defence in depth.
 """
 from __future__ import annotations
 
@@ -18,6 +18,11 @@ from .db import get_connection
 
 router = APIRouter(
     prefix="/workspaces/{workspace_id}/topics/{topic_id}/event-actions",
+    tags=["event-actions"],
+)
+
+workspace_router = APIRouter(
+    prefix="/workspaces/{workspace_id}/event-actions",
     tags=["event-actions"],
 )
 
@@ -78,7 +83,7 @@ class EventActionIn(BaseModel):
 class EventActionOut(BaseModel):
     id: str
     event_type: str
-    scope_type: Literal["topic"]
+    scope_type: Literal["topic", "workspace"]
     scope_id: str
     staff_name: str
     prompt_template: str
@@ -175,6 +180,48 @@ def _row_to_out(row) -> EventActionOut:
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
+
+
+# ── Workspace-scoped models ───────────────────────────────────────────────────
+
+class WorkspaceEventActionIn(BaseModel):
+    """Input for workspace-scoped event actions.
+
+    topic_scheduler is excluded because it needs a concrete topic to dispatch to.
+    All other event types fire in the context of whichever topic triggered the event.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    event_type: Literal[
+        "topic_message_sent",
+        "topic_message_received",
+        "topic_archived",
+        "topic_archiving",
+    ]
+    staff_name: str
+    prompt_template: str
+    timing: Literal["before", "after"] | None = None
+    enabled: bool = True
+    structured_output: bool = False
+
+    @model_validator(mode="after")
+    def validate_event_type_fields(self) -> "WorkspaceEventActionIn":
+        et = self.event_type
+        if et == "topic_message_sent":
+            if self.timing not in ("before", "after"):
+                raise ValueError("timing must be 'before' or 'after' for topic_message_sent")
+        elif et in ("topic_message_received", "topic_archived", "topic_archiving"):
+            if self.timing not in (None, "after"):
+                raise ValueError(f"timing must be null or 'after' for {et}")
+        return self
+
+
+def _require_workspace(conn, workspace_id: str) -> None:
+    if conn.execute(
+        "SELECT 1 FROM workspaces WHERE id = ? AND archived_at IS NULL",
+        (workspace_id,),
+    ).fetchone() is None:
+        raise HTTPException(404, "workspace not found")
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -324,6 +371,153 @@ def delete_event_action(
         row = conn.execute(
             "SELECT id FROM event_actions WHERE id = ? AND scope_id = ?",
             (action_id, topic_id),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(404, "event action not found")
+        conn.execute("DELETE FROM event_actions WHERE id = ?", (action_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── Workspace-scoped endpoints ─────────────────────────────────────────────────
+
+@workspace_router.get("", response_model=list[EventActionOut])
+def list_workspace_event_actions(workspace_id: str, request: Request) -> list[EventActionOut]:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        _require_workspace(conn, workspace_id)
+        rows = conn.execute(
+            "SELECT * FROM event_actions WHERE scope_type='workspace' AND scope_id=? ORDER BY created_at",
+            (workspace_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [_row_to_out(r) for r in rows]
+
+
+@workspace_router.post("", status_code=201, response_model=EventActionOut)
+def create_workspace_event_action(
+    workspace_id: str,
+    body: WorkspaceEventActionIn,
+    request: Request,
+) -> EventActionOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        _require_workspace(conn, workspace_id)
+        action_id = str(uuid.uuid4())
+        now = _now()
+        conn.execute(
+            "INSERT INTO event_actions"
+            " (id, event_type, scope_type, scope_id, staff_name, prompt_template,"
+            "  timing, cron_expr, last_fired_at, last_run_at, last_run_status,"
+            "  last_run_output, enabled, structured_output, created_at, updated_at)"
+            " VALUES (?, ?, 'workspace', ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?)",
+            (
+                action_id,
+                body.event_type,
+                workspace_id,
+                body.staff_name,
+                body.prompt_template,
+                body.timing,
+                1 if body.enabled else 0,
+                1 if body.structured_output else 0,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM event_actions WHERE id = ?", (action_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return _row_to_out(row)
+
+
+@workspace_router.get("/{action_id}", response_model=EventActionOut)
+def get_workspace_event_action(
+    workspace_id: str,
+    action_id: str,
+    request: Request,
+) -> EventActionOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        _require_workspace(conn, workspace_id)
+        row = conn.execute(
+            "SELECT * FROM event_actions WHERE id = ? AND scope_type='workspace' AND scope_id = ?",
+            (action_id, workspace_id),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        raise HTTPException(404, "event action not found")
+    return _row_to_out(row)
+
+
+@workspace_router.patch("/{action_id}", response_model=EventActionOut)
+def patch_workspace_event_action(
+    workspace_id: str,
+    action_id: str,
+    body: EventActionPatch,
+    request: Request,
+) -> EventActionOut:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        _require_workspace(conn, workspace_id)
+        existing = conn.execute(
+            "SELECT * FROM event_actions WHERE id = ? AND scope_type='workspace' AND scope_id = ?",
+            (action_id, workspace_id),
+        ).fetchone()
+        if existing is None:
+            raise HTTPException(404, "event action not found")
+
+        sent = body.model_dump(exclude_unset=True)
+        for field in ("staff_name", "prompt_template", "enabled", "structured_output"):
+            if field in sent and sent[field] is None:
+                raise HTTPException(422, f"{field} cannot be null")
+        new_staff = sent["staff_name"] if "staff_name" in sent else existing["staff_name"]
+        new_template = sent["prompt_template"] if "prompt_template" in sent else existing["prompt_template"]
+        new_timing = sent["timing"] if "timing" in sent else existing["timing"]
+        new_cron = sent["cron_expr"] if "cron_expr" in sent else existing["cron_expr"]
+        new_enabled = (1 if sent["enabled"] else 0) if "enabled" in sent else existing["enabled"]
+        new_structured_output = (1 if sent["structured_output"] else 0) if "structured_output" in sent else existing["structured_output"]
+
+        _validate_merged_state(
+            event_type=existing["event_type"],
+            timing=new_timing,
+            cron_expr=new_cron,
+        )
+
+        now = _now()
+        conn.execute(
+            "UPDATE event_actions"
+            "   SET staff_name=?, prompt_template=?, timing=?, cron_expr=?, enabled=?,"
+            "       structured_output=?, updated_at=?"
+            " WHERE id=?",
+            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, now, action_id),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM event_actions WHERE id = ?", (action_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return _row_to_out(row)
+
+
+@workspace_router.delete("/{action_id}", status_code=204)
+def delete_workspace_event_action(
+    workspace_id: str,
+    action_id: str,
+    request: Request,
+) -> None:
+    conn = get_connection(request.app.state.db_path)
+    try:
+        _require_workspace(conn, workspace_id)
+        row = conn.execute(
+            "SELECT id FROM event_actions WHERE id = ? AND scope_type='workspace' AND scope_id = ?",
+            (action_id, workspace_id),
         ).fetchone()
         if row is None:
             raise HTTPException(404, "event action not found")

--- a/src/master/event_dispatcher.py
+++ b/src/master/event_dispatcher.py
@@ -132,10 +132,14 @@ async def event_worker(app_state) -> None:
 
 
 async def _handle_event(app_state, event: dict) -> None:
-    """Load matching event_actions and dispatch all of them in parallel."""
+    """Load matching event_actions and dispatch all of them in parallel.
+
+    Loads both topic-scoped actions (for the specific topic) and workspace-scoped
+    actions (configured at the workspace level, fired in the topic context).
+    """
     conn = get_connection(app_state.db_path)
     try:
-        rows = conn.execute(
+        topic_rows = conn.execute(
             "SELECT * FROM event_actions"
             " WHERE scope_type='topic'"
             "   AND scope_id=?"
@@ -144,6 +148,16 @@ async def _handle_event(app_state, event: dict) -> None:
             "   AND (timing IS NULL OR timing=?)",
             (event["topic_id"], event["event_type"], event["timing"]),
         ).fetchall()
+        workspace_rows = conn.execute(
+            "SELECT * FROM event_actions"
+            " WHERE scope_type='workspace'"
+            "   AND scope_id=?"
+            "   AND event_type=?"
+            "   AND enabled=1"
+            "   AND (timing IS NULL OR timing=?)",
+            (event["workspace_id"], event["event_type"], event["timing"]),
+        ).fetchall()
+        rows = list(topic_rows) + list(workspace_rows)
     finally:
         conn.close()
 
@@ -274,7 +288,7 @@ async def run_gate_actions(
 
     conn = get_connection(app_state.db_path)
     try:
-        rows = conn.execute(
+        topic_rows = conn.execute(
             "SELECT * FROM event_actions"
             " WHERE scope_type='topic' AND scope_id=?"
             "   AND event_type='topic_message_sent'"
@@ -283,6 +297,16 @@ async def run_gate_actions(
             "   AND enabled=1",
             (topic_id,),
         ).fetchall()
+        workspace_rows = conn.execute(
+            "SELECT * FROM event_actions"
+            " WHERE scope_type='workspace' AND scope_id=?"
+            "   AND event_type='topic_message_sent'"
+            "   AND timing='before'"
+            "   AND structured_output=1"
+            "   AND enabled=1",
+            (workspace_id,),
+        ).fetchall()
+        rows = list(topic_rows) + list(workspace_rows)
         topic_row = conn.execute(
             "SELECT t.id, t.subject, t.workspace_id, w.name AS workspace_name"
             " FROM topics t JOIN workspaces w ON w.id = t.workspace_id"
@@ -422,7 +446,7 @@ async def veto_dispatch(
 
     conn = get_connection(app_state.db_path)
     try:
-        rows = conn.execute(
+        topic_rows = conn.execute(
             "SELECT * FROM event_actions"
             " WHERE scope_type='topic'"
             "   AND scope_id=?"
@@ -430,6 +454,15 @@ async def veto_dispatch(
             "   AND enabled=1",
             (topic_id,),
         ).fetchall()
+        workspace_rows = conn.execute(
+            "SELECT * FROM event_actions"
+            " WHERE scope_type='workspace'"
+            "   AND scope_id=?"
+            "   AND event_type='topic_archiving'"
+            "   AND enabled=1",
+            (workspace_id,),
+        ).fetchall()
+        rows = list(topic_rows) + list(workspace_rows)
     finally:
         conn.close()
 

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -31,6 +31,7 @@ from .staffs import topic_router as topic_staffs_router
 from .staffs import workspace_router as workspace_staffs_router
 from .storage import LocalAttachmentStore
 from .event_actions import router as event_actions_router
+from .event_actions import workspace_router as event_actions_workspace_router
 from .event_dispatcher import emit_event, event_worker, worker_watchdog
 from .topic_export import router as topic_export_router
 from .topics import recent_router as recent_topics_router
@@ -541,6 +542,7 @@ app.include_router(workspace_config_router, prefix="/api")
 app.include_router(attachments_router, prefix="/api")
 app.include_router(topic_export_router, prefix="/api")
 app.include_router(event_actions_router, prefix="/api")
+app.include_router(event_actions_workspace_router, prefix="/api")
 
 if (_STATIC_DIR / "assets").exists():
     app.mount("/assets", StaticFiles(directory=str(_STATIC_DIR / "assets")), name="static-assets")

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -149,6 +149,28 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
         LOGGER.exception("mqtt.save_agent_response_error topic_id=%s", topic_id)
 
 
+def _prompt_was_event_dispatched(db_path: str, reply_to: str) -> bool:
+    """Return True if the prompt message that triggered this reply had sender='event'.
+
+    Agent replies to event-dispatched prompts must not re-fire topic_message_received,
+    otherwise every event action on that event type loops indefinitely.
+    """
+    if not reply_to:
+        return False
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT sender FROM messages WHERE id = ?", (reply_to,)
+            ).fetchone()
+            return row is not None and row[0] == "event"
+        finally:
+            conn.close()
+    except Exception:
+        LOGGER.exception("mqtt.prompt_sender_check_error reply_to=%s", reply_to)
+        return False
+
+
 def _get_structured_output_action(db_path: str, message_id: str) -> sqlite3.Row | None:
     """Return the event_action row if message_id links to a structured-output action."""
     if not message_id:
@@ -385,7 +407,11 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
             app_state = userdata.get("app_state")
             # emit_event self-guards if event infrastructure isn't up; the only thing
             # we need to check here is that we have the app_state to pass through.
-            if app_state is not None:
+            # Skip if this reply is responding to an event-dispatched prompt — otherwise
+            # every topic_message_received action loops: action fires → agent replies →
+            # topic_message_received re-fires → action fires again.
+            reply_to = payload.get("reply_to", "")
+            if app_state is not None and not _prompt_was_event_dispatched(db_path, reply_to):
                 workspace_id = _get_workspace_id(db_path, topic_id)
                 topic_name = _get_topic_name(db_path, topic_id)
                 if workspace_id:

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -451,6 +451,7 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
             reply_to,
             payload.get("verdict"),
         )
+        return
     elif msg_type == "pong":
         try:
             app_state = userdata.get("app_state")


### PR DESCRIPTION
## Summary

- Widen `event_actions.scope_type` DB constraint from `('topic')` to `('topic', 'workspace')` via idempotent migration `_migrate_event_actions_v3`
- Add `workspace_router` with full CRUD under `/api/workspaces/{id}/event-actions`; supports `topic_message_sent`, `topic_message_received`, `topic_archived`, `topic_archiving` — `topic_scheduler` excluded (requires a concrete target topic)
- Update `event_dispatcher` (`_handle_event`, `run_gate_actions`, `veto_dispatch`) to load workspace-scoped actions alongside topic-scoped ones; workspace actions fire in the context of whichever topic triggered the event, resolving the output-channel question deferred in ADR-0013 §6
- Add **Workspace Event Actions** section to `WorkspaceDetail.vue` with create/edit/delete/enable-toggle UI, mirroring the per-topic panel in `TopicSettings.vue`

## Test plan

- [x] `572 passed, 1 skipped` in CI (full test suite ran on dev env)
- [ ] Navigate to a workspace → **Workspace Event Actions** section is visible
- [ ] Create a `topic_message_sent / after` action with a real staff → verify it fires when a message is sent in **any** topic of that workspace
- [ ] Create a `topic_archived` action → archive a topic → verify the action fires and `last_run_status=ok` is shown in the UI
- [ ] Create a `topic_archiving` action with a staff that returns `{"break": true}` → verify archive is vetoed workspace-wide
- [ ] Disable an action (toggle checkbox) → send a message → verify it does **not** fire
- [ ] Edit prompt template and staff on an existing workspace action → verify changes persist
- [ ] Delete a workspace action → confirm it disappears and no longer fires
- [ ] Confirm a topic-scoped action still fires independently alongside a workspace-scoped action for the same event type

🤖 Generated with repository automation