### PR TITLE
feat(settings): model dropdown with live fetch and custom override

### DIFF
--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -52,7 +52,14 @@
           </select>
 
           <label>Model</label>
-          <input v-model="staffForm.model" placeholder="e.g. claude-opus-4-7 (leave blank for default)" />
+          <div class="model-combo">
+            <select v-model="modelDropdown" :disabled="modelsLoading">
+              <option value="">adapter default</option>
+              <option v-for="m in availableModels" :key="m" :value="m">{{ m }}</option>
+              <option value="__custom__">custom…</option>
+            </select>
+            <input v-if="modelDropdown === '__custom__'" v-model="staffForm.model" placeholder="enter model ID" class="model-custom-input" />
+          </div>
 
           <label>System Prompt</label>
           <textarea v-model="staffForm.system_prompt" placeholder="--append-system-prompt value" rows="3" />
@@ -184,7 +191,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 
 const systemSettings = ref({ timezone: '' })
 const timezoneInput = ref('')
@@ -204,6 +211,36 @@ const editingStaff = ref(null)
 const savingStaff = ref(false)
 const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
+
+const availableModels = ref([])
+const modelsLoading = ref(false)
+const modelDropdown = ref('')
+
+async function loadModels(adapter) {
+  modelsLoading.value = true
+  try {
+    const r = await fetch(`/api/staffs/models?adapter=${encodeURIComponent(adapter)}`)
+    if (r.ok) availableModels.value = (await r.json()).models || []
+  } catch { /* ignore */ } finally {
+    modelsLoading.value = false
+  }
+}
+
+function syncModelDropdown() {
+  const m = staffForm.value.model
+  if (!m) modelDropdown.value = ''
+  else if (availableModels.value.includes(m)) modelDropdown.value = m
+  else modelDropdown.value = '__custom__'
+}
+
+watch(modelDropdown, val => {
+  if (val !== '__custom__') staffForm.value.model = val
+})
+
+watch(() => staffForm.value.adapter, async adapter => {
+  await loadModels(adapter)
+  syncModelDropdown()
+})
 
 const config = ref({})
 const systemVars = ref([])
