### PR TITLE
fix(agent): add session support for codex adapter

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -703,10 +703,17 @@ function buildDispatchCommand(transcript) {
     const p = JSON.parse(transcript)
     if (!p.adapter) return ''
     if (p.adapter === 'codex') {
+      const useEphemeral = (p.session_scope || 'topic') === 'none'
+      const resuming = !useEphemeral && p.session_id && !p.is_new_session
       const parts = ['codex', 'exec', '--json',
-        '--dangerously-bypass-approvals-and-sandbox', '-s', 'danger-full-access', '--ephemeral']
+        '--dangerously-bypass-approvals-and-sandbox', '-s', 'danger-full-access']
+      if (useEphemeral) parts.push('--ephemeral')
       if (p.model) parts.push('-m', JSON.stringify(p.model))
-      parts.push(JSON.stringify(p.text))
+      if (resuming) {
+        parts.push('resume', p.session_id, '-')
+      } else {
+        parts.push(JSON.stringify(p.text))
+      }
       return parts.join(' \\\n  ')
     }
     const parts = ['claude', '--print', '--verbose', '--output-format', 'stream-json', '--dangerously-skip-permissions']

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -392,29 +392,37 @@ def _stream_codex_once(
     worktree: str,
     text: str,
     model: str | None,
+    session_id: str | None = None,
+    is_new_session: bool = False,
+    session_scope: str = "topic",
     seq_start: int = 0,
-) -> tuple[str, str | None, bool]:
+) -> tuple[str, str | None, str | None, bool]:
     """Stream Codex stdout line by line, publishing each event as an MQTT chunk.
 
-    Returns (output, transcript, is_error).
+    Returns (output, new_session_id, transcript, is_error).
     """
     fd, output_file = tempfile.mkstemp(suffix=".txt")
     os.close(fd)
+    use_session = bool(session_id) and session_scope != "none"
     cmd = [
         "codex", "exec",
         "--json",
         "--dangerously-bypass-approvals-and-sandbox",
         "-s", "danger-full-access",
-        "--ephemeral",
-        "-o", output_file,
     ]
+    if not use_session:
+        cmd.append("--ephemeral")
     if model:
         cmd += ["-m", model]
+    cmd += ["-o", output_file]
+    if use_session and not is_new_session:
+        cmd += ["resume", session_id, "-"]
     chunk_topic = _chunk_topic(workspace_id, topic_id)
     events: list[dict] = []
     is_error = False
     seq = seq_start
     fallback_outputs: list[str] = []
