### PR TITLE
fix(agent): fetch remote before creating topic worktree (#250)

### DIFF
--- a/src/agent/mqtt_loop.py
+++ b/src/agent/mqtt_loop.py
@@ -133,10 +133,33 @@ def _verdict_topic(workspace_id: str, topic_id: str) -> str:
     return f"codex-slack/workspace/{workspace_id}/topic/{topic_id}/verdict"
 
 
+def _fetch_remote(repo_dir: str, repo_ref: str) -> None:
+    """Refresh remote-tracking refs before branching so the worktree is cut from
+    up-to-date remote state.  The agent's clone is only synced once at container
+    startup (stage_repo_sync); without this fetch a topic created later branches
+    off a stale origin/<repo_ref> and lands far behind remote (issue #250).  It
+    also pulls the object referenced by base_sha into the local store when the
+    remote has moved forward since startup.
+
+    Best-effort: a fetch failure (offline, transient network) must not block topic
+    creation — the worktree is still created from whatever refs are already local.
+    """
+    cmd = ["git", "-C", repo_dir, "fetch", "origin"]
+    if repo_ref:
+        cmd.append(repo_ref)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        LOGGER.warning("agent.worktree_fetch_failed repo_ref=%s stderr=%s", repo_ref, result.stderr.strip())
+    else:
+        LOGGER.info("agent.worktree_fetched repo_ref=%s", repo_ref or "(default refs)")
+
+
 def _ensure_worktree(repo_dir: str, worktree_path: str, branch: str, repo_ref: str = "", base_sha: str = "") -> None:
     if Path(worktree_path).exists():
         return
     Path(worktree_path).parent.mkdir(parents=True, exist_ok=True)
+    # Sync remote refs first so origin/<repo_ref> and the base_sha object are current.
+    _fetch_remote(repo_dir, repo_ref)
     # Prefer the pre-resolved SHA — it always exists in the local clone regardless of
     # which branch the agent repo was cloned from.  Fall back to origin/<repo_ref> so
     # remote-tracking refs resolve even when no local branch of that name exists.

--- a/tests/agent/test_mqtt_loop.py
+++ b/tests/agent/test_mqtt_loop.py
@@ -481,9 +481,49 @@ def test_ensure_worktree_falls_back_on_existing_branch(tmp_path):
     with patch("src.agent.mqtt_loop.subprocess.run", side_effect=side_effect):
         _ensure_worktree(str(tmp_path / "repo"), str(wt), "feat/existing")
 
-    assert len(calls) == 2
-    assert "-b" in calls[0]
-    assert "-b" not in calls[1]
+    # Only the worktree-add attempts matter here (a leading fetch call is expected too).
+    worktree_calls = [c for c in calls if "worktree" in c]
+    assert len(worktree_calls) == 2
+    assert "-b" in worktree_calls[0]
+    assert "-b" not in worktree_calls[1]
+
+
+def test_ensure_worktree_fetches_before_branching(tmp_path):
+    """Regression for #250: the remote is fetched before the worktree is cut, so the
+    topic branch is not created off a stale origin/<repo_ref>."""
+    wt = tmp_path / "wt"
+    calls = []
+
+    def side_effect(cmd, **kwargs):
+        calls.append(cmd)
+        return MagicMock(returncode=0)
+
+    with patch("src.agent.mqtt_loop.subprocess.run", side_effect=side_effect):
+        _ensure_worktree(str(tmp_path / "repo"), str(wt), "feat/new", repo_ref="main")
+
+    # A fetch of origin/main must happen, and it must precede the worktree add.
+    fetch_idx = next(i for i, c in enumerate(calls) if "fetch" in c)
+    worktree_idx = next(i for i, c in enumerate(calls) if "worktree" in c)
+    assert fetch_idx < worktree_idx
+    assert calls[fetch_idx][-2:] == ["origin", "main"]
+
+
+def test_ensure_worktree_survives_fetch_failure(tmp_path):
+    """A failed fetch (offline/transient) must not block worktree creation."""
+    wt = tmp_path / "wt"
+    calls = []
+
+    def side_effect(cmd, **kwargs):
+        calls.append(cmd)
+        if "fetch" in cmd:
+            return MagicMock(returncode=1, stderr="could not resolve host")
+        return MagicMock(returncode=0)
+
+    with patch("src.agent.mqtt_loop.subprocess.run", side_effect=side_effect):
+        _ensure_worktree(str(tmp_path / "repo"), str(wt), "feat/new", repo_ref="main")
+
+    # Worktree add still ran despite the fetch failing.
+    assert any("worktree" in c for c in calls)
 
 
 # --- _process_prompt ---


### PR DESCRIPTION
## Root cause
When a topic is created, the agent cut the topic branch from `origin/<repo_ref>` — a remote-tracking ref that is only ever updated by the initial `git clone` at container startup (`stage_repo_sync`, `src/agent/worker.py`). Any topic created after the agent booted branched off a **stale** base and landed far behind remote `main`. The `base_sha` resolved from the GitHub API in `create_topic` didn't help either, since that object may not exist in the un-fetched local clone.

## Fix
`_ensure_worktree` (`src/agent/mqtt_loop.py`) now runs a **best-effort `git fetch origin <repo_ref>`** before branching. This refreshes `origin/<repo_ref>` and pulls the `base_sha` object into the local store. A fetch failure (offline/transient) is logged and does **not** block worktree creation.

## Regression tests
`tests/agent/test_mqtt_loop.py`:
- `test_ensure_worktree_fetches_before_branching` — asserts `git fetch origin <ref>` runs and precedes `worktree add`.
- `test_ensure_worktree_survives_fetch_failure` — a failed fetch still creates the worktree.
- Existing worktree tests updated to tolerate the new fetch call.

## Verification
- [x] `pytest tests/agent/test_mqtt_loop.py` — 54 passed
- [x] `ruff check` — clean

Fixes #250