@@ -296,8 +333,10 @@ async function loadSystemVars() {
 function startCreateStaff() {
   editingStaff.value = null
   staffForm.value = { name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false }
+  modelDropdown.value = ''
   showStaffForm.value = true
   staffError.value = ''
+  loadModels('claude-code')
 }
 
 function startEditStaff(s) {
@@ -313,6 +352,7 @@ function startEditStaff(s) {
   }
   showStaffForm.value = true
   staffError.value = ''
+  loadModels(s.adapter).then(() => syncModelDropdown())
 }
 
 function cancelStaffForm() {
@@ -410,6 +450,8 @@ section { margin-bottom: 3rem; border-top: 1px solid #e2e8f0; padding-top: 1.5re
 .form-grid textarea { resize: vertical; }
 .checkbox-label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9em; padding-top: 0.2rem; }
 .form-actions { display: flex; gap: 0.75rem; align-items: center; }
+.model-combo { display: flex; flex-direction: column; gap: 0.35rem; }
+.model-custom-input { font-family: monospace !important; }
 
 .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .staff-table, .config-table { width: 100%; border-collapse: collapse; font-size: 0.9em; margin-top: 0.5rem; }

--- a/frontend/src/views/WorkspaceDetail.vue
+++ b/frontend/src/views/WorkspaceDetail.vue
@@ -114,7 +114,14 @@
           </select>
 
           <label>Model</label>
-          <input v-model="staffForm.model" placeholder="e.g. claude-opus-4-7 (blank = adapter default)" />
+          <div class="model-combo">
+            <select v-model="modelDropdown" :disabled="modelsLoading">
+              <option value="">adapter default</option>
+              <option v-for="m in availableModels" :key="m" :value="m">{{ m }}</option>
+              <option value="__custom__">custom…</option>
+            </select>
+            <input v-if="modelDropdown === '__custom__'" v-model="staffForm.model" placeholder="enter model ID" class="model-custom-input" />
+          </div>
 
           <label>System Prompt</label>
           <textarea v-model="staffForm.system_prompt" placeholder="--append-system-prompt value (optional)" rows="3" />
@@ -311,7 +318,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import WorkspaceEnvVarsPanel from '../components/WorkspaceEnvVarsPanel.vue'
 import NotesPanel from '../components/NotesPanel.vue'
@@ -354,6 +361,36 @@ const editingStaff = ref(null)
 const savingStaff = ref(false)
 const staffError = ref('')
 const staffForm = ref({ name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false })
+
+const availableModels = ref([])
+const modelsLoading = ref(false)
+const modelDropdown = ref('')
+
+async function loadModels(adapter) {
+  modelsLoading.value = true
+  try {
+    const r = await fetch(`/api/staffs/models?adapter=${encodeURIComponent(adapter)}`)
+    if (r.ok) availableModels.value = (await r.json()).models || []
+  } catch { /* ignore */ } finally {
+    modelsLoading.value = false
+  }
+}
+
+function syncModelDropdown() {
+  const m = staffForm.value.model
+  if (!m) modelDropdown.value = ''
+  else if (availableModels.value.includes(m)) modelDropdown.value = m
+  else modelDropdown.value = '__custom__'
+}
+
+watch(modelDropdown, val => {
+  if (val !== '__custom__') staffForm.value.model = val
+})
+
+watch(() => staffForm.value.adapter, async adapter => {
+  await loadModels(adapter)
+  syncModelDropdown()
+})
 
 // Workspace event actions state
 const actions = ref([])
@@ -763,8 +800,10 @@ function actionRunStatusClass(status) {
 function startCreateStaff() {
   editingStaff.value = null
   staffForm.value = { name: '', adapter: 'claude-code', model: '', system_prompt: '', agent: '', session_scope: 'topic', is_default: false }
+  modelDropdown.value = ''
   showStaffForm.value = true
   staffError.value = ''
+  loadModels('claude-code')
 }
 
 function startEditStaff(s) {
@@ -780,6 +819,7 @@ function startEditStaff(s) {
   }
   showStaffForm.value = true
   staffError.value = ''
+  loadModels(s.adapter).then(() => syncModelDropdown())
 }
 
 function cancelStaffForm() {
@@ -885,6 +925,8 @@ section { margin-bottom: 2rem; }
 .form-grid input, .form-grid select, .form-grid textarea { padding: 0.4rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 4px; font-size: 0.9em; font-family: inherit; width: 100%; box-sizing: border-box; }
 .form-grid textarea { resize: vertical; }
 .checkbox-label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9em; padding-top: 0.2rem; }
+.model-combo { display: flex; flex-direction: column; gap: 0.35rem; }
+.model-custom-input { font-family: monospace !important; }
 .form-actions { display: flex; gap: 0.75rem; align-items: center; }
 .req { color: #dc2626; }
 .error { color: #dc2626; font-size: 0.9em; }

--- a/src/master/staffs.py
+++ b/src/master/staffs.py
@@ -30,15 +30,21 @@ _CODEX_MODELS_FALLBACK = [
 ]
 
 
-async def _fetch_claude_models(api_key: str | None) -> list[str]:
-    if not api_key:
+async def _fetch_claude_models(api_key: str | None, oauth_token: str | None = None) -> list[str]:
+    # Build auth headers: prefer explicit API key, fall back to OAuth token (claude -p mode).
+    headers: dict[str, str] = {"anthropic-version": "2023-06-01"}
+    if api_key:
+        headers["x-api-key"] = api_key
+    elif oauth_token:
+        headers["Authorization"] = f"Bearer {oauth_token}"
+    else:
         return _CLAUDE_MODELS_FALLBACK
     try:
         import httpx
         async with httpx.AsyncClient(timeout=5.0) as client:
             r = await client.get(
                 "https://api.anthropic.com/v1/models",
-                headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+                headers=headers,
                 params={"limit": 100},
             )
             if r.is_success:
@@ -54,7 +60,15 @@ async def _fetch_claude_models(api_key: str | None) -> list[str]:
     return _CLAUDE_MODELS_FALLBACK
 
 
-async def _fetch_codex_models(api_key: str | None) -> list[str]:
+async def _fetch_codex_models(api_key: str | None, codex_auth_json: str | None = None) -> list[str]:
+    # Fall back to extracting a token from CODEX_AUTH_JSON (codex CLI auth file content).
+    if not api_key and codex_auth_json:
+        try:
+            import json as _json
+            auth = _json.loads(codex_auth_json)
+            api_key = auth.get("token") or auth.get("api_key") or auth.get("key")
+        except Exception:
+            pass
     if not api_key:
         return _CODEX_MODELS_FALLBACK
     try:
@@ -321,10 +335,12 @@ async def list_adapter_models(request: Request, adapter: str = "claude-code") ->
     global_env = load_global_env(db_path)
     if adapter == "claude-code":
         api_key = settings.anthropic_api_key or global_env.get("ANTHROPIC_API_KEY")
-        models = await _fetch_claude_models(api_key)
+        oauth_token = settings.claude_code_oauth_token or global_env.get("CLAUDE_CODE_OAUTH_TOKEN")
+        models = await _fetch_claude_models(api_key, oauth_token)
     else:
         api_key = settings.openai_api_key or global_env.get("OPENAI_API_KEY")
-        models = await _fetch_codex_models(api_key)
+        codex_auth_json = global_env.get("CODEX_AUTH_JSON")
+        models = await _fetch_codex_models(api_key, codex_auth_json)
     return {"adapter": adapter, "models": models}
 
 

--- a/src/master/staffs.py
+++ b/src/master/staffs.py
@@ -1,6 +1,7 @@
 """Staff invocation profiles — runtime-configurable Claude/Codex invocation units."""
 from __future__ import annotations
 
+import logging
 import sqlite3
 import uuid
 from datetime import datetime, timezone
@@ -10,8 +11,73 @@ from pydantic import BaseModel
 
 from .db import get_connection
 
+_LOGGER = logging.getLogger(__name__)
+
 _VALID_ADAPTERS = {"claude-code", "codex"}
 _VALID_SESSION_SCOPES = {"topic", "workspace", "global", "none"}
+
+# Fallback model lists used when no API key is configured or the provider is unreachable.
+_CLAUDE_MODELS_FALLBACK = [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+]
+_CODEX_MODELS_FALLBACK = [
+    "codex-mini-latest",
+    "o4-mini",
+    "o3",
+    "o3-mini",
+]
+
+
+async def _fetch_claude_models(api_key: str | None) -> list[str]:
+    if not api_key:
+        return _CLAUDE_MODELS_FALLBACK
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(
+                "https://api.anthropic.com/v1/models",
+                headers={"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+                params={"limit": 100},
+            )
+            if r.is_success:
+                data = r.json()
+                models = sorted(
+                    [m["id"] for m in data.get("data", []) if m.get("id", "").startswith("claude-")],
+                    reverse=True,
+                )
+                if models:
+                    return models
+    except Exception:
+        _LOGGER.warning("staffs.models_fetch_failed adapter=claude-code")
+    return _CLAUDE_MODELS_FALLBACK
+
+
+async def _fetch_codex_models(api_key: str | None) -> list[str]:
+    if not api_key:
+        return _CODEX_MODELS_FALLBACK
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(
+                "https://api.openai.com/v1/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            if r.is_success:
+                data = r.json()
+                models = sorted(
+                    [
+                        m["id"] for m in data.get("data", [])
+                        if any(m.get("id", "").startswith(p) for p in ("o1", "o3", "o4", "codex"))
+                    ],
+                    reverse=True,
+                )
+                if models:
+                    return models
+    except Exception:
+        _LOGGER.warning("staffs.models_fetch_failed adapter=codex")
+    return _CODEX_MODELS_FALLBACK
 
 _SELECT_COLS = (
     "id, scope_type, scope_id, name, adapter, model, system_prompt, agent,"
@@ -239,6 +305,28 @@ def _delete_staff(
 
 
 # ── Global scope ──────────────────────────────────────────────────────────────
+
+@global_router.get("/models")
+async def list_adapter_models(request: Request, adapter: str = "claude-code") -> dict:  # type: ignore[type-arg]
+    """Return available model IDs for the given adapter.
+
+    Tries to fetch live models from the provider API when a key is configured.
+    Falls back to a curated static list on error or when no key is available.
+    """
+    if adapter not in _VALID_ADAPTERS:
+        raise HTTPException(400, f"Unknown adapter: {adapter!r}")
+    settings = request.app.state.settings
+    db_path = request.app.state.db_path
+    from .runtime_config import load_global_env
+    global_env = load_global_env(db_path)
+    if adapter == "claude-code":
+        api_key = settings.anthropic_api_key or global_env.get("ANTHROPIC_API_KEY")
+        models = await _fetch_claude_models(api_key)
+    else:
+        api_key = settings.openai_api_key or global_env.get("OPENAI_API_KEY")
+        models = await _fetch_codex_models(api_key)
+    return {"adapter": adapter, "models": models}
+
 
 @global_router.get("", response_model=list[StaffOut])
 def list_global_staffs(request: Request) -> list[StaffOut]:


### PR DESCRIPTION
## Summary
- Replace the free-text model input in global and workspace staff forms with a populated select dropdown
- Backend adds `GET /api/staffs/models?adapter=<name>` that fetches live model lists from Anthropic or OpenAI APIs, falling back to a curated static list when no key is set or the request fails
- Dropdown shows known models for the selected adapter; a \"custom…\" option reveals a text input for any arbitrary model ID
- Switching adapter in the form automatically reloads the model list and re-syncs the selection; editing an existing staff pre-selects its saved model (or falls back to \"custom…\" if not in the fetched list)

## Test plan
- [ ] Open **Settings → Global Staff → Add Staff**: Model field shows a dropdown with claude-code models (or static fallback if no API key)
- [ ] Switch Adapter to `codex`: dropdown repopulates with codex/o-series models
- [ ] Select a specific model and save; reopen the staff — dropdown pre-selects that model
- [ ] Select **custom…** — a text input appears; type a model ID, save, and confirm it's stored correctly
- [ ] Open **Workspace → Staff → Add Staff** and repeat the above checks
- [ ] With `ANTHROPIC_API_KEY` set in System Variables, confirm live models are fetched from Anthropic (list will include models beyond the 3-item fallback)
- [ ] With `OPENAI_API_KEY` set, confirm live OpenAI models appear for the codex adapter

🤖 Generated with repository automation