+    new_session_id: str | None = None
     proc = None
     try:
         proc = subprocess.Popen(
@@ -434,34 +442,43 @@ def _stream_codex_once(
                 "agent_name": agent_name,
             }
             _persist_active_procs_locked()
-        for line in proc.stdout:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                event = {"type": "output", "content": line}
-            events.append(event)
-            client.publish(chunk_topic, json.dumps({
-                "message_id": reply_message_id,
-                "agent_name": agent_name,
-                "seq": seq,
-                "event": event,
-            }), qos=0)
-            LOGGER.debug("agent.codex_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
-            seq += 1
-            ev_type = event.get("type", "")
-            if ev_type == "turn.completed":
-                final = event.get("output_text") or event.get("last_message")
-                if final:
-                    fallback_outputs.append(str(final))
-            elif ev_type == "turn.failed":
-                is_error = True
-                err_msg = (event.get("error") or {}).get("message", "")
-                if err_msg:
-                    fallback_outputs.append(f"(codex error: {err_msg})")
-        proc.wait()
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    event = {"type": "output", "content": line}
+                events.append(event)
+                client.publish(chunk_topic, json.dumps({
+                    "message_id": reply_message_id,
+                    "agent_name": agent_name,
+                    "seq": seq,
+                    "event": event,
+                }), qos=0)
+                LOGGER.debug("agent.codex_chunk topic_id=%s seq=%d type=%s", topic_id, seq, event.get("type"))
+                seq += 1
+                ev_type = event.get("type", "")
+                if ev_type == "thread.started":
+                    sid = event.get("session_id")
+                    if sid and use_session:
+                        new_session_id = sid
+                elif ev_type == "turn.completed":
+                    final = event.get("output_text") or event.get("last_message")
+                    if final:
+                        fallback_outputs.append(str(final))
+                elif ev_type == "turn.failed":
+                    is_error = True
+                    err_msg = (event.get("error") or {}).get("message", "")
+                    if err_msg:
+                        fallback_outputs.append(f"(codex error: {err_msg})")
+            proc.wait()
+        finally:
+            with _active_procs_lock:
+                _active_procs.pop(reply_message_id, None)
+                _active_contexts.pop(reply_message_id, None)
         rc = proc.returncode
         if rc and rc != 0 and not is_error:
             is_error = True
@@ -496,7 +513,7 @@ def _stream_codex_once(
             topic_id, reply_message_id, proc.pid, rc,
             seq - seq_start, len(output),
         )
-        return output, transcript, is_error
+        return output, new_session_id, transcript, is_error
     except FileNotFoundError:
         LOGGER.error(
             "agent.codex_cli_missing topic_id=%s message_id=%s cmd=%s",
@@ -506,7 +523,7 @@ def _stream_codex_once(
             Path(output_file).unlink()
         except Exception:
             pass
-        return "(codex CLI not found in agent container)", None, True
+        return "(codex CLI not found in agent container)", None, None, True
     except Exception as exc:
         # See _stream_claude_once for rationale — same alive=False-without-done
         # pattern. Capture postmortem before kill_proc_tree.
@@ -534,7 +551,7 @@ def _stream_codex_once(
             Path(output_file).unlink()
         except Exception:
             pass
-        return f"(codex error: {exc})", None, True
+        return f"(codex error: {exc})", None, None, True
 
 
 def _run_codex(
@@ -546,12 +563,15 @@ def _run_codex(
     worktree: str,
     text: str,
     model: str | None,
+    session_id: str | None = None,
+    is_new_session: bool = False,
+    session_scope: str = "topic",
 ) -> tuple[str, str | None, str | None]:
-    output, transcript, _ = _stream_codex_once(
+    output, new_session_id, transcript, _ = _stream_codex_once(
         client, workspace_id, topic_id, reply_message_id, agent_name,
-        worktree, text, model,
+        worktree, text, model, session_id, is_new_session, session_scope,
     )
-    return output, None, transcript
+    return output, new_session_id, transcript
 
 
 def _process_prompt(
@@ -613,7 +633,7 @@ def _process_prompt(
     if adapter == "codex":
         response_text, new_session_id, transcript = _run_codex(
             client, workspace_id, topic_id, reply_message_id, agent_name,
-            cwd, text, model,
+            cwd, text, model, session_id, is_new_session, session_scope,
         )
     else:
         # Claude sessions are scoped to the CWD (project directory).

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -404,19 +404,19 @@ def _stream_codex_once(
     """
     fd, output_file = tempfile.mkstemp(suffix=".txt")
     os.close(fd)
-    use_session = bool(session_id) and session_scope != "none"
+    use_ephemeral = session_scope == "none"
     cmd = [
         "codex", "exec",
         "--json",
         "--dangerously-bypass-approvals-and-sandbox",
         "-s", "danger-full-access",
     ]
-    if not use_session:
+    if use_ephemeral:
         cmd.append("--ephemeral")
     if model:
         cmd += ["-m", model]
     cmd += ["-o", output_file]
-    if use_session and not is_new_session:
+    if not use_ephemeral and session_id and not is_new_session:
         cmd += ["resume", session_id, "-"]
     chunk_topic = _chunk_topic(workspace_id, topic_id)
     events: list[dict] = []
@@ -464,7 +464,7 @@ def _stream_codex_once(
                 ev_type = event.get("type", "")
                 if ev_type == "thread.started":
                     sid = event.get("session_id")
-                    if sid and use_session:
+                    if sid and not use_ephemeral:
                         new_session_id = sid
                 elif ev_type == "turn.completed":
                     final = event.get("output_text") or event.get("last_message")

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -158,6 +158,7 @@ def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str, repo_ref: s
 
 
 _SESSION_NOT_FOUND = "No conversation found with session ID"
+_CODEX_SESSION_NOT_FOUND = "no rollout found for thread id"
 
 _VERDICT_RE = __import__("re").compile(r'\{[^{}]+\}')
 
@@ -567,10 +568,26 @@ def _run_codex(
     is_new_session: bool = False,
     session_scope: str = "topic",
 ) -> tuple[str, str | None, str | None]:
-    output, new_session_id, transcript, _ = _stream_codex_once(
+    output, new_session_id, transcript, is_error = _stream_codex_once(
         client, workspace_id, topic_id, reply_message_id, agent_name,
         worktree, text, model, session_id, is_new_session, session_scope,
     )
+    if not is_new_session and session_id and is_error and _CODEX_SESSION_NOT_FOUND in (output or ""):
+        LOGGER.warning("agent.codex_session_expired sid=%s retrying_as_new", session_id)
+        first_event_count = len(json.loads(transcript)) if transcript else 0
+        seq = first_event_count
+        client.publish(_chunk_topic(workspace_id, topic_id), json.dumps({
+            "message_id": reply_message_id,
+            "agent_name": agent_name,
+            "seq": seq,
+            "event": {"type": "system", "subtype": "retry"},
+        }), qos=0)
+        seq += 1
+        output, new_session_id, transcript, _ = _stream_codex_once(
+            client, workspace_id, topic_id, reply_message_id, agent_name,
+            worktree, text, model, session_id, True, session_scope,
+            seq_start=seq,
+        )
     return output, new_session_id, transcript
 
 

--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -463,7 +463,7 @@ def _stream_codex_once(
                 seq += 1
                 ev_type = event.get("type", "")
                 if ev_type == "thread.started":
-                    sid = event.get("session_id")
+                    sid = event.get("thread_id") or event.get("session_id")
                     if sid and not use_ephemeral:
                         new_session_id = sid
                 elif ev_type == "turn.completed":

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -467,6 +467,10 @@ def init_db(db_path: str) -> None:
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_staffs_scope_name"
             " ON staffs(scope_type, COALESCE(scope_id, ''), name)"
         )
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_topic_agent"
+            " ON sessions(topic_id, agent_name)"
+        )
         conn.commit()
         for migration in _MIGRATIONS:
             try:

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -112,13 +112,33 @@ async def dispatch_to_staff(
 
         # For adapters like codex whose LLM session id differs from the internal
         # session_uuid, fetch the llm_session_id persisted by the agent response handler.
+        # For workspace/global scope the session is shared across topics, so we search
+        # the broadest matching set and take the most recently updated non-null id.
         llm_session_id: str | None = None
         if not is_new_session and session_uuid:
-            row = conn.execute(
-                "SELECT llm_session_id FROM sessions"
-                " WHERE topic_id = ? AND agent_name = ?",
-                (topic_id, staff["name"]),
-            ).fetchone()
+            scope = staff["session_scope"] or "topic"
+            if scope == "workspace":
+                row = conn.execute(
+                    "SELECT s.llm_session_id FROM sessions s"
+                    " JOIN topics t ON s.topic_id = t.id"
+                    " WHERE t.workspace_id = ? AND s.agent_name = ?"
+                    " AND s.llm_session_id IS NOT NULL"
+                    " ORDER BY s.updated_at DESC LIMIT 1",
+                    (workspace_id, staff["name"]),
+                ).fetchone()
+            elif scope == "global":
+                row = conn.execute(
+                    "SELECT llm_session_id FROM sessions"
+                    " WHERE agent_name = ? AND llm_session_id IS NOT NULL"
+                    " ORDER BY updated_at DESC LIMIT 1",
+                    (staff["name"],),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT llm_session_id FROM sessions"
+                    " WHERE topic_id = ? AND agent_name = ?",
+                    (topic_id, staff["name"]),
+                ).fetchone()
             if row:
                 llm_session_id = row["llm_session_id"]
 

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -101,6 +101,18 @@ async def dispatch_to_staff(
                 conn, ss_scope_type, ss_scope_id, staff["name"]
             )
 
+        # For adapters like codex whose LLM session id differs from the internal
+        # session_uuid, fetch the llm_session_id persisted by the agent response handler.
+        llm_session_id: str | None = None
+        if not is_new_session and session_uuid:
+            row = conn.execute(
+                "SELECT llm_session_id FROM sessions"
+                " WHERE topic_id = ? AND agent_name = ?",
+                (topic_id, staff["name"]),
+            ).fetchone()
+            if row:
+                llm_session_id = row["llm_session_id"]
+
         message_id = str(uuid.uuid4())
         now = _now()
         conn.execute(
@@ -135,7 +147,7 @@ async def dispatch_to_staff(
         "branch": topic["branch_name"],
         "repo_ref": topic["repo_ref"] or "",
         "base_sha": topic["base_sha"] or "",
-        "session_id": session_uuid,
+        "session_id": llm_session_id or session_uuid,
         "is_new_session": is_new_session,
         "session_scope": staff["session_scope"] or "topic",
         "model": staff["model"],

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -101,6 +101,15 @@ async def dispatch_to_staff(
                 conn, ss_scope_type, ss_scope_id, staff["name"]
             )
 
+        # Ensure a sessions row exists for this topic+agent so the agent response
+        # handler's UPDATE can store llm_session_id. INSERT OR IGNORE is a no-op on
+        # subsequent turns when the row already exists.
+        conn.execute(
+            "INSERT OR IGNORE INTO sessions (id, topic_id, agent_name, adapter, llm_session_id, updated_at)"
+            " VALUES (?, ?, ?, ?, NULL, ?)",
+            (str(uuid.uuid4()), topic_id, staff["name"], staff["adapter"], _now()),
+        )
+
         # For adapters like codex whose LLM session id differs from the internal
         # session_uuid, fetch the llm_session_id persisted by the agent response handler.
         llm_session_id: str | None = None

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -315,7 +315,32 @@ def test_run_codex_correct_command_flags(tmp_path):
     assert "--json" in cmd
     assert "--dangerously-bypass-approvals-and-sandbox" in cmd
     assert "-s" in cmd and "danger-full-access" in cmd
-    assert "--ephemeral" in cmd
+    # default scope is "topic" → persistent session, no --ephemeral
+    assert "--ephemeral" not in cmd
+
+
+def test_run_codex_first_turn_captures_session_id(tmp_path):
+    """First turn has no session_id; codex should run without --ephemeral and
+    the session_id from thread.started must be returned so master can persist it."""
+    events = [
+        {"type": "thread.started", "session_id": "first-turn-sid"},
+        {"type": "turn.completed", "output_text": "hello"},
+    ]
+    client = MagicMock()
+    output_file = tmp_path / "out.txt"
+    output_file.write_text("hello")
+    with patch("src.agent.mqtt_loop.tempfile.mkstemp", return_value=(0, str(output_file))):
+        with patch("src.agent.mqtt_loop.os.close"):
+            with patch("src.agent.mqtt_loop.subprocess.Popen", return_value=_make_popen_mock(events)) as mock_popen:
+                text, session, transcript = _run_codex(
+                    client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "hi", None,
+                    session_id=None, is_new_session=True, session_scope="topic",
+                )
+    cmd = mock_popen.call_args.args[0]
+    assert "--ephemeral" not in cmd
+    assert "resume" not in cmd
+    assert session == "first-turn-sid"
+    assert text == "hello"
 
 
 def test_run_codex_ephemeral_when_scope_none(tmp_path):

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -377,6 +377,34 @@ def test_run_codex_resumes_session(tmp_path):
     assert text == "continued"
 
 
+def test_run_codex_retries_as_new_on_session_not_found(tmp_path):
+    """When resume fails with 'no rollout found', _run_codex retries as a new session."""
+    error_output = "no rollout found for thread id abc-123"
+    retry_output = "hello from new session"
+    client = MagicMock()
+
+    call_count = 0
+
+    def fake_stream_codex_once(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return error_output, None, None, True
+        return retry_output, "new-sid", json.dumps([]), False
+
+    with patch("src.agent.mqtt_loop._stream_codex_once", side_effect=fake_stream_codex_once):
+        text, sid, transcript = _run_codex(
+            client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "hello", None,
+            session_id="old-sid", is_new_session=False, session_scope="topic",
+        )
+
+    assert call_count == 2
+    assert text == retry_output
+    assert sid == "new-sid"
+    published = [json.loads(c.args[1]) for c in client.publish.call_args_list]
+    assert any(p.get("event", {}).get("subtype") == "retry" for p in published)
+
+
 def test_run_codex_turn_failed_is_error(tmp_path):
     events = [{"type": "turn.failed", "error": {"message": "auth failed"}}]
     client = MagicMock()

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -245,7 +245,7 @@ def test_run_codex_returns_stdout(tmp_path):
             with patch("src.agent.mqtt_loop.subprocess.Popen", return_value=_make_popen_mock(events)):
                 text, session, transcript = _run_codex(client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "do it", None)
     assert text == "codex output"
-    assert session is None  # no session_id given, ephemeral mode
+    assert session == "abc"  # thread_id captured from thread.started even on first turn
     assert transcript is not None
 
 
@@ -321,9 +321,9 @@ def test_run_codex_correct_command_flags(tmp_path):
 
 def test_run_codex_first_turn_captures_session_id(tmp_path):
     """First turn has no session_id; codex should run without --ephemeral and
-    the session_id from thread.started must be returned so master can persist it."""
+    the thread_id from thread.started must be returned so master can persist it."""
     events = [
-        {"type": "thread.started", "session_id": "first-turn-sid"},
+        {"type": "thread.started", "thread_id": "first-turn-sid"},
         {"type": "turn.completed", "output_text": "hello"},
     ]
     client = MagicMock()
@@ -360,7 +360,7 @@ def test_run_codex_ephemeral_when_scope_none(tmp_path):
 
 def test_run_codex_new_session_no_ephemeral(tmp_path):
     events = [
-        {"type": "thread.started", "session_id": "codex-sess-1"},
+        {"type": "thread.started", "thread_id": "codex-sess-1"},
         {"type": "turn.completed", "output_text": "ok"},
     ]
     client = MagicMock()
@@ -381,7 +381,7 @@ def test_run_codex_new_session_no_ephemeral(tmp_path):
 
 def test_run_codex_resumes_session(tmp_path):
     events = [
-        {"type": "thread.started", "session_id": "codex-sess-1"},
+        {"type": "thread.started", "thread_id": "codex-sess-1"},
         {"type": "turn.completed", "output_text": "continued"},
     ]
     client = MagicMock()

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -245,7 +245,7 @@ def test_run_codex_returns_stdout(tmp_path):
             with patch("src.agent.mqtt_loop.subprocess.Popen", return_value=_make_popen_mock(events)):
                 text, session, transcript = _run_codex(client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "do it", None)
     assert text == "codex output"
-    assert session is None
+    assert session is None  # no session_id given, ephemeral mode
     assert transcript is not None
 
 
@@ -316,6 +316,65 @@ def test_run_codex_correct_command_flags(tmp_path):
     assert "--dangerously-bypass-approvals-and-sandbox" in cmd
     assert "-s" in cmd and "danger-full-access" in cmd
     assert "--ephemeral" in cmd
+
+
+def test_run_codex_ephemeral_when_scope_none(tmp_path):
+    events = [{"type": "turn.completed", "output_text": "ok"}]
+    client = MagicMock()
+    output_file = tmp_path / "out.txt"
+    output_file.write_text("ok")
+    with patch("src.agent.mqtt_loop.tempfile.mkstemp", return_value=(0, str(output_file))):
+        with patch("src.agent.mqtt_loop.os.close"):
+            with patch("src.agent.mqtt_loop.subprocess.Popen", return_value=_make_popen_mock(events)) as mock_popen:
+                _run_codex(client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "hi", None,
+                           session_id="some-uuid", is_new_session=True, session_scope="none")
+    cmd = mock_popen.call_args.args[0]
+    assert "--ephemeral" in cmd
+    assert "resume" not in cmd
+
+
+def test_run_codex_new_session_no_ephemeral(tmp_path):
+    events = [
+        {"type": "thread.started", "session_id": "codex-sess-1"},
+        {"type": "turn.completed", "output_text": "ok"},
+    ]
+    client = MagicMock()
+    output_file = tmp_path / "out.txt"
+    output_file.write_text("ok")
+    with patch("src.agent.mqtt_loop.tempfile.mkstemp", return_value=(0, str(output_file))):
+        with patch("src.agent.mqtt_loop.os.close"):
+            with patch("src.agent.mqtt_loop.subprocess.Popen", return_value=_make_popen_mock(events)) as mock_popen:
+                text, session, transcript = _run_codex(
+                    client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "hi", None,
+                    session_id="my-uuid", is_new_session=True, session_scope="topic",
+                )
+    cmd = mock_popen.call_args.args[0]
+    assert "--ephemeral" not in cmd
+    assert "resume" not in cmd
+    assert session == "codex-sess-1"
+
+
+def test_run_codex_resumes_session(tmp_path):
+    events = [
+        {"type": "thread.started", "session_id": "codex-sess-1"},
+        {"type": "turn.completed", "output_text": "continued"},
+    ]
+    client = MagicMock()
+    output_file = tmp_path / "out.txt"
+    output_file.write_text("continued")
+    with patch("src.agent.mqtt_loop.tempfile.mkstemp", return_value=(0, str(output_file))):
+        with patch("src.agent.mqtt_loop.os.close"):
+            with patch("src.agent.mqtt_loop.subprocess.Popen", return_value=_make_popen_mock(events)) as mock_popen:
+                text, session, transcript = _run_codex(
+                    client, "ws1", "t1", "reply-id", "codex", str(tmp_path), "follow up", None,
+                    session_id="codex-sess-1", is_new_session=False, session_scope="topic",
+                )
+    cmd = mock_popen.call_args.args[0]
+    assert "--ephemeral" not in cmd
+    assert "resume" in cmd
+    assert "codex-sess-1" in cmd
+    assert "-" in cmd  # stdin indicator
+    assert text == "continued"
 
 
 def test_run_codex_turn_failed_is_error(tmp_path):

--- a/tests/master/test_event_actions.py
+++ b/tests/master/test_event_actions.py
@@ -2613,6 +2613,128 @@ class TestSessionSharing:
         expected = _make_session_uuid("workspace", ws_id, "ws-reviewer")
         assert rows[0]["session_id"] == expected
 
+    def test_llm_session_id_stored_and_reused_topic_scope(self, tmp_path):
+        """SESS-04: llm_session_id written by _save_agent_response is passed back
+        on the next dispatch for topic-scoped sessions."""
+        import asyncio, sqlite3
+        from src.master.db import get_connection
+        from src.master.staffs import resolve_staff
+        from src.master.dispatch import dispatch_to_staff
+        from src.master.mqtt_client import _save_agent_response
+
+        db_path = str(tmp_path / "db.db")
+        _init_minimal_db(db_path)
+        ws_id, tp_id = _insert_workspace_and_topic(db_path)
+        _insert_staff(db_path, name="codex", scope_type="global", session_scope="topic")
+
+        # Patch adapter to 'codex' so sessions row is created with the right adapter.
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE staffs SET adapter='codex' WHERE name='codex'")
+        conn.commit()
+        conn.close()
+
+        app_state = _make_app_state(db_path=db_path)
+        payloads = []
+
+        async def run():
+            app_state.event_loop = asyncio.get_running_loop()
+            conn = get_connection(db_path)
+            staff = resolve_staff(conn, "codex", ws_id, tp_id)
+            conn.close()
+
+            # First dispatch — captures the payload sent to the agent.
+            msg_id = await dispatch_to_staff(
+                app_state=app_state, workspace_id=ws_id, topic_id=tp_id,
+                staff=staff, prompt_text="hello", sender="user",
+            )
+            payloads.append(dict(app_state.mqtt.publish.call_args.args[1] if False else
+                                 __import__('json').loads(app_state.mqtt.publish.call_args[0][1])))
+
+            # Simulate agent response with a real codex thread_id.
+            _save_agent_response(db_path, tp_id, {
+                "message_id": msg_id,
+                "agent_name": "codex",
+                "last_response": "hi back",
+                "session_id": "codex-thread-abc",
+            })
+
+            # Second dispatch — should carry the codex thread_id.
+            await dispatch_to_staff(
+                app_state=app_state, workspace_id=ws_id, topic_id=tp_id,
+                staff=staff, prompt_text="follow up", sender="user",
+            )
+            payloads.append(dict(__import__('json').loads(app_state.mqtt.publish.call_args[0][1])))
+
+        asyncio.run(run())
+
+        first_payload, second_payload = payloads
+        assert first_payload.get("session_id") != "codex-thread-abc"  # new session, no llm id yet
+        assert second_payload.get("session_id") == "codex-thread-abc"  # must use the stored id
+        assert second_payload.get("is_new_session") is False
+
+    def test_llm_session_id_shared_across_topics_workspace_scope(self, tmp_path):
+        """SESS-05: workspace-scoped codex session_id from topic A is reused in topic B."""
+        import asyncio, sqlite3
+        from src.master.db import get_connection
+        from src.master.staffs import resolve_staff
+        from src.master.dispatch import dispatch_to_staff
+        from src.master.mqtt_client import _save_agent_response
+
+        db_path = str(tmp_path / "db.db")
+        _init_minimal_db(db_path)
+        ws_id, tp1_id = _insert_workspace_and_topic(db_path, topic_subject="topic 1")
+
+        # Insert a second topic in the same workspace.
+        tp2_id = str(uuid.uuid4())
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "INSERT INTO topics (id, workspace_id, subject, branch_name, worktree_path, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (tp2_id, ws_id, "topic 2", "branch2", "/tmp/wt2", _NOW_UTC),
+        )
+        conn.execute("UPDATE staffs SET adapter='codex' WHERE 1")
+        conn.commit()
+        conn.close()
+        _insert_staff(db_path, name="codex-ws", scope_type="global", session_scope="workspace")
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE staffs SET adapter='codex' WHERE name='codex-ws'")
+        conn.commit()
+        conn.close()
+
+        app_state = _make_app_state(db_path=db_path)
+        payloads = []
+
+        async def run():
+            app_state.event_loop = asyncio.get_running_loop()
+            conn = get_connection(db_path)
+            staff1 = resolve_staff(conn, "codex-ws", ws_id, tp1_id)
+            staff2 = resolve_staff(conn, "codex-ws", ws_id, tp2_id)
+            conn.close()
+
+            # Dispatch to topic 1.
+            msg_id = await dispatch_to_staff(
+                app_state=app_state, workspace_id=ws_id, topic_id=tp1_id,
+                staff=staff1, prompt_text="hello from t1", sender="user",
+            )
+            # Simulate agent writing back the codex thread_id.
+            _save_agent_response(db_path, tp1_id, {
+                "message_id": msg_id, "agent_name": "codex-ws",
+                "last_response": "ok", "session_id": "ws-thread-xyz",
+            })
+
+            # Dispatch to topic 2 — should pick up ws-thread-xyz.
+            await dispatch_to_staff(
+                app_state=app_state, workspace_id=ws_id, topic_id=tp2_id,
+                staff=staff2, prompt_text="hello from t2", sender="user",
+            )
+            payloads.append(dict(__import__('json').loads(app_state.mqtt.publish.call_args[0][1])))
+
+        asyncio.run(run())
+
+        t2_payload = payloads[0]
+        assert t2_payload.get("session_id") == "ws-thread-xyz"
+        assert t2_payload.get("is_new_session") is False
+
 
 # ---------------------------------------------------------------------------
 # Area 11: Structural Input Variables


### PR DESCRIPTION
## Summary
- Pass \`session_id\`, \`is_new_session\`, and \`session_scope\` from MQTT payload through to \`_run_codex\` / \`_stream_codex_once\`
- Use \`--ephemeral\` only when \`session_scope\` is \`\"none\"\` or no session ID is present; otherwise resume with \`codex exec resume {session_id} -\`
- Capture the codex \`session_id\` from \`thread.started\` events so the master can persist it for subsequent turns
- Clean up \`_active_procs\`/\`_active_contexts\` in a \`finally\` block after the stream loop (compatible with the SIGKILL-survival persist added in master)

## Test plan
- [ ] Run unit tests: \`pytest tests/agent/test_mqtt_loop.py -v\`
- [ ] Verify new tests pass: \`test_run_codex_ephemeral_when_scope_none\`, \`test_run_codex_new_session_no_ephemeral\`, \`test_run_codex_resumes_session\`
- [ ] Send a message to a Codex agent topic; confirm \`session_id\` is returned and persisted by the master
- [ ] Send a follow-up message to the same topic; confirm \`codex exec resume <session_id>\` is invoked (check agent logs)

Closes #223

🤖 Generated with repository automation