### PR TITLE
fix(workspaces): apply project-specific agent image on create and restart

### DIFF
--- a/src/master/agent_runner.py
+++ b/src/master/agent_runner.py
@@ -2,6 +2,12 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 
 import docker
 import docker.errors
@@ -14,6 +20,72 @@ _GH_TOKEN_FALLBACK = "public-repo-no-auth-needed"
 
 def container_name(workspace_id: str) -> str:
     return f"codex-agent-{workspace_id}"
+
+
+def _inject_token(repo_url: str, gh_token: str | None) -> str:
+    """Embed a GitHub token into an HTTPS clone URL."""
+    if not gh_token:
+        return repo_url
+    m = re.match(r"(https?://)github\.com/(.+)", repo_url.strip())
+    if m:
+        return f"{m.group(1)}x-access-token:{gh_token}@github.com/{m.group(2)}"
+    return repo_url
+
+
+def resolve_agent_image(
+    *,
+    workspace_id: str,
+    repo_url: str,
+    repo_ref: str = "master",
+    default_image: str,
+    gh_token: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Return the image tag to use for this workspace's agent container.
+
+    Shallow-clones the repo, checks for .prj_assistant/image/Dockerfile, and
+    builds a project-specific image when the file is present. Falls back to
+    default_image if the clone fails or the Dockerfile is absent.
+    """
+    if dry_run:
+        return default_image
+
+    clone_url = _inject_token(repo_url, gh_token)
+    tmp_root = tempfile.mkdtemp(prefix="prj-image-resolve-")
+    clone_dest = os.path.join(tmp_root, "repo")
+    try:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", repo_ref, clone_url, clone_dest],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            LOGGER.warning(
+                "agent_runner.project_image_clone_failed workspace_id=%s ref=%s error=%s",
+                workspace_id, repo_ref, result.stderr.strip(),
+            )
+            return default_image
+
+        dockerfile = Path(clone_dest) / ".prj_assistant" / "image" / "Dockerfile"
+        if not dockerfile.exists():
+            LOGGER.info(
+                "agent_runner.project_dockerfile_absent workspace_id=%s using_default=%s",
+                workspace_id, default_image,
+            )
+            return default_image
+
+        image_tag = f"codex-agent-{workspace_id}:latest"
+        context_dir = str(Path(clone_dest) / ".prj_assistant" / "image")
+        LOGGER.info("agent_runner.building_project_image workspace_id=%s tag=%s", workspace_id, image_tag)
+        c = _client()
+        c.images.build(path=context_dir, dockerfile="Dockerfile", tag=image_tag, pull=True, rm=True)
+        LOGGER.info("agent_runner.built_project_image workspace_id=%s tag=%s", workspace_id, image_tag)
+        return image_tag
+    except Exception as exc:
+        LOGGER.exception("agent_runner.project_image_failed workspace_id=%s error=%s", workspace_id, exc)
+        raise
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
 
 
 def _client() -> docker.DockerClient:

--- a/src/master/agent_runner.py
+++ b/src/master/agent_runner.py
@@ -54,15 +54,29 @@ def resolve_agent_image(
     tmp_root = tempfile.mkdtemp(prefix="prj-image-resolve-")
     clone_dest = os.path.join(tmp_root, "repo")
     try:
-        result = subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", repo_ref, clone_url, clone_dest],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
+        refs_to_try = [repo_ref]
+        if repo_ref == "master":
+            refs_to_try.append("main")
+        elif repo_ref == "main":
+            refs_to_try.append("master")
+
+        clone_ok = False
+        for candidate_ref in refs_to_try:
+            result = subprocess.run(
+                ["git", "clone", "--depth", "1", "--branch", candidate_ref, clone_url, clone_dest],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                clone_ok = True
+                break
+            if os.path.exists(clone_dest):
+                shutil.rmtree(clone_dest)
+
+        if not clone_ok:
             LOGGER.warning(
-                "agent_runner.project_image_clone_failed workspace_id=%s ref=%s error=%s",
-                workspace_id, repo_ref, result.stderr.strip(),
+                "agent_runner.project_image_clone_failed workspace_id=%s refs=%s error=%s",
+                workspace_id, refs_to_try, result.stderr.strip(),
             )
             return default_image
 

--- a/src/master/db.py
+++ b/src/master/db.py
@@ -192,6 +192,7 @@ _MIGRATIONS = [
     "ALTER TABLE topics ADD COLUMN veto_reason TEXT",
     "ALTER TABLE topics ADD COLUMN current_staff_name TEXT",
     "ALTER TABLE messages ADD COLUMN interrupt_reason TEXT",
+    "ALTER TABLE workspaces ADD COLUMN repo_ref TEXT NOT NULL DEFAULT 'master'",
 ]
 
 

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from .agent_runner import get_container_status, refresh_auth, spawn_agent, stop_agent, container_name
+from .agent_runner import get_container_status, refresh_auth, resolve_agent_image, spawn_agent, stop_agent, container_name
 from .db import get_connection
 from .runtime_config import load_agent_env
 from .staffs import StaffOut, _SELECT_COLS as _STAFF_COLS, _row_to_out as _staff_row_to_out
@@ -100,9 +100,9 @@ def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
     try:
         try:
             conn.execute(
-                "INSERT INTO workspaces (id, name, repo_url, container_name, created_at)"
-                " VALUES (?, ?, ?, NULL, ?)",
-                (workspace_id, body.name.strip(), body.repo_url.strip(), now),
+                "INSERT INTO workspaces (id, name, repo_url, repo_ref, container_name, created_at)"
+                " VALUES (?, ?, ?, ?, NULL, ?)",
+                (workspace_id, body.name.strip(), body.repo_url.strip(), body.repo_ref.strip(), now),
             )
         except sqlite3.IntegrityError:
             raise HTTPException(status_code=409, detail="workspace name already exists")
@@ -122,12 +122,20 @@ def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
 
     settings = request.app.state.settings
     try:
+        image = resolve_agent_image(
+            workspace_id=workspace_id,
+            repo_url=body.repo_url.strip(),
+            repo_ref=body.repo_ref.strip(),
+            default_image=settings.agent_base_image,
+            gh_token=settings.gh_token,
+            dry_run=settings.dry_run,
+        )
         name = spawn_agent(
             runtime=settings.container_runtime,
             workspace_id=workspace_id,
             repo_url=body.repo_url.strip(),
             repo_ref=body.repo_ref.strip(),
-            image=settings.agent_base_image,
+            image=image,
             mqtt_host=settings.mqtt_host,
             mqtt_port=settings.mqtt_port,
             network=settings.agent_network,
@@ -251,13 +259,14 @@ def restart_workspace_agent(workspace_id: str, request: Request) -> dict:  # typ
     conn = get_connection(request.app.state.db_path)
     try:
         row = conn.execute(
-            "SELECT id, repo_url, container_name FROM workspaces WHERE id = ? AND archived_at IS NULL",
+            "SELECT id, repo_url, repo_ref, container_name FROM workspaces WHERE id = ? AND archived_at IS NULL",
             (workspace_id,),
         ).fetchone()
         if row is None:
             raise HTTPException(status_code=404, detail="workspace not found")
         cname = row["container_name"] or container_name(workspace_id)
         repo_url = row["repo_url"]
+        repo_ref = row["repo_ref"] or "master"
     finally:
         conn.close()
 
@@ -268,11 +277,20 @@ def restart_workspace_agent(workspace_id: str, request: Request) -> dict:  # typ
         LOGGER.exception("workspace.restart_stop_failed container=%s", cname)
 
     try:
+        image = resolve_agent_image(
+            workspace_id=workspace_id,
+            repo_url=repo_url,
+            repo_ref=repo_ref,
+            default_image=settings.agent_base_image,
+            gh_token=settings.gh_token,
+            dry_run=settings.dry_run,
+        )
         spawn_agent(
             runtime=settings.container_runtime,
             workspace_id=workspace_id,
             repo_url=repo_url,
-            image=settings.agent_base_image,
+            repo_ref=repo_ref,
+            image=image,
             mqtt_host=settings.mqtt_host,
             mqtt_port=settings.mqtt_port,
             network=settings.agent_network,

--- a/src/master/workspaces.py
+++ b/src/master/workspaces.py
@@ -122,12 +122,14 @@ def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
 
     settings = request.app.state.settings
     try:
+        db_env = load_agent_env(request.app.state.db_path, workspace_id)
+        resolved_gh_token = settings.gh_token or db_env.get("GH_TOKEN")
         image = resolve_agent_image(
             workspace_id=workspace_id,
             repo_url=body.repo_url.strip(),
             repo_ref=body.repo_ref.strip(),
             default_image=settings.agent_base_image,
-            gh_token=settings.gh_token,
+            gh_token=resolved_gh_token,
             dry_run=settings.dry_run,
         )
         name = spawn_agent(
@@ -146,7 +148,7 @@ def create_workspace(body: WorkspaceCreate, request: Request) -> WorkspaceOut:
             ssh_auth_sock_path=settings.agent_ssh_auth_sock_path,
             ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
             dry_run=settings.dry_run,
-            extra_env=load_agent_env(request.app.state.db_path, workspace_id),
+            extra_env=db_env,
             mem_limit=settings.agent_mem_limit or None,
         )
         conn2 = get_connection(request.app.state.db_path)
@@ -277,12 +279,14 @@ def restart_workspace_agent(workspace_id: str, request: Request) -> dict:  # typ
         LOGGER.exception("workspace.restart_stop_failed container=%s", cname)
 
     try:
+        db_env = load_agent_env(request.app.state.db_path, workspace_id)
+        resolved_gh_token = settings.gh_token or db_env.get("GH_TOKEN")
         image = resolve_agent_image(
             workspace_id=workspace_id,
             repo_url=repo_url,
             repo_ref=repo_ref,
             default_image=settings.agent_base_image,
-            gh_token=settings.gh_token,
+            gh_token=resolved_gh_token,
             dry_run=settings.dry_run,
         )
         spawn_agent(
@@ -302,7 +306,7 @@ def restart_workspace_agent(workspace_id: str, request: Request) -> dict:  # typ
             ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
             dry_run=settings.dry_run,
             master_url=settings.master_url,
-            extra_env=load_agent_env(request.app.state.db_path, workspace_id),
+            extra_env=db_env,
             mem_limit=settings.agent_mem_limit or None,
         )
     except Exception:

--- a/tests/master/test_agent_runner.py
+++ b/tests/master/test_agent_runner.py
@@ -282,6 +282,32 @@ def test_resolve_agent_image_falls_back_on_clone_failure():
     assert result == "base:latest"
 
 
+def test_resolve_agent_image_falls_back_to_main_when_master_absent():
+    """If --branch master fails, resolve_agent_image retries with --branch main."""
+    tried_refs: list[str] = []
+
+    def conditional_clone(args, **kwargs):
+        ref = args[5]  # git clone --depth 1 --branch <ref> <url> <dest>
+        tried_refs.append(ref)
+        clone_dest = args[-1]
+        if ref == "master":
+            return subprocess.CompletedProcess(args=args, returncode=128, stdout="", stderr="fatal: not found")
+        # main succeeds, but no Dockerfile — just verifying fallback works
+        os.makedirs(clone_dest, exist_ok=True)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    with patch("src.master.agent_runner.subprocess.run", side_effect=conditional_clone):
+        result = resolve_agent_image(
+            workspace_id="ws1",
+            repo_url="https://github.com/x/y",
+            repo_ref="master",
+            default_image="base:latest",
+        )
+
+    assert tried_refs == ["master", "main"]
+    assert result == "base:latest"  # no Dockerfile → still returns default
+
+
 def test_resolve_agent_image_returns_default_when_no_dockerfile():
     with patch("src.master.agent_runner.subprocess.run", side_effect=_ok_clone()):
         result = resolve_agent_image(

--- a/tests/master/test_agent_runner.py
+++ b/tests/master/test_agent_runner.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 import docker.errors
 import pytest
 
-from src.master.agent_runner import container_name, spawn_agent, stop_agent
+import os
+import subprocess
+
+from src.master.agent_runner import container_name, resolve_agent_image, spawn_agent, stop_agent
 
 
 def test_container_name_format():
@@ -235,3 +238,122 @@ def test_stop_agent_dry_run_skips_call():
     with patch("src.master.agent_runner._client") as mock_client_fn:
         stop_agent(runtime="docker", name="codex-agent-ws1", dry_run=True)
     mock_client_fn.assert_not_called()
+
+
+# --- resolve_agent_image ---
+
+def _ok_clone(extra_files: dict[str, str] | None = None):
+    """Return a subprocess.run replacement that fakes a successful git clone."""
+    def fake(args, **kwargs):
+        clone_dest = args[-1]
+        os.makedirs(clone_dest, exist_ok=True)
+        if extra_files:
+            for rel_path, content in extra_files.items():
+                full = os.path.join(clone_dest, rel_path)
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "w") as f:
+                    f.write(content)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+    return fake
+
+
+def test_resolve_agent_image_dry_run_returns_default_without_cloning():
+    with patch("src.master.agent_runner.subprocess.run") as mock_run:
+        result = resolve_agent_image(
+            workspace_id="ws1",
+            repo_url="https://github.com/x/y",
+            default_image="base:latest",
+            dry_run=True,
+        )
+    assert result == "base:latest"
+    mock_run.assert_not_called()
+
+
+def test_resolve_agent_image_falls_back_on_clone_failure():
+    def fail_clone(args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=128, stdout="", stderr="fatal: not found")
+
+    with patch("src.master.agent_runner.subprocess.run", side_effect=fail_clone):
+        result = resolve_agent_image(
+            workspace_id="ws1",
+            repo_url="https://github.com/x/y",
+            default_image="base:latest",
+        )
+    assert result == "base:latest"
+
+
+def test_resolve_agent_image_returns_default_when_no_dockerfile():
+    with patch("src.master.agent_runner.subprocess.run", side_effect=_ok_clone()):
+        result = resolve_agent_image(
+            workspace_id="ws1",
+            repo_url="https://github.com/x/y",
+            default_image="base:latest",
+        )
+    assert result == "base:latest"
+
+
+def test_resolve_agent_image_builds_project_image_when_dockerfile_present():
+    dockerfile_files = {".prj_assistant/image/Dockerfile": "FROM alpine:3.20\n"}
+    mock_docker = MagicMock()
+
+    with patch("src.master.agent_runner.subprocess.run", side_effect=_ok_clone(dockerfile_files)):
+        with patch("src.master.agent_runner._client", return_value=mock_docker):
+            result = resolve_agent_image(
+                workspace_id="ws1",
+                repo_url="https://github.com/x/y",
+                default_image="base:latest",
+            )
+
+    assert result == "codex-agent-ws1:latest"
+    mock_docker.images.build.assert_called_once()
+    _, build_kwargs = mock_docker.images.build.call_args
+    assert build_kwargs["tag"] == "codex-agent-ws1:latest"
+    assert build_kwargs["dockerfile"] == "Dockerfile"
+    assert build_kwargs["pull"] is True
+
+
+def test_resolve_agent_image_injects_gh_token_into_github_url():
+    seen_url: list[str] = []
+
+    def capture_clone(args, **kwargs):
+        seen_url.append(args[6])  # position of clone_url in: git clone --depth 1 --branch <ref> <url> <dest>
+        clone_dest = args[-1]
+        os.makedirs(clone_dest, exist_ok=True)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    with patch("src.master.agent_runner.subprocess.run", side_effect=capture_clone):
+        resolve_agent_image(
+            workspace_id="ws1",
+            repo_url="https://github.com/x/y",
+            default_image="base:latest",
+            gh_token="secret-token",
+        )
+
+    assert len(seen_url) == 1
+    assert "x-access-token:secret-token@github.com" in seen_url[0]
+
+
+def test_resolve_agent_image_cleans_up_temp_dir_on_success():
+    created_dirs: list[str] = []
+    original_mkdtemp = __import__("tempfile").mkdtemp
+
+    def capturing_mkdtemp(**kwargs):
+        d = original_mkdtemp(**kwargs)
+        created_dirs.append(d)
+        return d
+
+    dockerfile_files = {".prj_assistant/image/Dockerfile": "FROM alpine:3.20\n"}
+    mock_docker = MagicMock()
+
+    with patch("src.master.agent_runner.tempfile.mkdtemp", side_effect=capturing_mkdtemp):
+        with patch("src.master.agent_runner.subprocess.run", side_effect=_ok_clone(dockerfile_files)):
+            with patch("src.master.agent_runner._client", return_value=mock_docker):
+                resolve_agent_image(
+                    workspace_id="ws1",
+                    repo_url="https://github.com/x/y",
+                    default_image="base:latest",
+                )
+
+    assert created_dirs
+    for d in created_dirs:
+        assert not os.path.exists(d), f"temp dir {d} was not cleaned up"


### PR DESCRIPTION
Fixes #237

## Summary

- **Root cause 1**: \`create_workspace\` and \`restart_workspace_agent\` always passed \`image=settings.agent_base_image\` to \`spawn_agent()\` — the Dockerfile detection logic in \`service.py\` only covered the old named-agent flow, never the workspace/UI path.
- **Root cause 2**: The shallow clone used \`--branch <repo_ref>\` without retrying the opposite branch name, so a \`repo_ref="master"\` would silently fail on repos whose default branch is \`"main"\`.
- **Root cause 3**: \`resolve_agent_image()\` only read \`settings.gh_token\` (process env), ignoring the GH_TOKEN stored in the database via the UI settings panel — causing unauthenticated clones to fail silently for private repos.
- Adds \`repo_ref\` column to the \`workspaces\` table so agent restarts reuse the branch specified at creation time.

## Test plan

- [ ] Create a workspace pointing at a repo that has \`.prj_assistant/image/Dockerfile\` — master logs should show \`agent_runner.building_project_image\` and \`agent_runner.built_project_image\`; the container should run \`codex-agent-<id>:latest\`.
- [ ] Create a workspace pointing at a repo without that file — master should use \`MASTER_AGENT_BASE_IMAGE\` (no build step in logs).
- [ ] Create a workspace on a non-\`master\` branch — verify \`repo_ref\` is stored in DB and reused on restart.
- [ ] Restart a workspace whose repo has a Dockerfile — confirm the image is rebuilt.
- [ ] Verify with GH_TOKEN set only via the UI settings panel (not as a process env) — clone should still succeed for private repos.
- [ ] Simulate a clone failure (e.g., bad URL) — workspace creation still succeeds with the default image.
- [ ] Run unit tests: \`python -m pytest tests/master/test_agent_runner.py tests/master/test_workspaces.py -q\`

🤖 Generated with repository automation