### PR TITLE
perf(ui): skip off-screen message paint with content-visibility

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -754,7 +754,7 @@ onUnmounted(() => {
 .archived-banner { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; color: #713f12; }
 .status-bar { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; }
 .messages { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; padding: 0.5rem 0; }
-.message { display: flex; flex-direction: column; max-width: 72%; }
+.message { display: flex; flex-direction: column; max-width: 72%; content-visibility: auto; contain-intrinsic-size: auto 100px; }
 .message.agent { max-width: 88%; }
 .message.user { align-self: flex-end; align-items: flex-end; }
 .message.agent { align-self: flex-start; align-items: flex-start; }


### PR DESCRIPTION
## Summary
- Add \`content-visibility: auto\` to \`.message\` so the browser skips layout and paint for messages outside the viewport
- Add \`contain-intrinsic-size: auto 100px\` to give a stable size hint and prevent scrollbar jumping
- Addresses residual typing lag in long chats where a large unvirtualized message list causes compositor overhead even after the ChatInput isolation fix

## Test plan
- [ ] Open a topic with many messages (50+) and type in the input box — verify responsiveness is improved vs before
- [ ] Scroll through a long conversation — verify scrollbar behaviour is stable (no jumping)
- [ ] Verify messages render correctly when scrolled into view (no blank flashes)
- [ ] Verify the last message (always in view) renders immediately on arrival

🤖 Generated with repository automation