### PR TITLE
feat: add silent setting to actions to hide messages by default

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -23,6 +23,12 @@
     <div class="status-bar" v-if="agentStatus && !isArchived">
       Agent: <em>{{ agentStatus }}</em>
     </div>
+    <div class="verbose-bar">
+      <label class="verbose-label">
+        <input type="checkbox" v-model="verbose" />
+        Show silent messages
+      </label>
+    </div>
 
     <div class="messages" ref="msgBox">
       <p v-if="loading" class="muted center">Loading…</p>
@@ -276,6 +282,7 @@ const topic = ref(null)
 const workspace = ref(null)
 const messages = ref([])
 const loading = ref(true)
+const verbose = ref(false)
 const configuredTimezone = ref(Intl.DateTimeFormat().resolvedOptions().timeZone)
 const sending = ref(false)
 const agentStatus = ref('')
@@ -527,6 +534,14 @@ function handleChunk({ message_id, agent_name, seq, event }) {
 }
 
 function finaliseMessage(data) {
+  if (data.hidden && !verbose.value) {
+    // Remove any streaming bubble that accumulated chunks for this hidden message
+    const retractIdx = messages.value.findIndex(m => m.id === data.message_id)
+    if (retractIdx >= 0) messages.value.splice(retractIdx, 1)
+    delete liveStreams.value[data.message_id]
+    seenSeq.delete(data.message_id)
+    return
+  }
   const idx = messages.value.findIndex(m => m.id === data.message_id)
   const existing = idx >= 0 ? messages.value[idx] : null
   const finalMsg = {
@@ -537,6 +552,7 @@ function finaliseMessage(data) {
     traceRows: transcriptToRows(data.transcript) || existing?.traceRows || [],
     attachments: data.attachments ?? existing?.attachments ?? [],
     interrupt_reason: data.interrupt_reason ?? existing?.interrupt_reason ?? null,
+    hidden: !!data.hidden,
     traceOpen: false, streaming: false,
     created_at: existing?.created_at || new Date().toISOString(),
   }
@@ -547,12 +563,44 @@ function finaliseMessage(data) {
   scrollToBottom()
 }
 
+async function reloadMessages() {
+  const url = verbose.value
+    ? `/api/workspaces/${wsId}/topics/${topicId}/messages?verbose=true`
+    : `/api/workspaces/${wsId}/topics/${topicId}/messages`
+  const msgsRes = await fetch(url)
+  const rawMsgs = await msgsRes.json()
+  messages.value = rawMsgs.map(m => ({
+    ...m,
+    traceRows: transcriptToRows(m.transcript),
+    traceOpen: false,
+    streaming: false,
+  }))
+  for (const [mid, live] of Object.entries(liveStreams.value)) {
+    const existing = messages.value.find(m => m.id === mid)
+    if (!existing) {
+      messages.value.push({
+        id: mid, sender: 'agent',
+        agent_name: live.agent_name,
+        text: live.text, rows: live.rows,
+        streaming: true, traceOpen: false,
+        created_at: new Date().toISOString(),
+      })
+    } else if (!existing.streaming) {
+      delete liveStreams.value[mid]
+      seenSeq.delete(mid)
+    }
+  }
+  scrollToBottom()
+}
+
 async function load() {
   loading.value = true
   try {
     const [topicRes, msgsRes, wsRes, tzRes, staffsRes] = await Promise.all([
       fetch(`/api/workspaces/${wsId}/topics/${topicId}`),
-      fetch(`/api/workspaces/${wsId}/topics/${topicId}/messages`),
+      fetch(verbose.value
+        ? `/api/workspaces/${wsId}/topics/${topicId}/messages?verbose=true`
+        : `/api/workspaces/${wsId}/topics/${topicId}/messages`),
       fetch(`/api/workspaces/${wsId}`),
       fetch('/api/config/system-settings'),
       fetch(`/api/workspaces/${wsId}/staffs`),
@@ -748,6 +796,8 @@ function extractToolResult(content) {
   return JSON.stringify(content, null, 2)
 }
 
+watch(verbose, reloadMessages)
+
 watch(
   () => [route.params.wsId, route.params.topicId],
   ([newWsId, newTopicId]) => {
@@ -781,6 +831,8 @@ onUnmounted(() => {
 .topic-settings-link:hover { color: #475569; }
 .archived-banner { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; color: #713f12; }
 .status-bar { font-size: 0.85em; background: #fef9c3; border: 1px solid #fde047; border-radius: 4px; padding: 0.25rem 0.75rem; margin-bottom: 0.5rem; }
+.verbose-bar { display: flex; justify-content: flex-end; margin-bottom: 0.25rem; }
+.verbose-label { font-size: 0.8em; color: #64748b; cursor: pointer; display: flex; align-items: center; gap: 0.3rem; user-select: none; }
 .messages { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; padding: 0.5rem 0; }
 .message { display: flex; flex-direction: column; max-width: 72%; content-visibility: auto; contain-intrinsic-size: auto 100px; }
 .message.agent { max-width: 88%; }

--- a/frontend/src/views/TopicSettings.vue
+++ b/frontend/src/views/TopicSettings.vue
@@ -74,6 +74,15 @@
             Fire this action when the event occurs
           </label>
 
+          <label>Silent</label>
+          <div>
+            <label class="checkbox-label">
+              <input type="checkbox" v-model="form.silent" />
+              Hide messages from this action in the topic chat by default
+            </label>
+            <p class="form-hint">When checked, messages are stored but hidden unless "Show silent messages" is enabled in the chat.</p>
+          </div>
+
           <label>Structured output</label>
           <div>
             <label class="checkbox-label">
@@ -164,6 +173,7 @@ const emptyForm = () => ({
   timing: 'after',
   cron_expr: '',
   enabled: true,
+  silent: true,
   structured_output: false,
 })
 const form = ref(emptyForm())
@@ -236,6 +246,7 @@ function startEdit(a) {
     timing: a.timing ?? null,
     cron_expr: a.cron_expr ?? '',
     enabled: a.enabled,
+    silent: a.silent,
     structured_output: a.structured_output,
   }
   showForm.value = true
@@ -259,6 +270,7 @@ async function saveAction() {
       staff_name: form.value.staff_name.trim(),
       prompt_template: form.value.prompt_template,
       enabled: form.value.enabled,
+      silent: form.value.silent,
       structured_output: form.value.structured_output,
     }
     if (!isEdit) {

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -230,6 +230,15 @@
             Fire this action when the event occurs
           </label>
 
+          <label>Silent</label>
+          <div>
+            <label class="checkbox-label">
+              <input type="checkbox" v-model="actionForm.silent" />
+              Hide messages from this action in the topic chat by default
+            </label>
+            <p class="form-hint">When checked, messages are stored but hidden unless "Show silent messages" is enabled in the chat.</p>
+          </div>
+
           <label>Structured output</label>
           <div>
             <label class="checkbox-label">
@@ -363,6 +372,7 @@ const emptyActionForm = () => ({
   prompt_template: '',
   timing: 'after',
   enabled: true,
+  silent: true,
   structured_output: false,
 })
 const actionForm = ref(emptyActionForm())
@@ -651,6 +661,7 @@ function startEditAction(a) {
     prompt_template: a.prompt_template,
     timing: a.timing ?? null,
     enabled: a.enabled,
+    silent: a.silent,
     structured_output: a.structured_output,
   }
   showActionForm.value = true
@@ -672,6 +683,7 @@ async function saveAction() {
       staff_name: actionForm.value.staff_name.trim(),
       prompt_template: actionForm.value.prompt_template,
       enabled: actionForm.value.enabled,
+      silent: actionForm.value.silent,
       structured_output: actionForm.value.structured_output,
     }
     if (!isEdit) {

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -84,7 +84,8 @@ CREATE TABLE IF NOT EXISTS messages (
     usage_json       TEXT,
     attachments_json TEXT,
     event_action_id  TEXT,
-    created_at       TEXT NOT NULL
+    created_at       TEXT NOT NULL,
+    hidden           INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS attachments (
@@ -140,6 +141,7 @@ CREATE TABLE IF NOT EXISTS event_actions (
     last_run_output   TEXT,
     enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
     structured_output INTEGER NOT NULL DEFAULT 0 CHECK (structured_output IN (0, 1)),
+    silent            INTEGER NOT NULL DEFAULT 1,
     created_at        TEXT NOT NULL,
     updated_at        TEXT NOT NULL,
 
@@ -192,6 +194,7 @@ _MIGRATIONS = [
     "ALTER TABLE topics ADD COLUMN veto_reason TEXT",
     "ALTER TABLE topics ADD COLUMN current_staff_name TEXT",
     "ALTER TABLE messages ADD COLUMN interrupt_reason TEXT",
+    "ALTER TABLE messages ADD COLUMN hidden INTEGER DEFAULT 0",
 ]
 
 
@@ -361,9 +364,14 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
     ).fetchone()
     if row is None or "'workspace'" in (row[0] or ""):
         return
+    legacy_cols = {r[1] for r in conn.execute("PRAGMA table_info(event_actions)")}
+    structured_output_select = (
+        "structured_output" if "structured_output" in legacy_cols else "0 AS structured_output"
+    )
+    silent_select = "silent" if "silent" in legacy_cols else "1 AS silent"
     LOGGER.info("db.migration_start event_actions_v3")
     conn.execute("PRAGMA foreign_keys = OFF")
-    conn.executescript("""
+    conn.executescript(f"""
         CREATE TABLE IF NOT EXISTS event_actions_new (
             id              TEXT PRIMARY KEY,
             event_type      TEXT NOT NULL CHECK (event_type IN (
@@ -392,6 +400,7 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
             last_run_output   TEXT,
             enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
             structured_output INTEGER NOT NULL DEFAULT 0 CHECK (structured_output IN (0, 1)),
+            silent            INTEGER NOT NULL DEFAULT 1,
             created_at        TEXT NOT NULL,
             updated_at        TEXT NOT NULL,
             CHECK (
@@ -403,8 +412,16 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
                                                       AND cron_expr IS NULL     AND (timing IS NULL OR timing = 'after'))
             )
         );
-        INSERT OR IGNORE INTO event_actions_new
-            SELECT * FROM event_actions;
+        INSERT OR IGNORE INTO event_actions_new (
+            id, event_type, scope_type, scope_id, staff_name, prompt_template,
+            timing, cron_expr, last_fired_at, last_run_at, last_run_status,
+            last_run_output, enabled, structured_output, silent, created_at, updated_at
+        )
+            SELECT id, event_type, scope_type, scope_id, staff_name, prompt_template,
+                   timing, cron_expr, last_fired_at, last_run_at, last_run_status,
+                   last_run_output, enabled, {structured_output_select}, {silent_select},
+                   created_at, updated_at
+            FROM event_actions;
         DROP TABLE event_actions;
         ALTER TABLE event_actions_new RENAME TO event_actions;
         CREATE INDEX IF NOT EXISTS idx_event_actions_scope_event
@@ -415,6 +432,20 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA foreign_keys = ON")
     conn.commit()
     LOGGER.info("db.migration_done event_actions_v3")
+
+
+def _migrate_event_actions_v4(conn: sqlite3.Connection) -> None:
+    """Add silent column to event_actions for databases that already completed v3.
+
+    Idempotent: skips if silent is already present.
+    """
+    existing_cols = {r[1] for r in conn.execute("PRAGMA table_info(event_actions)")}
+    if "silent" in existing_cols:
+        return
+    LOGGER.info("db.migration_start event_actions_v4")
+    conn.execute("ALTER TABLE event_actions ADD COLUMN silent INTEGER NOT NULL DEFAULT 1")
+    conn.commit()
+    LOGGER.info("db.migration_done event_actions_v4")
 
 
 def _migrate_staffs_session_scope_none(conn: sqlite3.Connection) -> None:
@@ -481,6 +512,7 @@ def init_db(db_path: str) -> None:
         _migrate_agents_to_staffs(conn)
         _migrate_event_actions_v2(conn)
         _migrate_event_actions_v3(conn)
+        _migrate_event_actions_v4(conn)
         _migrate_staffs_session_scope_none(conn)
         conn.commit()
     finally:

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -71,6 +71,7 @@ async def dispatch_to_staff(
     attachments: list[dict] | None = None,
     event_action_id: str | None = None,
     response_mode: str | None = None,
+    hidden: bool = False,
 ) -> str:
     """Insert a message row, build the MQTT dispatch payload, broadcast on the hub, and publish.
 
@@ -146,9 +147,9 @@ async def dispatch_to_staff(
         now = _now()
         conn.execute(
             "INSERT INTO messages"
-            " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, event_action_id, created_at)"
-            " VALUES (?, ?, ?, NULL, ?, NULL, NULL, NULL, ?, ?)",
-            (message_id, topic_id, sender, raw_text, event_action_id, now),
+            " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, event_action_id, hidden, created_at)"
+            " VALUES (?, ?, ?, NULL, ?, NULL, NULL, NULL, ?, ?, ?)",
+            (message_id, topic_id, sender, raw_text, event_action_id, 1 if hidden else 0, now),
         )
         if sender == "user":
             conn.execute(
@@ -207,6 +208,7 @@ async def dispatch_to_staff(
         "text": raw_text,
         "transcript": payload,
         "attachments": attachments,
+        "hidden": hidden,
     })
 
     settings = app_state.settings
@@ -237,6 +239,7 @@ async def post_message_direct(
     text: str,
     sender: str = "agent",
     agent_name: str | None = None,
+    hidden: bool = False,
 ) -> str:
     """Insert a message row and broadcast it on the hub without MQTT dispatch.
 
@@ -249,9 +252,9 @@ async def post_message_direct(
         now = _now()
         conn.execute(
             "INSERT INTO messages"
-            " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, event_action_id, created_at)"
-            " VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
-            (message_id, topic_id, sender, agent_name, text, now),
+            " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, event_action_id, hidden, created_at)"
+            " VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)",
+            (message_id, topic_id, sender, agent_name, text, 1 if hidden else 0, now),
         )
         conn.commit()
     finally:
@@ -265,5 +268,6 @@ async def post_message_direct(
         "text": text,
         "transcript": None,
         "attachments": [],
+        "hidden": hidden,
     })
     return message_id

--- a/src/master/event_actions.py
+++ b/src/master/event_actions.py
@@ -57,6 +57,7 @@ class EventActionIn(BaseModel):
     cron_expr: str | None = None
     enabled: bool = True
     structured_output: bool = False
+    silent: bool = True
 
     @model_validator(mode="after")
     def validate_event_type_fields(self) -> "EventActionIn":
@@ -95,6 +96,7 @@ class EventActionOut(BaseModel):
     last_run_output: str | None
     enabled: bool
     structured_output: bool
+    silent: bool
     created_at: str
     updated_at: str
 
@@ -108,6 +110,7 @@ class EventActionPatch(BaseModel):
     cron_expr: str | None = None
     enabled: bool | None = None
     structured_output: bool | None = None
+    silent: bool | None = None
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -177,6 +180,7 @@ def _row_to_out(row) -> EventActionOut:
         last_run_output=row["last_run_output"],
         enabled=bool(row["enabled"]),
         structured_output=bool(row["structured_output"]),
+        silent=bool(row["silent"]),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -203,6 +207,7 @@ class WorkspaceEventActionIn(BaseModel):
     timing: Literal["before", "after"] | None = None
     enabled: bool = True
     structured_output: bool = False
+    silent: bool = True
 
     @model_validator(mode="after")
     def validate_event_type_fields(self) -> "WorkspaceEventActionIn":
@@ -256,8 +261,8 @@ def create_event_action(
             "INSERT INTO event_actions"
             " (id, event_type, scope_type, scope_id, staff_name, prompt_template,"
             "  timing, cron_expr, last_fired_at, last_run_at, last_run_status,"
-            "  last_run_output, enabled, structured_output, created_at, updated_at)"
-            " VALUES (?, ?, 'topic', ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?)",
+            "  last_run_output, enabled, structured_output, silent, created_at, updated_at)"
+            " VALUES (?, ?, 'topic', ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?)",
             (
                 action_id,
                 body.event_type,
@@ -268,6 +273,7 @@ def create_event_action(
                 body.cron_expr,
                 1 if body.enabled else 0,
                 1 if body.structured_output else 0,
+                1 if body.silent else 0,
                 now,
                 now,
             ),
@@ -325,7 +331,7 @@ def patch_event_action(
         # (e.g. patching a topic_archived row's timing back to null). The non-nullable
         # fields (staff_name, prompt_template, enabled) reject explicit null with 422.
         sent = body.model_dump(exclude_unset=True)
-        for field in ("staff_name", "prompt_template", "enabled", "structured_output"):
+        for field in ("staff_name", "prompt_template", "enabled", "structured_output", "silent"):
             if field in sent and sent[field] is None:
                 raise HTTPException(422, f"{field} cannot be null")
         new_staff = sent["staff_name"] if "staff_name" in sent else existing["staff_name"]
@@ -334,6 +340,7 @@ def patch_event_action(
         new_cron = sent["cron_expr"] if "cron_expr" in sent else existing["cron_expr"]
         new_enabled = (1 if sent["enabled"] else 0) if "enabled" in sent else existing["enabled"]
         new_structured_output = (1 if sent["structured_output"] else 0) if "structured_output" in sent else existing["structured_output"]
+        new_silent = (1 if sent["silent"] else 0) if "silent" in sent else existing["silent"]
 
         _validate_merged_state(
             event_type=existing["event_type"],
@@ -345,9 +352,9 @@ def patch_event_action(
         conn.execute(
             "UPDATE event_actions"
             "   SET staff_name=?, prompt_template=?, timing=?, cron_expr=?, enabled=?,"
-            "       structured_output=?, updated_at=?"
+            "       structured_output=?, silent=?, updated_at=?"
             " WHERE id=?",
-            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, now, action_id),
+            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, new_silent, now, action_id),
         )
         conn.commit()
         row = conn.execute(
@@ -411,8 +418,8 @@ def create_workspace_event_action(
             "INSERT INTO event_actions"
             " (id, event_type, scope_type, scope_id, staff_name, prompt_template,"
             "  timing, cron_expr, last_fired_at, last_run_at, last_run_status,"
-            "  last_run_output, enabled, structured_output, created_at, updated_at)"
-            " VALUES (?, ?, 'workspace', ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?)",
+            "  last_run_output, enabled, structured_output, silent, created_at, updated_at)"
+            " VALUES (?, ?, 'workspace', ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?)",
             (
                 action_id,
                 body.event_type,
@@ -422,6 +429,7 @@ def create_workspace_event_action(
                 body.timing,
                 1 if body.enabled else 0,
                 1 if body.structured_output else 0,
+                1 if body.silent else 0,
                 now,
                 now,
             ),
@@ -473,7 +481,7 @@ def patch_workspace_event_action(
             raise HTTPException(404, "event action not found")
 
         sent = body.model_dump(exclude_unset=True)
-        for field in ("staff_name", "prompt_template", "enabled", "structured_output"):
+        for field in ("staff_name", "prompt_template", "enabled", "structured_output", "silent"):
             if field in sent and sent[field] is None:
                 raise HTTPException(422, f"{field} cannot be null")
         new_staff = sent["staff_name"] if "staff_name" in sent else existing["staff_name"]
@@ -482,6 +490,7 @@ def patch_workspace_event_action(
         new_cron = sent["cron_expr"] if "cron_expr" in sent else existing["cron_expr"]
         new_enabled = (1 if sent["enabled"] else 0) if "enabled" in sent else existing["enabled"]
         new_structured_output = (1 if sent["structured_output"] else 0) if "structured_output" in sent else existing["structured_output"]
+        new_silent = (1 if sent["silent"] else 0) if "silent" in sent else existing["silent"]
 
         _validate_merged_state(
             event_type=existing["event_type"],
@@ -493,9 +502,9 @@ def patch_workspace_event_action(
         conn.execute(
             "UPDATE event_actions"
             "   SET staff_name=?, prompt_template=?, timing=?, cron_expr=?, enabled=?,"
-            "       structured_output=?, updated_at=?"
+            "       structured_output=?, silent=?, updated_at=?"
             " WHERE id=?",
-            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, now, action_id),
+            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, new_silent, now, action_id),
         )
         conn.commit()
         row = conn.execute(

--- a/src/master/event_dispatcher.py
+++ b/src/master/event_dispatcher.py
@@ -276,6 +276,7 @@ async def _dispatch_one(app_state, row, event: dict) -> None:
             return
 
         structured_output = bool(row["structured_output"])
+        silent = bool(row["silent"]) if "silent" in row.keys() else True
         try:
             message_id = await asyncio.wait_for(
                 dispatch_to_staff(
@@ -287,6 +288,7 @@ async def _dispatch_one(app_state, row, event: dict) -> None:
                     sender="event",
                     raw_text=prompt,
                     event_action_id=row["id"] if structured_output else None,
+                    hidden=silent,
                 ),
                 timeout=DISPATCH_TIMEOUT_S,
             )
@@ -407,6 +409,7 @@ async def run_gate_actions(
 
         fut: asyncio.Future = loop.create_future()
 
+        gate_silent = bool(row["silent"]) if "silent" in row.keys() else True
         try:
             message_id = await asyncio.wait_for(
                 dispatch_to_staff(
@@ -418,6 +421,7 @@ async def run_gate_actions(
                     sender="event",
                     raw_text=prompt,
                     event_action_id=row["id"],
+                    hidden=gate_silent,
                 ),
                 timeout=DISPATCH_TIMEOUT_S,
             )

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -5,7 +5,7 @@ import uuid
 import re
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel
 
 from .db import get_connection
@@ -56,6 +56,7 @@ class MessageOut(BaseModel):
     transcript: str | None
     usage_json: str | None = None
     interrupt_reason: str | None = None
+    hidden: bool = False
     created_at: str
     attachments: list[AttachmentMeta] = []
 
@@ -229,7 +230,12 @@ async def cancel_message(
 
 
 @router.get("", response_model=list[MessageOut])
-def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[MessageOut]:
+def list_messages(
+    workspace_id: str,
+    topic_id: str,
+    request: Request,
+    verbose: bool = Query(default=False),
+) -> list[MessageOut]:
     conn = get_connection(request.app.state.db_path)
     try:
         if conn.execute("SELECT 1 FROM workspaces WHERE id = ?", (workspace_id,)).fetchone() is None:
@@ -239,12 +245,14 @@ def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[Me
         ).fetchone() is None:
             raise HTTPException(404, "topic not found")
         rows = conn.execute(
-            "SELECT id, sender, agent_name, text, transcript, usage_json, interrupt_reason, created_at FROM messages"
-            " WHERE topic_id = ? ORDER BY created_at",
+            "SELECT id, sender, agent_name, text, transcript, usage_json, interrupt_reason, hidden, created_at"
+            " FROM messages WHERE topic_id = ? ORDER BY created_at",
             (topic_id,),
         ).fetchall()
         result = []
         for r in rows:
+            if r["hidden"] and not verbose:
+                continue
             att_rows = conn.execute(
                 "SELECT id, filename, mime_type, size_bytes FROM attachments WHERE message_id = ? ORDER BY created_at",
                 (r["id"],),
@@ -260,7 +268,7 @@ def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[Me
                 MessageOut(
                     id=r["id"], sender=r["sender"], agent_name=r["agent_name"],
                     text=r["text"], transcript=r["transcript"], usage_json=r["usage_json"],
-                    interrupt_reason=r["interrupt_reason"],
+                    interrupt_reason=r["interrupt_reason"], hidden=bool(r["hidden"]),
                     created_at=r["created_at"], attachments=attachments,
                 )
             )

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -101,7 +101,9 @@ def _save_chunk(db_path: str, topic_id: str, payload: dict) -> None:  # type: ig
         LOGGER.exception("mqtt.save_chunk_error topic_id=%s", topic_id)
 
 
-def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  # type: ignore[type-arg]
+def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> bool:  # type: ignore[type-arg]
+    """Save agent response to the database. Returns True if the message is hidden."""
+    hidden = False
     try:
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
@@ -112,6 +114,7 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
             llm_session_id = payload.get("session_id")
             agent_name = payload.get("agent_name")
             message_id = payload.get("message_id") or str(uuid.uuid4())
+            reply_to = payload.get("reply_to", "")
             interrupt_reason = payload.get("interrupt_reason")
             if transcript is None and text == "(message interrupted)":
                 chunk_rows = conn.execute(
@@ -128,6 +131,14 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
                     if events:
                         transcript = json.dumps(events)
             usage_json = _extract_usage(transcript)
+            # Propagate hidden flag from the prompt message so agent response bubbles
+            # are also hidden when the triggering action has silent=True.
+            if reply_to:
+                prompt_row = conn.execute(
+                    "SELECT hidden FROM messages WHERE id = ?", (reply_to,)
+                ).fetchone()
+                if prompt_row and prompt_row["hidden"]:
+                    hidden = True
             with conn:
                 # If the stale-stream detector beat us here with "(message interrupted)",
                 # update it with the real response instead of silently dropping it.
@@ -138,9 +149,9 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
                 )
                 conn.execute(
                     "INSERT OR IGNORE INTO messages"
-                    " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, interrupt_reason, created_at)"
-                    " VALUES (?, ?, 'agent', ?, ?, ?, ?, NULL, ?, ?)",
-                    (message_id, topic_id, agent_name, text, transcript, usage_json, interrupt_reason, _now()),
+                    " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, interrupt_reason, hidden, created_at)"
+                    " VALUES (?, ?, 'agent', ?, ?, ?, ?, NULL, ?, ?, ?)",
+                    (message_id, topic_id, agent_name, text, transcript, usage_json, interrupt_reason, 1 if hidden else 0, _now()),
                 )
                 conn.execute(
                     "DELETE FROM chunks WHERE message_id = ?", (message_id,)
@@ -155,6 +166,7 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
             conn.close()
     except Exception:
         LOGGER.exception("mqtt.save_agent_response_error topic_id=%s", topic_id)
+    return hidden
 
 
 def _prompt_was_event_dispatched(db_path: str, reply_to: str) -> bool:
@@ -278,6 +290,7 @@ def _handle_structured_response(
         _record_run(db_path, action["id"], status="ok", output=f"break message={msg_text!r}")
     elif "message" in response:
         msg_text = str(response["message"])
+        action_silent = bool(action["silent"]) if "silent" in action.keys() else True
         app_state = userdata.get("app_state")
         if app_state and loop:
             from .dispatch import post_message_direct
@@ -288,6 +301,7 @@ def _handle_structured_response(
                     text=msg_text,
                     sender="agent",
                     agent_name=action["staff_name"],
+                    hidden=action_silent,
                 ),
                 loop,
             )
@@ -404,7 +418,8 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
                 _handle_structured_response(db_path, action, topic_id, payload, userdata)
                 return
 
-            _save_agent_response(db_path, topic_id, payload)
+            response_hidden = _save_agent_response(db_path, topic_id, payload)
+            message["hidden"] = response_hidden
             _record_agent_response(db_path, topic_id)
             notify.notify_reply(
                 db_path=db_path,

--- a/tests/master/test_event_actions.py
+++ b/tests/master/test_event_actions.py
@@ -3102,7 +3102,7 @@ class TestStructuredOutput:
         # Track what post_message_direct receives
         posted = {}
 
-        async def fake_post_direct(*, app_state, topic_id, text, sender="agent", agent_name=None):
+        async def fake_post_direct(*, app_state, topic_id, text, sender="agent", agent_name=None, hidden=False):
             posted["text"] = text
             posted["agent_name"] = agent_name
             return str(uuid.uuid4())


### PR DESCRIPTION
## Summary

- Adds a `silent` field (default `true`) to event actions — when enabled, messages generated by the action are stored in the database but hidden from the topic chat by default
- The `messages` table gains a `hidden` column; the `/messages` endpoint accepts `?verbose=true` to include hidden messages
- Both the prompt message and the agent response message inherit the hidden flag, so the full exchange is suppressed when not in verbose mode
- A "Show silent messages" checkbox is added to the topic chat UI; toggling it reloads messages with verbose mode and reveals hidden bubbles in real-time via WebSocket

## Test plan

- [ ] Create an event action with **Silent** checked (default) — fire the event and confirm no bubble appears in the chat
- [ ] Toggle "Show silent messages" in the chat — confirm the hidden messages appear, including the prompt and agent response
- [ ] Create an event action with **Silent** unchecked — fire the event and confirm the message appears normally without toggling verbose
- [ ] Verify hidden messages are still stored: query `GET /api/workspaces/{wid}/topics/{tid}/messages?verbose=true` and confirm hidden messages are present with `hidden: true`
- [ ] Test with a `structured_output` action that returns `{"message": "..."}` — the posted message should also be hidden when the action is silent
- [ ] Existing tests pass: `pytest tests/master/test_event_actions.py` (119 passed, 1 skipped)
- [ ] Database migration: on an existing database, the `silent` column is added to `event_actions` and `hidden` column to `messages` without data loss

🤖 Generated with repository automation