### PR TITLE
feat(actions): add silent flag to hide action messages from chat

### DIFF
--- a/frontend/src/views/TopicChat.vue
+++ b/frontend/src/views/TopicChat.vue
@@ -24,14 +24,21 @@
       Agent: <em>{{ agentStatus }}</em>
     </div>
 
+    <div class="chat-toolbar">
+      <label class="verbose-toggle" :title="verboseMode ? 'Hide action messages' : 'Show hidden action messages'">
+        <input type="checkbox" v-model="verboseMode" />
+        Verbose
+      </label>
+    </div>
+
     <div class="messages" ref="msgBox">
       <p v-if="loading" class="muted center">Loading…</p>
-      <p v-else-if="!messages.length" class="muted center">No messages yet. Send one below.</p>
+      <p v-else-if="!filteredMessages.length" class="muted center">No messages yet. Send one below.</p>
       <div
-        v-for="(m, msgIdx) in messages"
+        v-for="(m, msgIdx) in filteredMessages"
         :key="m.id"
         class="message"
-        :class="m.sender === 'user' ? 'user' : 'agent'"
+        :class="[m.sender === 'user' ? 'user' : 'agent', m.silent ? 'message-silent' : '']"
       >
         <span class="label">{{ m.sender === 'user' ? 'You' : (m.agent_name ? `@${m.agent_name}` : 'Agent') }}</span>
         <div class="bubble" :class="{
@@ -287,6 +294,7 @@ const availableStaffs = ref([])
 const expandedMsgs = ref(new Set())
 const chatInputRef = ref(null)
 const sendError = ref('')
+const verboseMode = ref(false)
 
 const MSG_COLLAPSE_THRESHOLD = 600
 const MSG_COLLAPSED_PREVIEW = 300
@@ -294,8 +302,12 @@ const MSG_COLLAPSED_PREVIEW = 300
 const isArchived = computed(() => !!topic.value?.archived_at)
 const isWorkspaceArchived = computed(() => !!workspace.value?.archived_at)
 
+const filteredMessages = computed(() =>
+  verboseMode.value ? messages.value : messages.value.filter(m => !m.silent)
+)
+
 function isMsgCollapsible(msg, idx) {
-  if (idx !== undefined && idx >= messages.value.length - 1) return false
+  if (idx !== undefined && idx >= filteredMessages.value.length - 1) return false
   return !msg.streaming && (msg.text || '').length > MSG_COLLAPSE_THRESHOLD
 }
 function isMsgExpanded(id) { return expandedMsgs.value.has(id) }
@@ -545,6 +557,7 @@ function finaliseMessage(data) {
     traceRows: transcriptToRows(data.transcript) || existing?.traceRows || [],
     attachments: data.attachments ?? existing?.attachments ?? [],
     interrupt_reason: data.interrupt_reason ?? existing?.interrupt_reason ?? null,
+    silent: data.silent ?? existing?.silent ?? false,
     traceOpen: false, streaming: false,
     created_at: existing?.created_at || new Date().toISOString(),
   }
