### PR TITLE
fix(frontend): suppress mermaid render error on collapsed message preview

### DIFF
--- a/frontend/src/components/MarkdownMessage.vue
+++ b/frontend/src/components/MarkdownMessage.vue
@@ -129,8 +129,10 @@ watch(expanded, (val) => {
   }
 })
 
-onMounted(() => nextTick(() => renderMermaid(container.value)))
-watch(rendered, () => nextTick(() => renderMermaid(container.value)))
+// Skip mermaid rendering on the collapsed bubble (fullText present = preview mode).
+// The dialog uses renderedFull and renders mermaid correctly when opened.
+onMounted(() => { if (!props.fullText) nextTick(() => renderMermaid(container.value)) })
+watch(rendered, () => { if (!props.fullText) nextTick(() => renderMermaid(container.value)) })
 onUnmounted(() => document.removeEventListener('keydown', onEsc))
 </script>
 


### PR DESCRIPTION
## Summary

When a message is collapsed to a 300-char preview, the preview may contain a partial or complete mermaid code block. Attempting to render incomplete/malformed mermaid source produces a visible error widget in the collapsed bubble.

- Skip `renderMermaid` on the inline bubble entirely when `fullText` is set (i.e. the component is in collapsed-preview mode).
- The `⛶` expand dialog uses `renderedFull` and still renders mermaid correctly when opened.

Fixes #229

> Note: fixes for #228 (copy button full text, expand dialog full text, code-fence trimming) were already merged to master via earlier commits.

## Test plan

- [ ] Send a message containing a mermaid diagram that is long enough to trigger the fold (> 600 chars total)
- [ ] Verify no mermaid error widget appears in the collapsed preview
- [ ] Click `⛶` to open the expand dialog — verify the full mermaid diagram renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)