### PR TITLE
fix(agent): fix stale-stream race + show interrupt reason in UI

### DIFF
--- a/docs/guides/runbooks/agent-message-cutoff.md
+++ b/docs/guides/runbooks/agent-message-cutoff.md
@@ -1,0 +1,190 @@
+# Agent Message Cut-Off — Investigation Runbook
+
+## Symptom
+
+A message in the UI ends with the orange **"interrupted"** badge instead of a normal agent response. Master log shows:
+
+```
+master.stale_stream_interrupted message_id=<R> topic_id=<T> container_running=True chunk_age_s=<N>
+```
+
+…and the message row in `messages` has `text='(message interrupted)'` with `interrupt_reason` set.
+
+## Impact
+
+User's prompt produced no usable answer. Any work the codex/claude subprocess started (file edits, repo state, partial chunks) is preserved in the chunks table / worktree but the *response* is gone. The agent container itself usually keeps running.
+
+## Decision tree — start here
+
+Open the affected topic in the UI. Note the **`interrupt_reason`** displayed on the badge:
+
+| Badge text | Reason key | Most likely cause | Go to |
+|---|---|---|---|
+| "interrupted: agent restarted" | `agent-shutdown` | Clean SIGTERM (someone clicked Restart Agent, or container was `docker stop`'d) | §1 |
+| "interrupted: container gone" | `container-gone` | Container removed mid-stream — usually master's `stop_agent` (UI Restart Agent button) | §1 |
+| "interrupted: agent killed" | `agent-killed` | SIGKILL'd container, Docker's restart policy bounced it, new agent replayed (v4.15-rc6+) | §2 |
+| "interrupted: no response" | `ping-timeout` | Agent failed the ping but container still up — subprocess crashed in Python OR the agent is on a build prior to rc6 | §3 |
+| "interrupted" (no specific text) | NULL | Old DB row from before PR #222 — no diagnostic info available | §4 |
+
+## §1 — agent-shutdown / container-gone
+
+Almost always intentional (someone restarted the agent or the container was rescheduled). Cross-check:
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker logs codex-slack-master 2>&1 \
+  | grep -E "agent_runner\.(stopped|spawned)|workspace\.restarted|master\.idle_stop" \
+  | tail -20
+```
+
+If you find `agent_runner.stopped`/`workspace.restarted` near the cut-off timestamp, it was a deliberate restart. Document the action that triggered it (UI click, deploy, etc.) and close. No code fix needed.
+
+## §2 — agent-killed *(this is the case PR #222 / v4.15-rc6 added)*
+
+The container was killed by something outside Python (SIGKILL bypasses our handlers). Docker's restart policy brought it back, the new agent replayed `_active_procs` from disk, and published the `agent-killed` interrupt event.
+
+### Step 1: confirm the kill
+
+`docker inspect` lies — it reports `exitcode=0` for restarted containers. Use the dockerd journal for ground truth:
+
+```bash
+ssh ubuntu@<prod-host> \
+  'sudo journalctl --since "<HH:MM>:00" --until "<HH:MM>:59" -u docker' \
+  | grep -E "restarting container.*exitCode"
+```
+
+Expected match:
+```
+restarting container ... exitCode=137 exitedAt="..." manualRestart=false restartPolicy="{unless-stopped 0}"
+```
+
+- `exitCode=137` ⇒ SIGKILL
+- `exitCode=143` ⇒ SIGTERM that completed
+- `manualRestart=false` ⇒ Docker's policy, not a human `docker restart`
+
+### Step 2: rule out kernel OOM
+
+```bash
+ssh ubuntu@<prod-host> 'sudo journalctl -k --since "<HH:MM>:00" --until "<HH:MM>:59"' \
+  | grep -iE "oom|out of memory|killed process"
+
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker inspect <container> --format '{{.State.OOMKilled}}'
+```
+
+If `OOMKilled=true` or the kernel log shows an OOM event: the container exceeded available memory. Look at recent memory usage in the agent (large transcript? Many subprocess instances?) — fix is to set explicit `Memory` limits in `agent_runner.spawn_agent` or scale the host.
+
+### Step 3: rule out master initiating it
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker logs codex-slack-master --since 1h 2>&1 \
+  | grep -E "agent_runner\.(stopped|spawned)|master\.idle_stop|pause_agent" \
+  | grep <container>
+```
+
+Any hit here means master code stopped the agent. The most common case is `master.idle_stop` (idle timeout reached). Cross-reference with `MASTER_AGENT_IDLE_TIMEOUT_SECONDS`.
+
+### Step 4: rule out CD daemon
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker logs codex-slack-cd-daemon --since 1h 2>&1 \
+  | grep -E "cd\.deploy_start|cd\.force_recreate|cd\.new_image" | tail -10
+```
+
+If a deploy fired right before the kill: that's the source. CD daemon only restarts the master container — but a master restart can ripple into agent state.
+
+### Step 5: rule out host-wide event
+
+If multiple containers were killed in the same minute, it's a host event (kernel panic, dockerd restart). If only this container, it's container-specific.
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker ps -a \
+  --format '{{.Names}} RestartCount={{.RestartCount}} created={{.CreatedAt}}'
+```
+
+Compare `RestartCount` and `created` against the incident time.
+
+### Step 6: examine the codex transcript
+
+The chunks before the cut-off are preserved in `messages.transcript` for the interrupted message. They tell you what the model was *doing* at the moment of death:
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker exec codex-slack-master python -c "
+import sqlite3, json
+conn = sqlite3.connect('/opt/codex-slack/data/master/master_data.db')
+row = conn.execute(\"SELECT transcript FROM messages WHERE id=?\", ('<message-id>',)).fetchone()
+events = json.loads(row[0])
+for e in events[-10:]:
+    item = e.get('item', {}) if isinstance(e.get('item'), dict) else {}
+    print(e.get('type'), item.get('command', '')[:120])
+"
+```
+
+The last `item.started` (without matching `item.completed`) is the command the model was running when it died. If it correlates with shell commands that allocate memory, write to disk, or fork heavily, that's a strong signal.
+
+### Step 7: if all the above are clean
+
+You have an unexplained SIGKILL. Possibilities to investigate next:
+
+- **Tini SIGTERM→SIGKILL escalation.** Default 10s grace. Look upstream for whoever sent the original SIGTERM — could be a host-level systemd unit, container manager extension, or security tool.
+- **Disk pressure** (overlay2 ENOSPC, write rejected). `ssh ubuntu@<host> df -h /` near the incident time; pull `journalctl` for disk-related kernel messages.
+- **Codex CLI doing something fatal.** The CLI runs with `--dangerously-bypass-approvals-and-sandbox` and can run any shell command the model picks. In principle the model could issue `kill -9 1` against tini. Inspect the transcript for any such command.
+
+If still unidentified, file the incident with the full timeline + ruled-out items. The new logs at least give you a marker — `agent.startup_inherited_active count=N message_ids=[...]` — so you can correlate future incidents.
+
+## §3 — ping-timeout
+
+Agent container is still up, but answered `alive=False` to master's ping. Two sub-cases:
+
+### §3a — Python exception path (preferred outcome with v4.15-rc5+)
+
+Look for either of these in the agent container log around the cut-off time:
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker logs <agent-container> --since 1h 2>&1 \
+  | grep -E "agent\.(llm|codex)_subprocess_(aborted|nonzero_exit)"
+```
+
+If matched, the line carries everything you need:
+```
+agent.codex_subprocess_aborted topic_id=… message_id=… pid=…
+   returncode=… chunks=… exc_type=BrokenPipeError exc=… stderr_tail=…
+```
+
+- `exc_type` + `exc` → which exception type aborted the stream (look in `_stream_codex_once`/`_stream_claude_once` for the matching code path)
+- `stderr_tail` → last bytes of the codex/claude CLI's stderr, often the actual error text
+- `returncode` → if non-None, the subprocess had exited cleanly with a failure code
+
+### §3b — agent on a pre-rc5 build, no detailed logs
+
+If you see `agent.pong message_id=… alive=False` with no preceding `agent.llm_done` / `agent.codex_done` / `agent.*_subprocess_aborted`:
+
+The agent is missing the rc5/rc6 logging. Confirm:
+
+```bash
+DOCKER_HOST=ssh://ubuntu@<prod-host> docker exec <agent-container> sh -c 'env | grep APP_VERSION'
+```
+
+If `APP_VERSION` is earlier than `v4.15-rc5`: trigger a respawn so the agent picks up the latest image. After that, the next incident will give you the detailed logs.
+
+```bash
+# Restart the workspace's agent (master will recreate the container)
+curl -sS -X POST 'https://codex-slack-prod.pandazxx.com/api/workspaces/<workspace-id>/restart-agent'
+```
+
+## §4 — bare "interrupted" with NULL reason
+
+The row predates PR #222 / v4.14. No diagnostic information was captured. There's nothing to investigate; close as historical.
+
+## Quick reference — important paths
+
+| What | Where |
+|---|---|
+| Master DB | `/opt/codex-slack/data/master/master_data.db` inside `codex-slack-master` |
+| Agent persisted `_active_procs` snapshot (v4.15-rc6+) | `/tmp/master-agent/active_procs.json` inside the agent container |
+| Master logs | `docker logs codex-slack-master` |
+| Agent logs | `docker logs codex-agent-<workspace-id>` |
+| CD daemon logs | `docker logs codex-slack-cd-daemon` |
+| Host journal | `journalctl -u docker` and `journalctl -k` |
+
+## Reference case
+
+The runbook was written after the **2026-05-17 cbc02192 incident** in topic `7c4f67e9` (workspace `e6d8e527`). See `docs/knowledge-base/lessons-learned.md` for the post-mortem. Symptoms were exactly §2: `exitCode=137`, `manualRestart=false`, no master logs of a stop/spawn, no kernel OOM. Codex was running `git worktree add origin/pr/219` at the moment of death. Source of the SIGKILL was not positively identified. PR #222 (v4.15-rc5 + rc6) was the response: rc5 adds subprocess-abort logging, rc6 adds the persistent `_active_procs` snapshot + startup replay so that future occurrences surface as `agent-killed` instead of silent `ping-timeout`.

--- a/docs/knowledge-base/lessons-learned.md
+++ b/docs/knowledge-base/lessons-learned.md
@@ -2,7 +2,26 @@
 
 Append-only log. Each entry: date, summary, root cause, fix applied, prevention.
 
-<!-- last updated: 2026-05-09 -->
+<!-- last updated: 2026-05-17 -->
+
+---
+
+## 2026-05-17 — Agent container SIGKILL'd mid-stream surfaces as `ping-timeout` with no diagnostic
+
+*Summary:* Prod message `cbc02192` in topic `7c4f67e9` was cut off mid-response. Master labeled it `interrupt_reason=ping-timeout`, which read as "agent unresponsive" — misleading. The actual sequence: agent container was SIGKILL'd at 08:48:03 while codex was running `git worktree add origin/pr/219`, Docker's `restart: unless-stopped` policy bounced it ~1s later, master pinged the fresh agent 4s after that, the new agent had no record of the message (in-memory `_active_procs` is empty), so it returned `alive=False`. None of the existing interrupt paths (SIGTERM handler, master `stop_agent`, container-gone detection) fit, because SIGKILL bypasses Python entirely and the container *was* running by the time master checked.
+
+*Root cause:* Two compounding gaps.
+1. **Visibility:** `docker inspect` reports the post-restart `ExitCode=0` regardless of what killed the previous run. The ground-truth `exitCode=137` only appears in `journalctl -u docker`. Operators tracking through `docker inspect` will be misled into ruling out a kill.
+2. **Recovery:** `_active_procs` was Python-memory-only. SIGKILL → restart-policy bounce loses the entire in-flight set with no signal to master beyond an opaque `alive=False`.
+
+*Fix applied:*
+- **v4.15-rc5 (`f36eee3`)** — `LOGGER.exception` in the `except Exception` branches of `_stream_claude_once` / `_stream_codex_once` carrying `pid`, `returncode`, `chunks`, `exc_type`, `exc`, `stderr_tail[-500:]`. Non-zero proc exits now emit `agent.*_subprocess_nonzero_exit` even when partial output was produced. `agent.llm_done`/`agent.codex_done` now include `message_id`/`pid`/`returncode`. `agent.pong … alive=False` now includes `active_procs_size`.
+- **v4.15-rc6 (`8b5fa1d`)** — Atomic snapshot of `_active_contexts` written to `/tmp/master-agent/active_procs.json` on every mutation under `_active_procs_lock`. On agent startup (`_on_connect` after subscribe), `_publish_inherited_interrupts` reads the snapshot and emits `(message interrupted)` with new `interrupt_reason=agent-killed` for every leftover entry, then unlinks the file. SIGTERM handler (`_publish_interrupted_all`) also clears the file so a clean stop+restart doesn't double-publish. UI badge added for `agent-killed`.
+- **Runbook** — `docs/guides/runbooks/agent-message-cutoff.md` documents the §1–§4 decision tree.
+
+*Prevention:* Two angles.
+1. Future incidents of the same shape now self-label as `agent-killed` and leave a marker (`agent.startup_inherited_active`) in the agent log. That's enough to confirm a SIGKILL+restart vs. other interrupt modes without paging the host journal.
+2. The kill *source* was never positively identified for the 2026-05-17 case — ruled out kernel OOM, master stop_agent, CD daemon, host-wide event, cron. Most plausible remaining hypothesis is tini's SIGTERM→SIGKILL escalation, but no SIGTERM source was located either. If the same pattern recurs with the new logs in place, the additional context (which message_ids, what codex was doing per the transcript, exact dockerd journal line) should narrow it.
 
 ---
 

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -53,6 +53,10 @@
                     <span v-else-if="row.kind === 'task_progress'">↳ {{ row.event.description }}</span>
                     <span v-else-if="row.kind === 'task_started'">🚀 {{ row.event.description }}</span>
                     <span v-else-if="row.kind === 'retry_notice'">⟳ Session expired — retrying…</span>
+                    <div v-else-if="row.kind === 'parse_warning'" class="tr-meta">
+                      <span class="tr-badge tr-badge-warning">parse error</span>
+                      <span class="tr-stat">{{ row.event.line || '' }}</span>
+                    </div>
                     <div v-else-if="row.kind === 'thinking'" class="thinking-block">
                       <div class="thinking-meta">💭 Thinking</div>
                       <div class="thinking-text">{{ thinkingText(row.event) }}</div>
@@ -89,6 +93,10 @@
                   <span v-else-if="row.kind === 'task_progress'">↳ {{ row.event.description }}</span>
                   <span v-else-if="row.kind === 'task_started'">🚀 {{ row.event.description }}</span>
                   <span v-else-if="row.kind === 'retry_notice'">⟳ Session expired — retrying…</span>
+                  <div v-else-if="row.kind === 'parse_warning'" class="tr-meta">
+                    <span class="tr-badge tr-badge-warning">parse error</span>
+                    <span class="tr-stat">{{ row.event.line || '' }}</span>
+                  </div>
                   <div v-else-if="row.kind === 'thinking'" class="thinking-block">
                     <div class="thinking-meta">💭 Thinking</div>
                     <div class="thinking-text">{{ thinkingText(row.event) }}</div>
@@ -385,6 +393,7 @@ function compactRowLabel(row) {
   if (kind === 'codex_cmd') return codexCmdLabel(event)
   if (kind === 'codex_error') return `✗ ${event.error?.message || 'error'}`
   if (kind === 'retry_notice') return '⟳ Session expired — retrying…'
+  if (kind === 'parse_warning') return `⚠ parse error: ${(event.line || '').slice(0, 60)}`
   return '···'
 }
 
@@ -446,9 +455,10 @@ function classifyEvent(event) {
     if (c.some(b => b.type === 'thinking')) return 'thinking'
     if (c.some(b => b.type === 'tool_use')) return 'tool_use'
   }
-  if (t === 'system' && s === 'task_progress') return 'task_progress'
-  if (t === 'system' && s === 'task_started')  return 'task_started'
-  if (t === 'system' && s === 'retry')         return 'retry_notice'
+  if (t === 'system' && s === 'task_progress')  return 'task_progress'
+  if (t === 'system' && s === 'task_started')   return 'task_started'
+  if (t === 'system' && s === 'retry')          return 'retry_notice'
+  if (t === 'system' && s === 'parse_warning')  return 'parse_warning'
   if (t === 'user') {
     const c = event.message?.content || []
     if (c.some(b => b.type === 'tool_result')) {
@@ -943,6 +953,7 @@ onUnmounted(() => {
 .tr-badge-result { background: #dcfce7; color: #15803d; }
 .tr-badge-done { background: #dcfce7; color: #15803d; }
 .tr-badge-error { background: #fee2e2; color: #dc2626; }
+.tr-badge-warning { background: #fef3c7; color: #92400e; }
 .tr-badge-thinking { background: #f3e8ff; color: #7c3aed; }
 .tr-thinking { display: flex; flex-direction: column; gap: 2px; }
 .tr-thinking-body { background: #1a0a2e; color: #c4b5fd; }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -114,7 +114,7 @@
               </details>
             </template>
             <div v-if="m.text === '(message interrupted)'" class="interrupted-notice">
-              <span class="tr-badge tr-badge-interrupted">interrupted</span>
+              <span class="tr-badge tr-badge-interrupted">{{ interruptLabel(m) }}</span>
             </div>
             <template v-else-if="isMsgCollapsible(m, msgIdx) && !isMsgExpanded(m.id)">
               <MarkdownMessage :text="collapsedPreview(m.text)" />
@@ -365,6 +365,15 @@ function collapsedPreview(text) {
   return text.slice(0, MSG_COLLAPSED_PREVIEW) + '…'
 }
 
+function interruptLabel(m) {
+  switch (m.interrupt_reason) {
+    case 'agent-shutdown': return 'interrupted: agent restarted'
+    case 'container-gone': return 'interrupted: container gone'
+    case 'ping-timeout':   return 'interrupted: no response'
+    default:               return 'interrupted'
+  }
+}
+
 function compactRowLabel(row) {
   const { kind, event } = row
   if (kind === 'tool_use') return toolUseLabel(event)
@@ -594,6 +603,7 @@ function finaliseMessage(data) {
     transcript: data.transcript || existing?.transcript || null,
     traceRows: transcriptToRows(data.transcript) || existing?.traceRows || [],
     attachments: data.attachments ?? existing?.attachments ?? [],
+    interrupt_reason: data.interrupt_reason ?? existing?.interrupt_reason ?? null,
     traceOpen: false, streaming: false,
     created_at: existing?.created_at || new Date().toISOString(),
   }

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -376,6 +376,7 @@ function collapsedPreview(text) {
 function interruptLabel(m) {
   switch (m.interrupt_reason) {
     case 'agent-shutdown': return 'interrupted: agent restarted'
+    case 'agent-killed':   return 'interrupted: agent killed'
     case 'container-gone': return 'interrupted: container gone'
     case 'ping-timeout':   return 'interrupted: no response'
     default:               return 'interrupted'

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -223,36 +223,31 @@ def _stream_claude_once(
                 "topic_id": topic_id,
                 "agent_name": agent_name,
             }
-        try:
-            for line in proc.stdout:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                events.append(event)
-                client.publish(chunk_topic, json.dumps({
-                    "message_id": reply_message_id,
-                    "agent_name": agent_name,
-                    "seq": seq,
-                    "event": event,
-                }), qos=0)
-                LOGGER.debug("agent.llm_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
-                seq += 1
-                if event.get("type") == "result":
-                    new_session_id = event.get("session_id")
-                    result_text = event.get("result") or event.get("last_response")
-                    if result_text:
-                        outputs.append(result_text)
-                    if event.get("is_error"):
-                        is_error = True
-            proc.wait()
-        finally:
-            with _active_procs_lock:
-                _active_procs.pop(reply_message_id, None)
-                _active_contexts.pop(reply_message_id, None)
+        for line in proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            events.append(event)
+            client.publish(chunk_topic, json.dumps({
+                "message_id": reply_message_id,
+                "agent_name": agent_name,
+                "seq": seq,
+                "event": event,
+            }), qos=0)
+            LOGGER.debug("agent.llm_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
+            seq += 1
+            if event.get("type") == "result":
+                new_session_id = event.get("session_id")
+                result_text = event.get("result") or event.get("last_response")
+                if result_text:
+                    outputs.append(result_text)
+                if event.get("is_error"):
+                    is_error = True
+        proc.wait()
         output = "\n\n---\n\n".join(outputs) if outputs else None
         if not output:
             err = (proc.stderr.read() or "").strip()
@@ -362,39 +357,34 @@ def _stream_codex_once(
                 "topic_id": topic_id,
                 "agent_name": agent_name,
             }
-        try:
-            for line in proc.stdout:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
-                    event = {"type": "output", "content": line}
-                events.append(event)
-                client.publish(chunk_topic, json.dumps({
-                    "message_id": reply_message_id,
-                    "agent_name": agent_name,
-                    "seq": seq,
-                    "event": event,
-                }), qos=0)
-                LOGGER.debug("agent.codex_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
-                seq += 1
-                ev_type = event.get("type", "")
-                if ev_type == "turn.completed":
-                    final = event.get("output_text") or event.get("last_message")
-                    if final:
-                        fallback_outputs.append(str(final))
-                elif ev_type == "turn.failed":
-                    is_error = True
-                    err_msg = (event.get("error") or {}).get("message", "")
-                    if err_msg:
-                        fallback_outputs.append(f"(codex error: {err_msg})")
-            proc.wait()
-        finally:
-            with _active_procs_lock:
-                _active_procs.pop(reply_message_id, None)
-                _active_contexts.pop(reply_message_id, None)
+        for line in proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                event = {"type": "output", "content": line}
+            events.append(event)
+            client.publish(chunk_topic, json.dumps({
+                "message_id": reply_message_id,
+                "agent_name": agent_name,
+                "seq": seq,
+                "event": event,
+            }), qos=0)
+            LOGGER.debug("agent.codex_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
+            seq += 1
+            ev_type = event.get("type", "")
+            if ev_type == "turn.completed":
+                final = event.get("output_text") or event.get("last_message")
+                if final:
+                    fallback_outputs.append(str(final))
+            elif ev_type == "turn.failed":
+                is_error = True
+                err_msg = (event.get("error") or {}).get("message", "")
+                if err_msg:
+                    fallback_outputs.append(f"(codex error: {err_msg})")
+        proc.wait()
         if proc.returncode and proc.returncode != 0 and not is_error:
             is_error = True
         output = None
@@ -429,6 +419,9 @@ def _stream_codex_once(
     except Exception as exc:
         if proc is not None:
             _kill_proc_tree(proc)
+        with _active_procs_lock:
+            _active_procs.pop(reply_message_id, None)
+            _active_contexts.pop(reply_message_id, None)
         try:
             Path(output_file).unlink()
         except Exception:
@@ -532,36 +525,43 @@ def _process_prompt(
 
     LOGGER.info("agent.llm_done topic_id=%s chars=%d", topic_id, len(response_text))
 
-    client.publish(
-        _response_topic(workspace_id, topic_id),
-        json.dumps({
-            "message_id": reply_message_id,
-            "agent_name": agent_name,
-            "reply_to": message_id,
-            "last_response": response_text,
-            "transcript": transcript,
-            "session_id": new_session_id,
-        }),
-        qos=1,
-    )
-
-    if response_mode == "verdict":
-        verdict = _extract_verdict(response_text)
+    try:
         client.publish(
-            _verdict_topic(workspace_id, topic_id),
+            _response_topic(workspace_id, topic_id),
             json.dumps({
-                "reply_to": message_id,
+                "message_id": reply_message_id,
                 "agent_name": agent_name,
-                "verdict": verdict["verdict"],
-                "reason": verdict.get("reason", ""),
+                "reply_to": message_id,
+                "last_response": response_text,
+                "transcript": transcript,
+                "session_id": new_session_id,
             }),
             qos=1,
         )
-        LOGGER.info(
-            "agent.verdict_published topic_id=%s verdict=%s",
-            topic_id,
-            verdict["verdict"],
-        )
+
+        if response_mode == "verdict":
+            verdict = _extract_verdict(response_text)
+            client.publish(
+                _verdict_topic(workspace_id, topic_id),
+                json.dumps({
+                    "reply_to": message_id,
+                    "agent_name": agent_name,
+                    "verdict": verdict["verdict"],
+                    "reason": verdict.get("reason", ""),
+                }),
+                qos=1,
+            )
+            LOGGER.info(
+                "agent.verdict_published topic_id=%s verdict=%s",
+                topic_id,
+                verdict["verdict"],
+            )
+    finally:
+        # Keep proc in _active_procs until the response is queued so that
+        # the stale-stream ping returns alive=True during the post-exit window.
+        with _active_procs_lock:
+            _active_procs.pop(reply_message_id, None)
+            _active_contexts.pop(reply_message_id, None)
 
     client.publish(_status_topic(workspace_id, topic_id), json.dumps({"state": "idle"}), qos=0)
 
@@ -625,7 +625,7 @@ def _on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
         if message_id:
             with _active_procs_lock:
                 proc = _active_procs.get(message_id)
-            alive = proc is not None and proc.poll() is None
+            alive = proc is not None
             client.publish(
                 _pong_topic(workspace_id_ping, topic_id_ping),
                 json.dumps({"message_id": message_id, "alive": alive}),

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -257,19 +257,58 @@ def _stream_claude_once(
                 if event.get("is_error"):
                     is_error = True
         proc.wait()
+        rc = proc.returncode
         output = "\n\n---\n\n".join(outputs) if outputs else None
-        if not output:
-            err = (proc.stderr.read() or "").strip()
-            output = err or "(no output)"
+        stderr_tail = ""
+        if not output or rc != 0:
+            stderr_tail = (proc.stderr.read() or "").strip()
+            if not output:
+                output = stderr_tail or "(no output)"
         transcript = json.dumps(events) if events else None
+        if rc != 0:
+            # Non-zero exit without an exception — claude exited cleanly with
+            # a failure code. Surface enough postmortem to correlate with a
+            # later alive=False ping (master keeps the proc reference past
+            # this point, so the ping window is short but it exists).
+            LOGGER.warning(
+                "agent.llm_subprocess_nonzero_exit topic_id=%s message_id=%s pid=%s returncode=%d chunks=%d chars=%d stderr_tail=%r",
+                topic_id, reply_message_id, proc.pid, rc,
+                seq - seq_start, len(output), stderr_tail[-500:],
+            )
+            is_error = True
         LOGGER.info(
-            "agent.llm_done topic_id=%s chunks=%d chars=%d",
-            topic_id, seq - seq_start, len(output),
+            "agent.llm_done topic_id=%s message_id=%s pid=%s returncode=%s chunks=%d chars=%d",
+            topic_id, reply_message_id, proc.pid, rc,
+            seq - seq_start, len(output),
         )
         return output, new_session_id, transcript, is_error
     except FileNotFoundError:
+        LOGGER.error(
+            "agent.llm_cli_missing topic_id=%s message_id=%s cmd=%s",
+            topic_id, reply_message_id, cmd[0] if cmd else "claude",
+        )
         return "(claude CLI not found in agent container)", None, None, True
     except Exception as exc:
+        # Silent subprocess crashes (e.g. broken pipe on stdout, MQTT publish
+        # raising mid-stream, an OS error while reading proc.stdout) were the
+        # observed cause of "alive=False without agent.llm_done" in prod.
+        # Capture proc state BEFORE killing the tree so the postmortem is
+        # accurate, even if proc.poll() may already be None for a live proc
+        # that we're about to terminate.
+        rc = proc.poll() if proc is not None else None
+        stderr_tail = ""
+        if proc is not None and proc.stderr is not None:
+            try:
+                stderr_tail = (proc.stderr.read() or "").strip()
+            except Exception:
+                pass
+        LOGGER.exception(
+            "agent.llm_subprocess_aborted topic_id=%s message_id=%s pid=%s returncode=%s chunks=%d exc_type=%s exc=%s stderr_tail=%r",
+            topic_id, reply_message_id,
+            proc.pid if proc is not None else None,
+            rc, seq - seq_start,
+            type(exc).__name__, exc, stderr_tail[-500:],
+        )
         if proc is not None:
             _kill_proc_tree(proc)
         with _active_procs_lock:
@@ -394,7 +433,8 @@ def _stream_codex_once(
                 if err_msg:
                     fallback_outputs.append(f"(codex error: {err_msg})")
         proc.wait()
-        if proc.returncode and proc.returncode != 0 and not is_error:
+        rc = proc.returncode
+        if rc and rc != 0 and not is_error:
             is_error = True
         output = None
         try:
@@ -410,22 +450,51 @@ def _stream_codex_once(
                 pass
         if not output:
             output = "\n\n---\n\n".join(fallback_outputs) if fallback_outputs else None
-        if not output:
-            err = (proc.stderr.read() or "").strip()
-            output = err or "(no output)"
+        stderr_tail = ""
+        if not output or (rc is not None and rc != 0):
+            stderr_tail = (proc.stderr.read() or "").strip()
+            if not output:
+                output = stderr_tail or "(no output)"
         transcript = json.dumps(events) if events else None
+        if rc is not None and rc != 0:
+            LOGGER.warning(
+                "agent.codex_subprocess_nonzero_exit topic_id=%s message_id=%s pid=%s returncode=%d chunks=%d chars=%d stderr_tail=%r",
+                topic_id, reply_message_id, proc.pid, rc,
+                seq - seq_start, len(output), stderr_tail[-500:],
+            )
         LOGGER.info(
-            "agent.codex_done topic_id=%s chunks=%d chars=%d",
-            topic_id, seq - seq_start, len(output),
+            "agent.codex_done topic_id=%s message_id=%s pid=%s returncode=%s chunks=%d chars=%d",
+            topic_id, reply_message_id, proc.pid, rc,
+            seq - seq_start, len(output),
         )
         return output, transcript, is_error
     except FileNotFoundError:
+        LOGGER.error(
+            "agent.codex_cli_missing topic_id=%s message_id=%s cmd=%s",
+            topic_id, reply_message_id, cmd[0] if cmd else "codex",
+        )
         try:
             Path(output_file).unlink()
         except Exception:
             pass
         return "(codex CLI not found in agent container)", None, True
     except Exception as exc:
+        # See _stream_claude_once for rationale — same alive=False-without-done
+        # pattern. Capture postmortem before kill_proc_tree.
+        rc = proc.poll() if proc is not None else None
+        stderr_tail = ""
+        if proc is not None and proc.stderr is not None:
+            try:
+                stderr_tail = (proc.stderr.read() or "").strip()
+            except Exception:
+                pass
+        LOGGER.exception(
+            "agent.codex_subprocess_aborted topic_id=%s message_id=%s pid=%s returncode=%s chunks=%d exc_type=%s exc=%s stderr_tail=%r",
+            topic_id, reply_message_id,
+            proc.pid if proc is not None else None,
+            rc, seq - seq_start,
+            type(exc).__name__, exc, stderr_tail[-500:],
+        )
         if proc is not None:
             _kill_proc_tree(proc)
         with _active_procs_lock:
@@ -635,13 +704,30 @@ def _on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
         if message_id:
             with _active_procs_lock:
                 proc = _active_procs.get(message_id)
+                active_count = len(_active_procs)
             alive = proc is not None
             client.publish(
                 _pong_topic(workspace_id_ping, topic_id_ping),
                 json.dumps({"message_id": message_id, "alive": alive}),
                 qos=0,
             )
-            LOGGER.info("agent.pong message_id=%s alive=%s", message_id, alive)
+            if alive:
+                LOGGER.info(
+                    "agent.pong message_id=%s alive=True pid=%s",
+                    message_id, proc.pid,
+                )
+            else:
+                # alive=False means the proc is no longer in _active_procs.
+                # The subprocess either exited normally (look up the prior
+                # agent.llm_done / agent.codex_done line for returncode) or
+                # aborted (look up the prior agent.llm_subprocess_aborted /
+                # agent.codex_subprocess_aborted line for the exception and
+                # stderr tail). active_procs_size aids correlation when many
+                # streams are in flight.
+                LOGGER.info(
+                    "agent.pong message_id=%s alive=False active_procs_size=%d",
+                    message_id, active_count,
+                )
         return
 
     parsed_cancel = _parse_cancel_topic(msg.topic)

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -231,6 +231,14 @@ def _stream_claude_once(
                 event = json.loads(line)
             except (json.JSONDecodeError, ValueError):
                 LOGGER.warning("agent.llm_chunk_parse_error topic_id=%s line=%r", topic_id, line[:200])
+                warn_event = {"type": "system", "subtype": "parse_warning", "line": line[:200]}
+                client.publish(chunk_topic, json.dumps({
+                    "message_id": reply_message_id,
+                    "agent_name": agent_name,
+                    "seq": seq,
+                    "event": warn_event,
+                }), qos=0)
+                seq += 1
                 continue
             events.append(event)
             client.publish(chunk_topic, json.dumps({

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -230,6 +230,7 @@ def _stream_claude_once(
             try:
                 event = json.loads(line)
             except (json.JSONDecodeError, ValueError):
+                LOGGER.warning("agent.llm_chunk_parse_error topic_id=%s line=%r", topic_id, line[:200])
                 continue
             events.append(event)
             client.publish(chunk_topic, json.dumps({

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -29,6 +29,16 @@ _active_procs: dict[str, subprocess.Popen] = {}  # type: ignore[type-arg]
 _active_contexts: dict[str, dict] = {}  # message_id → {workspace_id, topic_id, agent_name}
 _active_procs_lock = threading.Lock()
 
+# Persisted snapshot of in-flight subprocess contexts so that a SIGKILL-survivor
+# restart can emit a real interrupt event for messages whose subprocess died
+# along with the container. Path is on the container's writable layer; survives
+# a Docker restart (same container) but not a remove+recreate, which is fine —
+# remove+recreate is master-initiated and master's stale-stream check already
+# detects "container-gone" in that path.
+_STATE_DIR = Path("/tmp/master-agent")
+_ACTIVE_PROCS_PATH = _STATE_DIR / "active_procs.json"
+_inherited_already_published = False
+
 # Deduplication: clean_session=False means the broker redelivers QoS-1 prompts when
 # the agent reconnects mid-run, which would start a second parallel LLM run and produce
 # two streaming bubbles. Track seen message_ids (bounded to 2000) and discard re-deliveries.
@@ -223,6 +233,7 @@ def _stream_claude_once(
                 "topic_id": topic_id,
                 "agent_name": agent_name,
             }
+            _persist_active_procs_locked()
         for line in proc.stdout:
             line = line.strip()
             if not line:
@@ -314,6 +325,7 @@ def _stream_claude_once(
         with _active_procs_lock:
             _active_procs.pop(reply_message_id, None)
             _active_contexts.pop(reply_message_id, None)
+            _persist_active_procs_locked()
         return f"(claude error: {exc})", None, None, True
 
 
@@ -405,6 +417,7 @@ def _stream_codex_once(
                 "topic_id": topic_id,
                 "agent_name": agent_name,
             }
+            _persist_active_procs_locked()
         for line in proc.stdout:
             line = line.strip()
             if not line:
@@ -500,6 +513,7 @@ def _stream_codex_once(
         with _active_procs_lock:
             _active_procs.pop(reply_message_id, None)
             _active_contexts.pop(reply_message_id, None)
+            _persist_active_procs_locked()
         try:
             Path(output_file).unlink()
         except Exception:
@@ -640,6 +654,7 @@ def _process_prompt(
         with _active_procs_lock:
             _active_procs.pop(reply_message_id, None)
             _active_contexts.pop(reply_message_id, None)
+            _persist_active_procs_locked()
 
     client.publish(_status_topic(workspace_id, topic_id), json.dumps({"state": "idle"}), qos=0)
 
@@ -656,10 +671,88 @@ def _on_connect(client: mqtt.Client, userdata, flags, reason_code, properties) -
     client.subscribe(cancel_sub, qos=1)
     client.subscribe(ping_sub, qos=0)
     LOGGER.info("agent.mqtt_connected subscribed=%s,%s,%s", prompt_sub, cancel_sub, ping_sub)
+    # Emit `(message interrupted)` for any subprocess that didn't survive the
+    # previous container life. No-op on the first start after a clean shutdown
+    # (the file was unlinked by `_publish_interrupted_all`).
+    _publish_inherited_interrupts(client)
 
 
 def _on_disconnect(client, userdata, disconnect_flags, reason_code, properties) -> None:  # type: ignore[type-arg]
     LOGGER.warning("agent.mqtt_disconnected reason=%s", reason_code)
+
+
+def _persist_active_procs_locked() -> None:
+    """Atomically write `_active_contexts` to disk. Caller MUST hold
+    `_active_procs_lock` so the snapshot matches the in-memory state.
+
+    Failure to persist is non-fatal (logged) — the worst case is a missed
+    `agent-killed` interrupt event after a SIGKILL, which is no worse than
+    today's behavior."""
+    try:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        snapshot = json.dumps(_active_contexts)
+        tmp = _ACTIVE_PROCS_PATH.with_suffix(".json.tmp")
+        tmp.write_text(snapshot)
+        os.replace(tmp, _ACTIVE_PROCS_PATH)
+    except Exception:
+        LOGGER.exception("agent.persist_active_procs_failed")
+
+
+def _publish_inherited_interrupts(client: mqtt.Client) -> None:
+    """Emit `(message interrupted)` with reason `agent-killed` for any
+    in-flight subprocesses that didn't survive the previous container life.
+
+    The typical trigger is the container being SIGKILL'd while a subprocess
+    was running — Python is just gone, so the SIGTERM handler never ran and
+    master can only see `alive=False` on its next ping. Without this replay,
+    master labels such messages `ping-timeout`, which is misleading.
+
+    Fires at most once per agent process (guarded by `_inherited_already_published`)
+    even if MQTT reconnects multiple times."""
+    global _inherited_already_published
+    if _inherited_already_published:
+        return
+    _inherited_already_published = True
+    try:
+        if not _ACTIVE_PROCS_PATH.exists():
+            return
+        try:
+            data = json.loads(_ACTIVE_PROCS_PATH.read_text())
+        except Exception:
+            LOGGER.exception("agent.startup_inherited_parse_failed path=%s", _ACTIVE_PROCS_PATH)
+            _ACTIVE_PROCS_PATH.unlink(missing_ok=True)
+            return
+        if not isinstance(data, dict) or not data:
+            _ACTIVE_PROCS_PATH.unlink(missing_ok=True)
+            return
+        LOGGER.warning(
+            "agent.startup_inherited_active count=%d message_ids=%s",
+            len(data), list(data.keys()),
+        )
+        for message_id, ctx in data.items():
+            if not isinstance(ctx, dict) or "workspace_id" not in ctx or "topic_id" not in ctx:
+                LOGGER.warning("agent.startup_inherited_skip_bad_entry message_id=%s ctx=%r", message_id, ctx)
+                continue
+            try:
+                client.publish(
+                    _response_topic(ctx["workspace_id"], ctx["topic_id"]),
+                    json.dumps({
+                        "message_id": message_id,
+                        "agent_name": ctx.get("agent_name"),
+                        "reply_to": None,
+                        "last_response": "(message interrupted)",
+                        "interrupt_reason": "agent-killed",
+                        "transcript": None,
+                        "session_id": None,
+                    }),
+                    qos=1,
+                )
+                LOGGER.info("agent.startup_interrupt_published message_id=%s", message_id)
+            except Exception:
+                LOGGER.exception("agent.startup_interrupt_publish_failed message_id=%s", message_id)
+        _ACTIVE_PROCS_PATH.unlink(missing_ok=True)
+    except Exception:
+        LOGGER.exception("agent.startup_inherited_unexpected")
 
 
 def _publish_interrupted_all(client: mqtt.Client) -> None:
@@ -688,6 +781,12 @@ def _publish_interrupted_all(client: mqtt.Client) -> None:
             LOGGER.info("agent.sigterm_abort message_id=%s", message_id)
         except Exception:
             LOGGER.exception("agent.sigterm_abort_failed message_id=%s", message_id)
+    # Clear the persisted snapshot so the restart doesn't double-publish with
+    # interrupt_reason=agent-killed for the same messages we just handled.
+    try:
+        _ACTIVE_PROCS_PATH.unlink(missing_ok=True)
+    except Exception:
+        LOGGER.exception("agent.persist_active_procs_clear_failed")
 
 
 def _on_message(client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -601,6 +601,7 @@ def _publish_interrupted_all(client: mqtt.Client) -> None:
                     "agent_name": ctx["agent_name"],
                     "reply_to": None,
                     "last_response": "(message interrupted)",
+                    "interrupt_reason": "agent-shutdown",
                     "transcript": None,
                     "session_id": None,
                 }),

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -191,6 +191,7 @@ _MIGRATIONS = [
     "ALTER TABLE topics ADD COLUMN veto_status TEXT",
     "ALTER TABLE topics ADD COLUMN veto_reason TEXT",
     "ALTER TABLE topics ADD COLUMN current_staff_name TEXT",
+    "ALTER TABLE messages ADD COLUMN interrupt_reason TEXT",
 ]
 
 

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -155,16 +155,22 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
         except Exception:
             LOGGER.exception("master.stale_stream_container_check_failed message_id=%s", message_id)
 
+        interrupt_reason: str | None = None
         if container_running:
             if mqtt_client is not None and ws_row:
                 workspace_id = ws_row["workspace_id"]
                 alive = _ping_for_alive(mqtt_client, app_state, workspace_id, topic_id, message_id)
                 is_stale = not alive
+                if is_stale:
+                    interrupt_reason = "ping-timeout"
             else:
                 # No mqtt client available — fall back to age timeout
                 is_stale = chunk_age > _STALE_STREAM_TIMEOUT_SECONDS
+                if is_stale:
+                    interrupt_reason = "ping-timeout"
         else:
             is_stale = True  # container not running → definitely stale
+            interrupt_reason = "container-gone"
 
         if not is_stale:
             continue
@@ -196,9 +202,9 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
                 with conn:
                     conn.execute(
                         "INSERT OR IGNORE INTO messages"
-                        " (id, topic_id, sender, agent_name, text, transcript, created_at)"
-                        " VALUES (?, ?, 'agent', ?, ?, ?, ?)",
-                        (message_id, topic_id, agent_name, "(message interrupted)", transcript_json, now_str),
+                        " (id, topic_id, sender, agent_name, text, transcript, interrupt_reason, created_at)"
+                        " VALUES (?, ?, 'agent', ?, ?, ?, ?, ?)",
+                        (message_id, topic_id, agent_name, "(message interrupted)", transcript_json, interrupt_reason, now_str),
                     )
                     conn.execute("DELETE FROM chunks WHERE message_id = ?", (message_id,))
             finally:
@@ -217,6 +223,7 @@ def _close_stale_streams(db_path: str, settings, app_state=None) -> None:
                     "sender": "agent",
                     "agent_name": agent_name,
                     "last_response": "(message interrupted)",
+                    "interrupt_reason": interrupt_reason,
                     "transcript": transcript_json,
                 },
                 loop,

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -55,6 +55,7 @@ class MessageOut(BaseModel):
     text: str
     transcript: str | None
     usage_json: str | None = None
+    interrupt_reason: str | None = None
     created_at: str
     attachments: list[AttachmentMeta] = []
 
@@ -238,7 +239,7 @@ def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[Me
         ).fetchone() is None:
             raise HTTPException(404, "topic not found")
         rows = conn.execute(
-            "SELECT id, sender, agent_name, text, transcript, usage_json, created_at FROM messages"
+            "SELECT id, sender, agent_name, text, transcript, usage_json, interrupt_reason, created_at FROM messages"
             " WHERE topic_id = ? ORDER BY created_at",
             (topic_id,),
         ).fetchall()
@@ -259,6 +260,7 @@ def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[Me
                 MessageOut(
                     id=r["id"], sender=r["sender"], agent_name=r["agent_name"],
                     text=r["text"], transcript=r["transcript"], usage_json=r["usage_json"],
+                    interrupt_reason=r["interrupt_reason"],
                     created_at=r["created_at"], attachments=attachments,
                 )
             )

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -112,6 +112,7 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
             llm_session_id = payload.get("session_id")
             agent_name = payload.get("agent_name")
             message_id = payload.get("message_id") or str(uuid.uuid4())
+            interrupt_reason = payload.get("interrupt_reason")
             if transcript is None and text == "(message interrupted)":
                 chunk_rows = conn.execute(
                     "SELECT event FROM chunks WHERE message_id = ? ORDER BY seq",
@@ -131,15 +132,15 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
                 # If the stale-stream detector beat us here with "(message interrupted)",
                 # update it with the real response instead of silently dropping it.
                 conn.execute(
-                    "UPDATE messages SET text=?, transcript=?, usage_json=?"
+                    "UPDATE messages SET text=?, transcript=?, usage_json=?, interrupt_reason=?"
                     " WHERE id=? AND text=?",
-                    (text, transcript, usage_json, message_id, "(message interrupted)"),
+                    (text, transcript, usage_json, interrupt_reason, message_id, "(message interrupted)"),
                 )
                 conn.execute(
                     "INSERT OR IGNORE INTO messages"
-                    " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, created_at)"
-                    " VALUES (?, ?, 'agent', ?, ?, ?, ?, NULL, ?)",
-                    (message_id, topic_id, agent_name, text, transcript, usage_json, _now()),
+                    " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, interrupt_reason, created_at)"
+                    " VALUES (?, ?, 'agent', ?, ?, ?, ?, NULL, ?, ?)",
+                    (message_id, topic_id, agent_name, text, transcript, usage_json, interrupt_reason, _now()),
                 )
                 conn.execute(
                     "DELETE FROM chunks WHERE message_id = ?", (message_id,)

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -128,6 +128,13 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
                         transcript = json.dumps(events)
             usage_json = _extract_usage(transcript)
             with conn:
+                # If the stale-stream detector beat us here with "(message interrupted)",
+                # update it with the real response instead of silently dropping it.
+                conn.execute(
+                    "UPDATE messages SET text=?, transcript=?, usage_json=?"
+                    " WHERE id=? AND text=?",
+                    (text, transcript, usage_json, message_id, "(message interrupted)"),
+                )
                 conn.execute(
                     "INSERT OR IGNORE INTO messages"
                     " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, created_at)"

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -598,8 +598,9 @@ def test_pong_alive_false_when_proc_not_found():
     assert payload["alive"] is False
 
 
-def test_pong_alive_false_when_proc_exited():
-    """Ping for a message whose process has already exited → pong with alive=False."""
+def test_pong_alive_true_when_proc_exited_but_still_registered():
+    """Ping for a message whose process exited but is still in _active_procs (response
+    not yet published) → pong with alive=True to prevent premature stream interruption."""
     client = MagicMock()
     userdata = {"workspace_id": "ws1", "repo_dir": ""}
 
@@ -614,7 +615,9 @@ def test_pong_alive_false_when_proc_exited():
     pong_call = next((c for c in client.publish.call_args_list if "pong" in c.args[0]), None)
     assert pong_call is not None
     payload = json.loads(pong_call.args[1])
-    assert payload["alive"] is False
+    # Proc exited but still registered: response publish is in flight.
+    # alive=True prevents the stale-stream detector from inserting "(message interrupted)".
+    assert payload["alive"] is True
 
 
 def test_publish_interrupted_all():

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -648,3 +648,91 @@ def test_publish_interrupted_all():
     assert payload["message_id"] == "msg-abc"
     assert payload["last_response"] == "(message interrupted)"
     assert payload["agent_name"] == "claude"
+
+
+# ---------------------------------------------------------------------------
+# SIGKILL-survivor path: persist + replay inherited interrupts on startup.
+# ---------------------------------------------------------------------------
+
+
+def test_persist_active_procs_writes_atomic_snapshot(tmp_path):
+    """_persist_active_procs_locked dumps _active_contexts to disk atomically."""
+    state_path = tmp_path / "active_procs.json"
+    contexts = {
+        "msg-1": {"workspace_id": "ws1", "topic_id": "t1", "agent_name": "codex"},
+        "msg-2": {"workspace_id": "ws1", "topic_id": "t2", "agent_name": "claude"},
+    }
+    with patch.object(mqtt_loop_module, "_STATE_DIR", tmp_path), \
+         patch.object(mqtt_loop_module, "_ACTIVE_PROCS_PATH", state_path), \
+         patch.dict(mqtt_loop_module._active_contexts, contexts, clear=True):
+        mqtt_loop_module._persist_active_procs_locked()
+    assert state_path.exists()
+    written = json.loads(state_path.read_text())
+    assert written == contexts
+
+
+def test_publish_inherited_interrupts_replays_each_leftover(tmp_path):
+    """On startup, a non-empty active_procs.json triggers `(message interrupted)`
+    publishes with interrupt_reason=agent-killed for every leftover entry, and
+    the file is then deleted so subsequent reconnects don't re-publish."""
+    state_path = tmp_path / "active_procs.json"
+    state_path.write_text(json.dumps({
+        "msg-killed-1": {"workspace_id": "wsX", "topic_id": "tA", "agent_name": "codex"},
+        "msg-killed-2": {"workspace_id": "wsX", "topic_id": "tB", "agent_name": "claude"},
+    }))
+    client = MagicMock()
+    with patch.object(mqtt_loop_module, "_ACTIVE_PROCS_PATH", state_path), \
+         patch.object(mqtt_loop_module, "_inherited_already_published", False):
+        mqtt_loop_module._publish_inherited_interrupts(client)
+    response_calls = [c for c in client.publish.call_args_list if "response" in c.args[0]]
+    assert len(response_calls) == 2
+    payloads = [json.loads(c.args[1]) for c in response_calls]
+    ids = {p["message_id"] for p in payloads}
+    assert ids == {"msg-killed-1", "msg-killed-2"}
+    for p in payloads:
+        assert p["last_response"] == "(message interrupted)"
+        assert p["interrupt_reason"] == "agent-killed"
+        assert p["transcript"] is None
+    # File must be cleared so future _on_connect calls (reconnects) don't replay.
+    assert not state_path.exists()
+
+
+def test_publish_inherited_interrupts_is_idempotent(tmp_path):
+    """Multiple invocations (e.g. MQTT reconnect during the same process)
+    must not re-publish."""
+    state_path = tmp_path / "active_procs.json"
+    state_path.write_text(json.dumps({
+        "msg-killed-1": {"workspace_id": "wsX", "topic_id": "tA", "agent_name": "codex"},
+    }))
+    client = MagicMock()
+    with patch.object(mqtt_loop_module, "_ACTIVE_PROCS_PATH", state_path), \
+         patch.object(mqtt_loop_module, "_inherited_already_published", False):
+        mqtt_loop_module._publish_inherited_interrupts(client)
+        first_call_count = client.publish.call_count
+        mqtt_loop_module._publish_inherited_interrupts(client)
+        assert client.publish.call_count == first_call_count
+
+
+def test_publish_inherited_interrupts_noop_when_file_missing(tmp_path):
+    """Fresh startup (no leftover file) is a no-op, no publish."""
+    state_path = tmp_path / "active_procs.json"
+    client = MagicMock()
+    with patch.object(mqtt_loop_module, "_ACTIVE_PROCS_PATH", state_path), \
+         patch.object(mqtt_loop_module, "_inherited_already_published", False):
+        mqtt_loop_module._publish_inherited_interrupts(client)
+    assert client.publish.call_count == 0
+
+
+def test_publish_interrupted_all_clears_persisted_state(tmp_path):
+    """SIGTERM handler path clears the snapshot so the post-shutdown restart
+    doesn't double-publish agent-killed for the same messages."""
+    state_path = tmp_path / "active_procs.json"
+    state_path.write_text(json.dumps({"msg-abc": {"workspace_id": "ws1", "topic_id": "t1", "agent_name": "claude"}}))
+    client = MagicMock()
+    contexts = {"msg-abc": {"workspace_id": "ws1", "topic_id": "t1", "agent_name": "claude"}}
+    with patch.object(mqtt_loop_module, "_ACTIVE_PROCS_PATH", state_path), \
+         patch.dict(mqtt_loop_module._active_procs, {"msg-abc": MagicMock()}, clear=True), \
+         patch.dict(mqtt_loop_module._active_contexts, contexts, clear=True), \
+         patch("src.agent.mqtt_loop.os.killpg"):
+        _publish_interrupted_all(client)
+    assert not state_path.exists()

--- a/tests/test_agent_streaming.py
+++ b/tests/test_agent_streaming.py
@@ -290,7 +290,7 @@ def test_stream_claude_once_detects_is_error_from_result(tmp_path):
 
 
 def test_stream_claude_once_skips_blank_and_malformed_lines(tmp_path):
-    """Blank lines and non-JSON lines are silently ignored."""
+    """Blank lines are skipped; non-JSON lines emit a parse_warning chunk."""
     text_event = _events("text")[0]
     result_event = _events("result_ok")[0]
     lines = [
@@ -313,8 +313,13 @@ def test_stream_claude_once_skips_blank_and_malformed_lines(tmp_path):
             subagent=None, model=None, system_prompt=None,
         )
 
-    # Only 2 valid events published
-    assert len(client.publish.call_args_list) == 2
+    # 2 valid events + 2 parse_warning chunks (one per malformed line)
+    assert len(client.publish.call_args_list) == 4
+    published_events = [json.loads(call.args[1])["event"] for call in client.publish.call_args_list]
+    warnings = [e for e in published_events if e.get("subtype") == "parse_warning"]
+    assert len(warnings) == 2
+    assert warnings[0]["line"] == "not-json"
+    assert warnings[1]["line"] == "{broken"
     assert is_error is False
 
 


### PR DESCRIPTION
## Summary

- **Bug fix (closes #221):** Eliminated the race condition where `_close_stale_streams()` (runs every 60s) could insert `(message interrupted)` after a codex/claude subprocess exited but *before* its MQTT response arrived at master. Fix: keep the proc in `_active_procs` until after the response is published, so the ping correctly reports `alive=True` during the delivery window. Added a defense-in-depth UPDATE in `_save_agent_response` to overwrite any stale `(message interrupted)` row if the real response arrives late.
- **New DB column:** `messages.interrupt_reason TEXT` (migration in `db.py`) records why a message was interrupted: `agent-shutdown`, `container-gone`, or `ping-timeout`.
- **Differentiated interrupt display:** The UI badge now shows the specific cause — *"interrupted: agent restarted"*, *"interrupted: container gone"*, *"interrupted: no response"* — instead of a generic *"interrupted"*.
- **Agent MQTT:** `_publish_interrupted_all` (SIGTERM handler) sets `interrupt_reason=agent-shutdown`; `_close_stale_streams` sets `container-gone` or `ping-timeout` depending on whether the container is still running.

## Test plan

- [ ] 610/610 unit tests pass (`pytest` — verified in CI)
- [ ] Send a message, kill the agent container mid-response → bubble shows **"interrupted: container gone"**
- [ ] Send a message, let the 60s stale-stream timeout fire while agent is running but unresponsive to ping → bubble shows **"interrupted: no response"**
- [ ] Restart the agent container with SIGTERM while a response is in-flight → bubble shows **"interrupted: agent restarted"**
- [ ] Normal message round-trip completes without spurious interruption (regression check for #221)
- [ ] Old interrupted messages without a reason (null `interrupt_reason`) still display the plain **"interrupted"** badge

🤖 Generated with repository automation