### PR TITLE
revert(ui): remove content-visibility from message items

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -754,7 +754,7 @@ onUnmounted(() => {
 .archived-banner { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; color: #713f12; }
 .status-bar { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; }
 .messages { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; padding: 0.5rem 0; }
-.message { display: flex; flex-direction: column; max-width: 72%; content-visibility: auto; contain-intrinsic-size: auto 100px; }
+.message { display: flex; flex-direction: column; max-width: 72%; }
 .message.agent { max-width: 88%; }
 .message.user { align-self: flex-end; align-items: flex-end; }
 .message.agent { align-self: flex-start; align-items: flex-start; }


### PR DESCRIPTION
## Summary
- Reverts the \`content-visibility: auto\` added in #227
- \`content-visibility: auto\` defers layout for off-screen messages, causing \`scrollHeight\` to be underestimated when a topic loads
- This broke \`scrollToBottom()\` on topic switch — the view landed at the wrong position instead of the bottom of the conversation
- The fix would require waiting for full layout before scrolling, which negates the performance benefit

## Test plan
- [ ] Switch between topics — verify each topic scrolls to the bottom on load
- [ ] Switch back to a previously visited topic — verify scroll position is at the bottom
- [ ] Verify no regression in typing responsiveness (ChatInput isolation from #220 still applies)

🤖 Generated with repository automation