### PR TITLE
fix(frontend): copy button copies full message when collapsed

### DIFF
--- a/frontend/src/components/MarkdownMessage.vue
+++ b/frontend/src/components/MarkdownMessage.vue
@@ -65,6 +65,7 @@ import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 
 const props = defineProps({
   text: { type: String, required: true },
+  fullText: { type: String, default: null },
 })
 
 const container = ref(null)
@@ -73,12 +74,13 @@ const expanded = ref(false)
 const copied = ref(false)
 
 async function copyText() {
+  const textToCopy = props.fullText ?? props.text
   try {
-    await navigator.clipboard.writeText(props.text)
+    await navigator.clipboard.writeText(textToCopy)
   } catch {
     // Fallback for non-secure (HTTP) contexts where clipboard API is unavailable
     const ta = document.createElement('textarea')
-    ta.value = props.text
+    ta.value = textToCopy
     ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none'
     document.body.appendChild(ta)
     ta.select()

--- a/frontend/src/components/MarkdownMessage.vue
+++ b/frontend/src/components/MarkdownMessage.vue
@@ -10,7 +10,7 @@
     <div v-if="expanded" class="md-overlay" @click.self="expanded = false">
       <div class="md-dialog">
         <button class="md-close" @click="expanded = false" title="Close (Esc)">✕</button>
-        <div class="md-dialog-body" ref="dialogContainer" v-html="rendered"></div>
+        <div class="md-dialog-body" ref="dialogContainer" v-html="renderedFull"></div>
       </div>
     </div>
   </Teleport>
@@ -92,6 +92,7 @@ async function copyText() {
 }
 
 const rendered = computed(() => marked.parse(props.text || ''))
+const renderedFull = computed(() => marked.parse(props.fullText || props.text || ''))
 
 async function renderMermaid(el) {
   const blocks = Array.from(

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -306,7 +306,15 @@ function toggleMsgExpand(id) {
   expandedMsgs.value = s
 }
 function collapsedPreview(text) {
-  return text.slice(0, MSG_COLLAPSED_PREVIEW) + '…'
+  const slice = text.slice(0, MSG_COLLAPSED_PREVIEW)
+  // If the slice cuts inside a code fence (odd number of ``` fence openers),
+  // trim back to just before the unclosed fence to avoid broken mermaid/code rendering.
+  const fenceCount = (slice.match(/^```/gm) || []).length
+  if (fenceCount % 2 !== 0) {
+    const cutIdx = slice.lastIndexOf('\n```')
+    return (cutIdx > 0 ? slice.slice(0, cutIdx) : slice) + '…'
+  }
+  return slice + '…'
 }
 
 function interruptLabel(m) {

--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -125,7 +125,7 @@
               <span class="tr-badge tr-badge-interrupted">{{ interruptLabel(m) }}</span>
             </div>
             <template v-else-if="isMsgCollapsible(m, msgIdx) && !isMsgExpanded(m.id)">
-              <MarkdownMessage :text="collapsedPreview(m.text)" />
+              <MarkdownMessage :text="collapsedPreview(m.text)" :fullText="m.text" />
               <button class="expand-msg-btn" @click="toggleMsgExpand(m.id)">Show more ▾</button>
             </template>
             <template v-else>
@@ -135,7 +135,7 @@
             <span v-if="m.streaming" class="cursor">▍</span>
           </template>
           <template v-else-if="isMsgCollapsible(m, msgIdx) && !isMsgExpanded(m.id)">
-            <MarkdownMessage :text="collapsedPreview(m.text)" />
+            <MarkdownMessage :text="collapsedPreview(m.text)" :fullText="m.text" />
             <button class="expand-msg-btn" @click="toggleMsgExpand(m.id)">Show more ▾</button>
           </template>
           <template v-else>


### PR DESCRIPTION
## Summary

- When a long message was folded/collapsed, the copy button was copying only the truncated 300-char preview instead of the full original message.
- The ⛶ expand dialog was also rendering truncated text when a message was collapsed.
- A message folded mid-code-fence caused a mermaid render error on the collapsed preview.

Fixes #228
Fixes #229

## Changes

- Added an optional \`fullText\` prop to \`MarkdownMessage.vue\`; \`copyText()\` uses it when present, falling back to \`text\` otherwise.
- \`TopicChat.vue\` passes \`:fullText="m.text"\` on both collapsed-preview render sites.
- Added \`renderedFull\` computed in \`MarkdownMessage.vue\` so the expand dialog renders the full original text.
- \`collapsedPreview()\` now detects unclosed code fences and trims back to before the fence opening, preventing broken mermaid/code rendering.

## Test plan

- [ ] Send a message longer than 600 characters so it collapses with "Show more"
- [ ] Click the copy button while collapsed — verify clipboard contains the full text
- [ ] Click ⛶ while collapsed — verify the dialog shows the full text
- [ ] Send a message with a mermaid diagram that gets folded mid-fence — verify no render error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)