### PR TITLE
fix(master): respawn not_found agents on message and health-check (#251)

### DIFF
--- a/src/master/agent_runner.py
+++ b/src/master/agent_runner.py
@@ -309,3 +309,56 @@ def get_container_status(*, name: str, dry_run: bool = False) -> dict:  # type: 
     except Exception as exc:
         LOGGER.warning("agent_runner.inspect_failed name=%s error=%s", name, exc)
         return {"status": "unknown", "exit_code": None, "restart_count": None, "error": str(exc), "version": None}
+
+
+def build_spawn_kwargs(*, settings, db_path: str, workspace_id: str, repo_url: str) -> dict:  # type: ignore[type-arg]
+    """Assemble the keyword arguments for spawn_agent from current settings + DB config.
+
+    Centralizes the mapping so startup respawn, the health-check loop, and the
+    message-dispatch recovery path all create identically-configured containers.
+    """
+    from .runtime_config import load_agent_env
+
+    return dict(
+        runtime=settings.container_runtime,
+        workspace_id=workspace_id,
+        repo_url=repo_url,
+        image=settings.agent_base_image,
+        mqtt_host=settings.mqtt_host,
+        mqtt_port=settings.mqtt_port,
+        network=settings.agent_network,
+        claude_code_oauth_token=settings.claude_code_oauth_token,
+        anthropic_api_key=settings.anthropic_api_key,
+        openai_api_key=settings.openai_api_key,
+        gh_token=settings.gh_token,
+        ssh_auth_sock_path=settings.agent_ssh_auth_sock_path,
+        ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
+        dry_run=settings.dry_run,
+        master_url=settings.master_url,
+        extra_env=load_agent_env(db_path, workspace_id),
+        mem_limit=settings.agent_mem_limit or None,
+    )
+
+
+def ensure_agent_running(*, name: str, spawn_kwargs: dict, dry_run: bool = False) -> str:  # type: ignore[type-arg]
+    """Ensure the agent container is up, recreating it when it has gone missing.
+
+    Unlike start_agent_if_stopped — which can only restart a container that still
+    exists — this recovers the "not_found" case (container removed/pruned/crashed
+    away) by spawning a fresh one from spawn_kwargs. This is what lets an incoming
+    message revive a not_found agent instead of being silently dropped (issue #251).
+
+    Returns the action taken: "spawned", "started", "running", "dry_run", or "noop".
+    """
+    if dry_run:
+        LOGGER.info("agent_runner.dry_run_ensure container=%s", name)
+        return "dry_run"
+    status = get_container_status(name=name)["status"]
+    if status == "running":
+        return "running"
+    if status == "not_found":
+        spawn_agent(**spawn_kwargs)
+        LOGGER.info("agent_runner.ensure_spawned container=%s reason=not_found", name)
+        return "spawned"
+    # exited / unknown — the container object still exists, so a plain start suffices.
+    return "started" if start_agent_if_stopped(name=name) else "noop"

--- a/src/master/dispatch.py
+++ b/src/master/dispatch.py
@@ -7,12 +7,19 @@ session-sharing, MQTT contract, and agent-start behaviour.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import uuid
 from datetime import datetime, timezone
 
-from .agent_runner import container_name as _agent_container_name, start_agent_if_stopped
+from .agent_runner import (
+    build_spawn_kwargs,
+    container_name as _agent_container_name,
+    ensure_agent_running,
+)
 from .db import get_connection
+
+LOGGER = logging.getLogger(__name__)
 
 _PROMPT_TOPIC = "codex-slack/workspace/{workspace_id}/topic/{topic_id}/prompt"
 
@@ -215,16 +222,23 @@ async def dispatch_to_staff(
     ws_conn = get_connection(app_state.db_path)
     try:
         ws_row = ws_conn.execute(
-            "SELECT container_name FROM workspaces WHERE id = ?", (workspace_id,)
+            "SELECT container_name, repo_url FROM workspaces WHERE id = ?", (workspace_id,)
         ).fetchone()
         cname = (ws_row["container_name"] if ws_row else None) or _agent_container_name(workspace_id)
+        repo_url = ws_row["repo_url"] if ws_row else ""
     finally:
         ws_conn.close()
 
+    # Recover the agent before publishing: start it if merely stopped, or respawn it
+    # if the container is gone (not_found) — otherwise the prompt is published to a
+    # topic no one is subscribed to and silently lost (issue #251).
     try:
-        start_agent_if_stopped(name=cname, dry_run=settings.dry_run)
+        spawn_kwargs = build_spawn_kwargs(
+            settings=settings, db_path=app_state.db_path, workspace_id=workspace_id, repo_url=repo_url or "",
+        )
+        ensure_agent_running(name=cname, spawn_kwargs=spawn_kwargs, dry_run=settings.dry_run)
     except Exception:
-        pass
+        LOGGER.exception("dispatch.ensure_agent_failed container=%s", cname)
 
     mqtt_topic = _PROMPT_TOPIC.format(workspace_id=workspace_id, topic_id=topic_id)
     app_state.mqtt.publish(mqtt_topic, payload, qos=1)

--- a/src/master/main.py
+++ b/src/master/main.py
@@ -17,10 +17,10 @@ from fastapi.staticfiles import StaticFiles
 
 from ..logging_utils import LocalTimeFormatter
 from ..version import get_app_version
-from .agent_runner import container_name, get_container_status, pause_agent, refresh_auth, spawn_agent, start_agent_if_stopped, stop_agent
+from .agent_runner import build_spawn_kwargs, container_name, get_container_status, pause_agent, refresh_auth, spawn_agent, start_agent_if_stopped, stop_agent
 from .config import load_master_settings
 from .db import get_connection, init_db, schema_info
-from .runtime_config import load_agent_env, load_global_env
+from .runtime_config import load_global_env
 from .attachments import router as attachments_router
 from .messages import router as messages_router
 from .mqtt_client import build_client as build_mqtt_client
@@ -60,7 +60,7 @@ def _active_workspaces(db_path: str) -> list[dict]:  # type: ignore[type-arg]
     conn = get_connection(db_path)
     try:
         rows = conn.execute(
-            "SELECT id, container_name, last_message_at, last_refreshed_at,"
+            "SELECT id, container_name, repo_url, last_message_at, last_refreshed_at,"
             " last_dispatched_at, last_responded_at"
             " FROM workspaces WHERE archived_at IS NULL AND container_name IS NOT NULL"
         ).fetchall()
@@ -273,6 +273,12 @@ def _background_tasks(settings, db_path: str, stop_event: threading.Event, app_s
                 if status["status"] == "exited" and exit_code not in (0, 143):
                     LOGGER.warning("master.health_restart container=%s exit_code=%s", cname, exit_code)
                     start_agent_if_stopped(name=cname, dry_run=settings.dry_run)
+                # not_found: the container is gone entirely (removed/pruned/crashed away).
+                # start_agent_if_stopped can't recover this — respawn a fresh one so the
+                # agent doesn't stay dead until the next master restart (issue #251).
+                elif status["status"] == "not_found":
+                    LOGGER.warning("master.health_respawn container=%s reason=not_found", cname)
+                    _spawn_agent_for_workspace(settings, db_path, ws_id, ws["repo_url"])
             except Exception:
                 LOGGER.exception("master.health_check_failed container=%s", cname)
 
@@ -422,6 +428,15 @@ def _scheduler_tick(db_path: str, app_state, now_utc_aware) -> None:
         conn.close()
 
 
+def _spawn_agent_for_workspace(settings, db_path: str, ws_id: str, repo_url: str) -> None:
+    """Create a fresh agent container for a workspace from current settings + DB config.
+
+    Shared by startup respawn and the health-check loop's not_found recovery so both
+    paths produce identically-configured containers.
+    """
+    spawn_agent(**build_spawn_kwargs(settings=settings, db_path=db_path, workspace_id=ws_id, repo_url=repo_url))
+
+
 def _respawn_agents(settings, db_path: str) -> None:
     """Respawn agent containers for all workspaces on master startup."""
     import docker
@@ -451,25 +466,7 @@ def _respawn_agents(settings, db_path: str) -> None:
         except docker.errors.NotFound:
             pass
         try:
-            spawn_agent(
-                runtime=settings.container_runtime,
-                workspace_id=ws_id,
-                repo_url=row["repo_url"],
-                image=settings.agent_base_image,
-                mqtt_host=settings.mqtt_host,
-                mqtt_port=settings.mqtt_port,
-                network=settings.agent_network,
-                claude_code_oauth_token=settings.claude_code_oauth_token,
-                anthropic_api_key=settings.anthropic_api_key,
-                openai_api_key=settings.openai_api_key,
-                gh_token=settings.gh_token,
-                ssh_auth_sock_path=settings.agent_ssh_auth_sock_path,
-                ssh_known_hosts_path=settings.agent_ssh_known_hosts_path,
-                dry_run=settings.dry_run,
-                master_url=settings.master_url,
-                extra_env=load_agent_env(db_path, ws_id),
-                mem_limit=settings.agent_mem_limit or None,
-            )
+            _spawn_agent_for_workspace(settings, db_path, ws_id, row["repo_url"])
             LOGGER.info("master.respawned container=%s workspace_id=%s", cname, ws_id)
         except Exception:
             LOGGER.exception("master.respawn_failed workspace_id=%s", ws_id)

--- a/tests/master/test_agent_runner.py
+++ b/tests/master/test_agent_runner.py
@@ -383,3 +383,84 @@ def test_resolve_agent_image_cleans_up_temp_dir_on_success():
     assert created_dirs
     for d in created_dirs:
         assert not os.path.exists(d), f"temp dir {d} was not cleaned up"
+
+
+# --- ensure_agent_running (issue #251) ---
+
+from types import SimpleNamespace
+
+from src.master.agent_runner import build_spawn_kwargs, ensure_agent_running
+
+
+def test_ensure_agent_running_spawns_when_not_found():
+    """Regression for #251: a not_found container must be recreated, not ignored."""
+    spawn_kwargs = {"runtime": "docker", "workspace_id": "ws1"}
+    with patch("src.master.agent_runner.get_container_status", return_value={"status": "not_found"}):
+        with patch("src.master.agent_runner.spawn_agent") as mock_spawn:
+            with patch("src.master.agent_runner.start_agent_if_stopped") as mock_start:
+                action = ensure_agent_running(name="codex-agent-ws1", spawn_kwargs=spawn_kwargs)
+    assert action == "spawned"
+    mock_spawn.assert_called_once_with(**spawn_kwargs)
+    mock_start.assert_not_called()
+
+
+def test_ensure_agent_running_starts_when_exited():
+    with patch("src.master.agent_runner.get_container_status", return_value={"status": "exited"}):
+        with patch("src.master.agent_runner.spawn_agent") as mock_spawn:
+            with patch("src.master.agent_runner.start_agent_if_stopped", return_value=True) as mock_start:
+                action = ensure_agent_running(name="codex-agent-ws1", spawn_kwargs={})
+    assert action == "started"
+    mock_start.assert_called_once_with(name="codex-agent-ws1")
+    mock_spawn.assert_not_called()
+
+
+def test_ensure_agent_running_noop_when_running():
+    with patch("src.master.agent_runner.get_container_status", return_value={"status": "running"}):
+        with patch("src.master.agent_runner.spawn_agent") as mock_spawn:
+            with patch("src.master.agent_runner.start_agent_if_stopped") as mock_start:
+                action = ensure_agent_running(name="codex-agent-ws1", spawn_kwargs={})
+    assert action == "running"
+    mock_spawn.assert_not_called()
+    mock_start.assert_not_called()
+
+
+def test_ensure_agent_running_dry_run_touches_nothing():
+    with patch("src.master.agent_runner.get_container_status") as mock_status:
+        with patch("src.master.agent_runner.spawn_agent") as mock_spawn:
+            action = ensure_agent_running(name="codex-agent-ws1", spawn_kwargs={}, dry_run=True)
+    assert action == "dry_run"
+    mock_status.assert_not_called()
+    mock_spawn.assert_not_called()
+
+
+def test_build_spawn_kwargs_maps_settings_and_repo_url():
+    settings = SimpleNamespace(
+        container_runtime="docker",
+        agent_base_image="codex-slack-master:latest",
+        mqtt_host="mosquitto",
+        mqtt_port=1883,
+        agent_network="codex-slack_internal",
+        claude_code_oauth_token="oauth-tok",
+        anthropic_api_key=None,
+        openai_api_key=None,
+        gh_token="gh-tok",
+        agent_ssh_auth_sock_path=None,
+        agent_ssh_known_hosts_path=None,
+        dry_run=False,
+        master_url="http://master:8080",
+        agent_mem_limit="",
+    )
+    with patch("src.master.runtime_config.load_agent_env", return_value={"FOO": "bar"}):
+        kwargs = build_spawn_kwargs(settings=settings, db_path=":memory:", workspace_id="ws1", repo_url="https://github.com/x/y")
+    assert kwargs["workspace_id"] == "ws1"
+    assert kwargs["repo_url"] == "https://github.com/x/y"
+    assert kwargs["image"] == "codex-slack-master:latest"
+    assert kwargs["gh_token"] == "gh-tok"
+    assert kwargs["extra_env"] == {"FOO": "bar"}
+    # empty-string mem_limit normalizes to None so spawn_agent omits the flag
+    assert kwargs["mem_limit"] is None
+    # kwargs must be directly consumable by spawn_agent
+    mock_client = _mock_docker_client()
+    with patch("src.master.agent_runner._client", return_value=mock_client):
+        spawn_agent(**kwargs)
+    mock_client.containers.run.assert_called_once()

--- a/tests/master/test_event_actions.py
+++ b/tests/master/test_event_actions.py
@@ -880,6 +880,56 @@ class TestDispatchCore:
         conn.close()
         assert row["sender"] == "event"
 
+    def test_dispatch_recovers_not_found_agent(self, tmp_path):
+        # DISP-251 — regression for issue #251: dispatch must recover a missing
+        # (not_found) agent by respawning it, not merely try to start it. Verify
+        # dispatch routes through ensure_agent_running with the workspace's
+        # spawn config, so a removed container is recreated before the prompt is
+        # published (instead of being silently dropped).
+        db_path = str(tmp_path / "db.db")
+        _init_minimal_db(db_path)
+        ws_id, tp_id = _insert_workspace_and_topic(db_path)
+        _insert_staff(db_path, name="reviewer", scope_type="global")
+
+        app_state = _make_app_state(db_path=db_path)
+        app_state.settings.dry_run = False  # exercise the real recovery branch
+        loop = asyncio.new_event_loop()
+        app_state.event_loop = loop
+
+        from src.master.db import get_connection
+        from src.master.staffs import resolve_staff
+
+        conn = get_connection(db_path)
+        staff = resolve_staff(conn, "reviewer", ws_id, tp_id)
+        conn.close()
+
+        sentinel_kwargs = {"workspace_id": ws_id, "repo_url": "https://github.com/x/y"}
+
+        async def run():
+            from src.master.dispatch import dispatch_to_staff
+            with patch("src.master.dispatch.build_spawn_kwargs", return_value=sentinel_kwargs) as mock_build:
+                with patch("src.master.dispatch.ensure_agent_running") as mock_ensure:
+                    await dispatch_to_staff(
+                        app_state=app_state,
+                        workspace_id=ws_id,
+                        topic_id=tp_id,
+                        staff=staff,
+                        prompt_text="please review",
+                        sender="user",
+                    )
+            return mock_build, mock_ensure
+
+        mock_build, mock_ensure = loop.run_until_complete(run())
+        loop.close()
+
+        # build_spawn_kwargs received the workspace repo_url so a respawn is fully configured.
+        assert mock_build.call_args.kwargs["repo_url"] == "https://github.com/x/y"
+        assert mock_build.call_args.kwargs["workspace_id"] == ws_id
+        # ensure_agent_running (spawn-capable) was invoked with those kwargs and the container name.
+        mock_ensure.assert_called_once()
+        assert mock_ensure.call_args.kwargs["name"] == f"codex-agent-{ws_id}"
+        assert mock_ensure.call_args.kwargs["spawn_kwargs"] is sentinel_kwargs
+
     def test_session_uuid_matches_scope(self, tmp_path):
         # DISP-05 — session uuid is deterministic from _make_session_uuid
         db_path = str(tmp_path / "db.db")


### PR DESCRIPTION
## Root cause
When an agent container is removed (docker prune, crash-with-autoremove, post-merge cleanup), `get_container_status` reports `not_found`. Two recovery paths existed, neither of which handled that state:
- `start_agent_if_stopped` can only `container.start()` an **existing** stopped container — on `NotFound` it returns `False` and does nothing.
- The background health-check loop only restarted containers with status `exited`.

The only path that *did* spawn a missing container was `_respawn_agents`, which runs **once at master startup**. So a `not_found` agent stayed dead indefinitely, and every message dispatched to it was published to MQTT with no subscriber and silently dropped.

## Fix
- **`agent_runner.build_spawn_kwargs`** — centralizes the spawn-parameter assembly (settings + DB config) that was previously inlined in `_respawn_agents`.
- **`agent_runner.ensure_agent_running`** — starts the container when `exited`, **spawns a fresh one when `not_found`**, no-ops when `running`.
- **`dispatch_to_staff`** now calls `ensure_agent_running` (spawn-capable) instead of `start_agent_if_stopped`, so an incoming message revives a missing agent *before* the prompt is published.
- **Health-check loop** now respawns `not_found` containers proactively (within one 60s tick), so recovery doesn't depend on a message arriving.
- `_respawn_agents` refactored onto the shared builder — no behavior change.

## Regression tests
- `tests/master/test_agent_runner.py` — `ensure_agent_running` spawns on `not_found`, starts on `exited`, no-ops on `running`, and skips everything in `dry_run`; `build_spawn_kwargs` maps settings/repo_url and its output is directly consumable by `spawn_agent`.
- `tests/master/test_event_actions.py::TestDispatchCore::test_dispatch_recovers_not_found_agent` — dispatch routes through `ensure_agent_running` with the workspace's spawn config.

## Verification
- [x] `pytest tests/master/test_agent_runner.py tests/master/test_event_actions.py tests/master/test_main.py tests/master/test_messages.py tests/master/test_master_service.py` — all pass
- [x] `ruff check` — clean

Fixes #251