@@ -569,6 +582,7 @@ async function load() {
     const rawMsgs = await msgsRes.json()
     messages.value = rawMsgs.map(m => ({
       ...m,
+      silent: m.silent ?? false,
       traceRows: transcriptToRows(m.transcript),
       traceOpen: false,
       streaming: false,
@@ -767,6 +781,7 @@ watch(
     liveStreams.value = {}
     seenSeq.clear()
     agentStatus.value = ''
+    verboseMode.value = false
     load()
     if (!isArchived.value) connectWs()
   },
@@ -784,6 +799,10 @@ onUnmounted(() => {
 
 <style scoped>
 .chat-layout { display: flex; flex-direction: column; height: calc(100vh - 110px); }
+.chat-toolbar { display: flex; align-items: center; justify-content: flex-end; padding: 2px 0; min-height: 22px; }
+.verbose-toggle { display: flex; align-items: center; gap: 0.35rem; font-size: 0.78em; color: #94a3b8; cursor: pointer; user-select: none; }
+.verbose-toggle input { cursor: pointer; }
+.message-silent .bubble { opacity: 0.55; border-style: dashed; }
 .breadcrumb { font-size: 0.9em; color: #64748b; margin-bottom: 0.5rem; }
 .topic-settings-link { color: #94a3b8; text-decoration: none; margin-left: 0.5rem; font-size: 1em; }
 .topic-settings-link:hover { color: #475569; }

--- a/frontend/src/views/TopicSettings.vue
+++ b/frontend/src/views/TopicSettings.vue
@@ -87,6 +87,12 @@
               <code>{"silent": true, "log": "optional log"}</code>
             </p>
           </div>
+
+          <label>Silent</label>
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="form.silent" />
+            Hide action messages from chat by default
+          </label>
         </div>
         <div class="form-actions">
           <button class="btn-primary" @click="saveAction" :disabled="saving">{{ saving ? 'Saving…' : 'Save' }}</button>
@@ -106,6 +112,7 @@
             <span class="action-type-badge" :class="typeBadgeClass(a.event_type)">{{ a.event_type }}</span>
             <span v-if="a.timing" class="timing-badge">{{ a.timing }}</span>
             <span v-if="a.structured_output" class="structured-badge" title="Expects JSON response">JSON</span>
+            <span v-if="a.silent" class="silent-badge" title="Messages hidden from chat by default">silent</span>
             <span class="action-staff">@{{ a.staff_name }}</span>
             <span class="action-preview muted">{{ a.prompt_template.slice(0, 60) }}{{ a.prompt_template.length > 60 ? '…' : '' }}</span>
             <div class="action-btns">
@@ -165,6 +172,7 @@ const emptyForm = () => ({
   cron_expr: '',
   enabled: true,
   structured_output: false,
+  silent: true,
 })
 const form = ref(emptyForm())
 
@@ -237,6 +245,7 @@ function startEdit(a) {
     cron_expr: a.cron_expr ?? '',
     enabled: a.enabled,
     structured_output: a.structured_output,
+    silent: a.silent,
   }
   showForm.value = true
   formError.value = ''
@@ -260,6 +269,7 @@ async function saveAction() {
       prompt_template: form.value.prompt_template,
       enabled: form.value.enabled,
       structured_output: form.value.structured_output,
+      silent: form.value.silent,
     }
     if (!isEdit) {
       body.event_type = form.value.event_type
@@ -388,6 +398,7 @@ onMounted(load)
 .badge-archived { background: #fef9c3; color: #713f12; }
 .timing-badge { background: #f1f5f9; color: #475569; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; }
 .structured-badge { background: #ecfdf5; color: #065f46; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.silent-badge { background: #f1f5f9; color: #64748b; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
 .action-staff { font-weight: 600; font-size: 0.9em; }
 .action-preview { font-size: 0.82em; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .action-btns { margin-left: auto; display: flex; gap: 0.25rem; white-space: nowrap; }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -243,6 +243,12 @@
               <code>{"silent": true, "log": "optional log"}</code>
             </p>
           </div>
+
+          <label>Silent</label>
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="actionForm.silent" />
+            Hide action messages from chat by default
+          </label>
         </div>
         <div class="form-actions">
           <button class="btn-primary" @click="saveAction" :disabled="savingAction">{{ savingAction ? 'Saving…' : 'Save' }}</button>
@@ -262,6 +268,7 @@
             <span class="action-type-badge" :class="actionTypeBadgeClass(a.event_type)">{{ a.event_type }}</span>
             <span v-if="a.timing" class="timing-badge">{{ a.timing }}</span>
             <span v-if="a.structured_output" class="structured-badge" title="Expects JSON response">JSON</span>
+            <span v-if="a.silent" class="silent-badge" title="Messages hidden from chat by default">silent</span>
             <span class="action-staff">@{{ a.staff_name }}</span>
             <span class="action-preview muted">{{ a.prompt_template.slice(0, 60) }}{{ a.prompt_template.length > 60 ? '…' : '' }}</span>
             <div class="action-btns">
@@ -364,6 +371,7 @@ const emptyActionForm = () => ({
   timing: 'after',
   enabled: true,
   structured_output: false,
+  silent: true,
 })
 const actionForm = ref(emptyActionForm())
 
@@ -652,6 +660,7 @@ function startEditAction(a) {
     timing: a.timing ?? null,
     enabled: a.enabled,
     structured_output: a.structured_output,
+    silent: a.silent,
   }
   showActionForm.value = true
   actionError.value = ''
@@ -673,6 +682,7 @@ async function saveAction() {
       prompt_template: actionForm.value.prompt_template,
       enabled: actionForm.value.enabled,
       structured_output: actionForm.value.structured_output,
+      silent: actionForm.value.silent,
     }
     if (!isEdit) {
       body.event_type = actionForm.value.event_type
@@ -953,6 +963,7 @@ section { margin-bottom: 2rem; }
 .badge-archiving { background: #fee2e2; color: #991b1b; }
 .timing-badge { background: #f1f5f9; color: #475569; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; }
 .structured-badge { background: #ecfdf5; color: #065f46; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
+.silent-badge { background: #f1f5f9; color: #64748b; border-radius: 10px; padding: 1px 8px; font-size: 0.78em; font-weight: 600; }
 .action-staff { font-weight: 600; font-size: 0.9em; }
 .action-preview { font-size: 0.82em; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .action-btns { margin-left: auto; display: flex; gap: 0.25rem; white-space: nowrap; }

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -84,6 +84,7 @@ CREATE TABLE IF NOT EXISTS messages (
     usage_json       TEXT,
     attachments_json TEXT,
     event_action_id  TEXT,
+    silent           INTEGER NOT NULL DEFAULT 0,
     created_at       TEXT NOT NULL
 );
 
@@ -140,6 +141,7 @@ CREATE TABLE IF NOT EXISTS event_actions (
     last_run_output   TEXT,
     enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
     structured_output INTEGER NOT NULL DEFAULT 0 CHECK (structured_output IN (0, 1)),
+    silent            INTEGER NOT NULL DEFAULT 1 CHECK (silent IN (0, 1)),
     created_at        TEXT NOT NULL,
     updated_at        TEXT NOT NULL,
 
@@ -193,6 +195,8 @@ _MIGRATIONS = [
     "ALTER TABLE topics ADD COLUMN current_staff_name TEXT",
     "ALTER TABLE messages ADD COLUMN interrupt_reason TEXT",
     "ALTER TABLE workspaces ADD COLUMN repo_ref TEXT NOT NULL DEFAULT 'master'",
+    "ALTER TABLE event_actions ADD COLUMN silent INTEGER NOT NULL DEFAULT 1",
+    "ALTER TABLE messages ADD COLUMN silent INTEGER NOT NULL DEFAULT 0",
 ]
 
 

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -360,15 +360,25 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
 
     SQLite cannot modify CHECK constraints in-place; we recreate the table.
     Idempotent: skips if 'workspace' is already present in the constraint.
+    Uses an explicit column list (not SELECT *) so that columns added by
+    concurrent ALTER TABLE migrations (e.g. structured_output, silent) are
+    preserved even when they weren't in the original schema.
     """
     row = conn.execute(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='event_actions'"
     ).fetchone()
     if row is None or "'workspace'" in (row[0] or ""):
         return
+    legacy_cols = {r[1] for r in conn.execute("PRAGMA table_info(event_actions)")}
+    structured_output_select = (
+        "structured_output" if "structured_output" in legacy_cols else "0 AS structured_output"
+    )
+    silent_select = (
+        "silent" if "silent" in legacy_cols else "1 AS silent"
+    )
     LOGGER.info("db.migration_start event_actions_v3")
     conn.execute("PRAGMA foreign_keys = OFF")
-    conn.executescript("""
+    conn.executescript(f"""
         CREATE TABLE IF NOT EXISTS event_actions_new (
             id              TEXT PRIMARY KEY,
             event_type      TEXT NOT NULL CHECK (event_type IN (
@@ -397,6 +407,7 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
             last_run_output   TEXT,
             enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
             structured_output INTEGER NOT NULL DEFAULT 0 CHECK (structured_output IN (0, 1)),
+            silent            INTEGER NOT NULL DEFAULT 1 CHECK (silent IN (0, 1)),
             created_at        TEXT NOT NULL,
             updated_at        TEXT NOT NULL,
             CHECK (
@@ -408,8 +419,16 @@ def _migrate_event_actions_v3(conn: sqlite3.Connection) -> None:
                                                       AND cron_expr IS NULL     AND (timing IS NULL OR timing = 'after'))
             )
         );
-        INSERT OR IGNORE INTO event_actions_new
-            SELECT * FROM event_actions;
+        INSERT OR IGNORE INTO event_actions_new (
+            id, event_type, scope_type, scope_id, staff_name, prompt_template,
+            timing, cron_expr, last_fired_at, last_run_at, last_run_status,
+            last_run_output, enabled, structured_output, silent, created_at, updated_at
+        )
+            SELECT id, event_type, scope_type, scope_id, staff_name, prompt_template,
+                   timing, cron_expr, last_fired_at, last_run_at, last_run_status,
+                   last_run_output, enabled, {structured_output_select}, {silent_select},
+                   created_at, updated_at
+            FROM event_actions;
         DROP TABLE event_actions;
         ALTER TABLE event_actions_new RENAME TO event_actions;
         CREATE INDEX IF NOT EXISTS idx_event_actions_scope_event

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -71,6 +71,7 @@ async def dispatch_to_staff(
     attachments: list[dict] | None = None,
     event_action_id: str | None = None,
     response_mode: str | None = None,
+    silent: bool = False,
 ) -> str:
     """Insert a message row, build the MQTT dispatch payload, broadcast on the hub, and publish.
 
@@ -146,9 +147,9 @@ async def dispatch_to_staff(
         now = _now()
         conn.execute(
             "INSERT INTO messages"
-            " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, event_action_id, created_at)"
-            " VALUES (?, ?, ?, NULL, ?, NULL, NULL, NULL, ?, ?)",
-            (message_id, topic_id, sender, raw_text, event_action_id, now),
+            " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, event_action_id, silent, created_at)"
+            " VALUES (?, ?, ?, NULL, ?, NULL, NULL, NULL, ?, ?, ?)",
+            (message_id, topic_id, sender, raw_text, event_action_id, 1 if silent else 0, now),
         )
         if sender == "user":
             conn.execute(
@@ -207,6 +208,7 @@ async def dispatch_to_staff(
         "text": raw_text,
         "transcript": payload,
         "attachments": attachments,
+        "silent": silent,
     })
 
     settings = app_state.settings

--- a/src/master/event_actions.py
+++ b/src/master/event_actions.py
@@ -57,6 +57,7 @@ class EventActionIn(BaseModel):
     cron_expr: str | None = None
     enabled: bool = True
     structured_output: bool = False
+    silent: bool = True
 
     @model_validator(mode="after")
     def validate_event_type_fields(self) -> "EventActionIn":
@@ -95,6 +96,7 @@ class EventActionOut(BaseModel):
     last_run_output: str | None
     enabled: bool
     structured_output: bool
+    silent: bool
     created_at: str
     updated_at: str
 
@@ -108,6 +110,7 @@ class EventActionPatch(BaseModel):
     cron_expr: str | None = None
     enabled: bool | None = None
     structured_output: bool | None = None
+    silent: bool | None = None
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -177,6 +180,7 @@ def _row_to_out(row) -> EventActionOut:
         last_run_output=row["last_run_output"],
         enabled=bool(row["enabled"]),
         structured_output=bool(row["structured_output"]),
+        silent=bool(row["silent"]),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -203,6 +207,7 @@ class WorkspaceEventActionIn(BaseModel):
     timing: Literal["before", "after"] | None = None
     enabled: bool = True
     structured_output: bool = False
+    silent: bool = True
 
     @model_validator(mode="after")
     def validate_event_type_fields(self) -> "WorkspaceEventActionIn":
@@ -256,8 +261,8 @@ def create_event_action(
             "INSERT INTO event_actions"
             " (id, event_type, scope_type, scope_id, staff_name, prompt_template,"
             "  timing, cron_expr, last_fired_at, last_run_at, last_run_status,"
-            "  last_run_output, enabled, structured_output, created_at, updated_at)"
-            " VALUES (?, ?, 'topic', ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?)",
+            "  last_run_output, enabled, structured_output, silent, created_at, updated_at)"
+            " VALUES (?, ?, 'topic', ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?)",
             (
                 action_id,
                 body.event_type,
@@ -268,6 +273,7 @@ def create_event_action(
                 body.cron_expr,
                 1 if body.enabled else 0,
                 1 if body.structured_output else 0,
+                1 if body.silent else 0,
                 now,
                 now,
             ),
@@ -325,7 +331,7 @@ def patch_event_action(
         # (e.g. patching a topic_archived row's timing back to null). The non-nullable
         # fields (staff_name, prompt_template, enabled) reject explicit null with 422.
         sent = body.model_dump(exclude_unset=True)
-        for field in ("staff_name", "prompt_template", "enabled", "structured_output"):
+        for field in ("staff_name", "prompt_template", "enabled", "structured_output", "silent"):
             if field in sent and sent[field] is None:
                 raise HTTPException(422, f"{field} cannot be null")
         new_staff = sent["staff_name"] if "staff_name" in sent else existing["staff_name"]
@@ -334,6 +340,7 @@ def patch_event_action(
         new_cron = sent["cron_expr"] if "cron_expr" in sent else existing["cron_expr"]
         new_enabled = (1 if sent["enabled"] else 0) if "enabled" in sent else existing["enabled"]
         new_structured_output = (1 if sent["structured_output"] else 0) if "structured_output" in sent else existing["structured_output"]
+        new_silent = (1 if sent["silent"] else 0) if "silent" in sent else existing["silent"]
 
         _validate_merged_state(
             event_type=existing["event_type"],
@@ -345,9 +352,9 @@ def patch_event_action(
         conn.execute(
             "UPDATE event_actions"
             "   SET staff_name=?, prompt_template=?, timing=?, cron_expr=?, enabled=?,"
-            "       structured_output=?, updated_at=?"
+            "       structured_output=?, silent=?, updated_at=?"
             " WHERE id=?",
-            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, now, action_id),
+            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, new_silent, now, action_id),
         )
         conn.commit()
         row = conn.execute(
@@ -411,8 +418,8 @@ def create_workspace_event_action(
             "INSERT INTO event_actions"
             " (id, event_type, scope_type, scope_id, staff_name, prompt_template,"
             "  timing, cron_expr, last_fired_at, last_run_at, last_run_status,"
-            "  last_run_output, enabled, structured_output, created_at, updated_at)"
-            " VALUES (?, ?, 'workspace', ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?)",
+            "  last_run_output, enabled, structured_output, silent, created_at, updated_at)"
+            " VALUES (?, ?, 'workspace', ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?)",
             (
                 action_id,
                 body.event_type,
@@ -422,6 +429,7 @@ def create_workspace_event_action(
                 body.timing,
                 1 if body.enabled else 0,
                 1 if body.structured_output else 0,
+                1 if body.silent else 0,
                 now,
                 now,
             ),
@@ -473,7 +481,7 @@ def patch_workspace_event_action(
             raise HTTPException(404, "event action not found")
 
         sent = body.model_dump(exclude_unset=True)
-        for field in ("staff_name", "prompt_template", "enabled", "structured_output"):
+        for field in ("staff_name", "prompt_template", "enabled", "structured_output", "silent"):
             if field in sent and sent[field] is None:
                 raise HTTPException(422, f"{field} cannot be null")
         new_staff = sent["staff_name"] if "staff_name" in sent else existing["staff_name"]
@@ -482,6 +490,7 @@ def patch_workspace_event_action(
         new_cron = sent["cron_expr"] if "cron_expr" in sent else existing["cron_expr"]
         new_enabled = (1 if sent["enabled"] else 0) if "enabled" in sent else existing["enabled"]
         new_structured_output = (1 if sent["structured_output"] else 0) if "structured_output" in sent else existing["structured_output"]
+        new_silent = (1 if sent["silent"] else 0) if "silent" in sent else existing["silent"]
 
         _validate_merged_state(
             event_type=existing["event_type"],
@@ -493,9 +502,9 @@ def patch_workspace_event_action(
         conn.execute(
             "UPDATE event_actions"
             "   SET staff_name=?, prompt_template=?, timing=?, cron_expr=?, enabled=?,"
-            "       structured_output=?, updated_at=?"
+            "       structured_output=?, silent=?, updated_at=?"
             " WHERE id=?",
-            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, now, action_id),
+            (new_staff, new_template, new_timing, new_cron, new_enabled, new_structured_output, new_silent, now, action_id),
         )
         conn.commit()
         row = conn.execute(

--- a/src/master/event_dispatcher.py
+++ b/src/master/event_dispatcher.py
@@ -564,6 +564,7 @@ async def veto_dispatch(
                     sender="event",
                     raw_text=prompt,
                     response_mode="verdict",
+                    silent=bool(row["silent"]),
                 ),
                 timeout=DISPATCH_TIMEOUT_S,
             )

--- a/src/master/event_dispatcher.py
+++ b/src/master/event_dispatcher.py
@@ -287,6 +287,7 @@ async def _dispatch_one(app_state, row, event: dict) -> None:
                     sender="event",
                     raw_text=prompt,
                     event_action_id=row["id"] if structured_output else None,
+                    silent=bool(row["silent"]),
                 ),
                 timeout=DISPATCH_TIMEOUT_S,
             )
@@ -418,6 +419,7 @@ async def run_gate_actions(
                     sender="event",
                     raw_text=prompt,
                     event_action_id=row["id"],
+                    silent=bool(row["silent"]),
                 ),
                 timeout=DISPATCH_TIMEOUT_S,
             )

--- a/src/master/messages.py
+++ b/src/master/messages.py
@@ -56,6 +56,7 @@ class MessageOut(BaseModel):
     transcript: str | None
     usage_json: str | None = None
     interrupt_reason: str | None = None
+    silent: bool = False
     created_at: str
     attachments: list[AttachmentMeta] = []
 
@@ -239,7 +240,7 @@ def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[Me
         ).fetchone() is None:
             raise HTTPException(404, "topic not found")
         rows = conn.execute(
-            "SELECT id, sender, agent_name, text, transcript, usage_json, interrupt_reason, created_at FROM messages"
+            "SELECT id, sender, agent_name, text, transcript, usage_json, interrupt_reason, silent, created_at FROM messages"
             " WHERE topic_id = ? ORDER BY created_at",
             (topic_id,),
         ).fetchall()
@@ -261,6 +262,7 @@ def list_messages(workspace_id: str, topic_id: str, request: Request) -> list[Me
                     id=r["id"], sender=r["sender"], agent_name=r["agent_name"],
                     text=r["text"], transcript=r["transcript"], usage_json=r["usage_json"],
                     interrupt_reason=r["interrupt_reason"],
+                    silent=bool(r["silent"]),
                     created_at=r["created_at"], attachments=attachments,
                 )
             )

--- a/src/master/mqtt_client.py
+++ b/src/master/mqtt_client.py
@@ -101,7 +101,9 @@ def _save_chunk(db_path: str, topic_id: str, payload: dict) -> None:  # type: ig
         LOGGER.exception("mqtt.save_chunk_error topic_id=%s", topic_id)
 
 
-def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  # type: ignore[type-arg]
+def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> bool:  # type: ignore[type-arg]
+    """Save agent response and return the silent flag inherited from the prompt message."""
+    silent = False
     try:
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
@@ -113,6 +115,7 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
             agent_name = payload.get("agent_name")
             message_id = payload.get("message_id") or str(uuid.uuid4())
             interrupt_reason = payload.get("interrupt_reason")
+            reply_to = payload.get("reply_to", "")
             if transcript is None and text == "(message interrupted)":
                 chunk_rows = conn.execute(
                     "SELECT event FROM chunks WHERE message_id = ? ORDER BY seq",
@@ -128,6 +131,13 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
                     if events:
                         transcript = json.dumps(events)
             usage_json = _extract_usage(transcript)
+            # Inherit silent flag from the prompt message so the reply is also hidden.
+            if reply_to:
+                prompt_row = conn.execute(
+                    "SELECT silent FROM messages WHERE id = ?", (reply_to,)
+                ).fetchone()
+                if prompt_row is not None:
+                    silent = bool(prompt_row["silent"])
             with conn:
                 # If the stale-stream detector beat us here with "(message interrupted)",
                 # update it with the real response instead of silently dropping it.
@@ -138,9 +148,9 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
                 )
                 conn.execute(
                     "INSERT OR IGNORE INTO messages"
-                    " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, interrupt_reason, created_at)"
-                    " VALUES (?, ?, 'agent', ?, ?, ?, ?, NULL, ?, ?)",
-                    (message_id, topic_id, agent_name, text, transcript, usage_json, interrupt_reason, _now()),
+                    " (id, topic_id, sender, agent_name, text, transcript, usage_json, attachments_json, interrupt_reason, silent, created_at)"
+                    " VALUES (?, ?, 'agent', ?, ?, ?, ?, NULL, ?, ?, ?)",
+                    (message_id, topic_id, agent_name, text, transcript, usage_json, interrupt_reason, 1 if silent else 0, _now()),
                 )
                 conn.execute(
                     "DELETE FROM chunks WHERE message_id = ?", (message_id,)
@@ -155,6 +165,7 @@ def _save_agent_response(db_path: str, topic_id: str, payload: dict) -> None:  #
             conn.close()
     except Exception:
         LOGGER.exception("mqtt.save_agent_response_error topic_id=%s", topic_id)
+    return silent
 
 
 def _prompt_was_event_dispatched(db_path: str, reply_to: str) -> bool:
@@ -404,7 +415,8 @@ def _on_message(client, userdata, msg: mqtt.MQTTMessage) -> None:
                 _handle_structured_response(db_path, action, topic_id, payload, userdata)
                 return
 
-            _save_agent_response(db_path, topic_id, payload)
+            silent = _save_agent_response(db_path, topic_id, payload)
+            message["silent"] = silent
             _record_agent_response(db_path, topic_id)
             notify.notify_reply(
                 db_path=db_path,


### PR DESCRIPTION
## Summary
- Actions now have a \`silent\` boolean (default \`true\`); messages produced by silent actions are stored in the DB but hidden from the topic chat by default
- A **Verbose** checkbox in the chat toolbar reveals silent messages, shown with a dimmed, dashed-border style to distinguish them from normal messages
- DB schema migrated for both \`event_actions\` (adds \`silent\` column, default 1) and \`messages\` (adds \`silent\` column, default 0); existing rows are unaffected
- The \`silent\` flag is exposed in the action create/edit forms (TopicSettings + WorkspaceDetail) and shown as a \"silent\" badge in action lists
- Both the prompt message **and** the agent reply message are silenced — the full exchange is hidden when the action is silent
- Fix: archive (veto) actions now also respect the silent flag; the \`veto_dispatch()\` path was missing the \`silent\` kwarg

## Test plan
- [ ] Create a new event action with **Silent** checked (default) — verify \"silent\" badge appears in the action list
- [ ] Trigger the action; confirm its message does **not** appear in the topic chat by default
- [ ] Toggle **Verbose** in the chat toolbar — confirm both the prompt and the agent reply appear with a dimmed/dashed style
- [ ] Uncheck **Verbose** — confirm the messages disappear again
- [ ] Create an action with **Silent** unchecked — verify its messages appear normally without the \"silent\" badge
- [ ] Edit an existing action and change the silent flag — confirm the badge and chat behaviour update accordingly
- [ ] Workspace-level actions: repeat the above for actions configured in WorkspaceDetail
- [ ] Archive action (topic_archiving / veto): configure with silent=true — confirm the archive agent exchange is hidden from chat

Closes #233